### PR TITLE
Add event-sourced storage tracking for SaaS workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 log/
-storage/
+/storage/
 tmp/
 
 # SaaS mode marker file (use SAAS=true env var in production)

--- a/app/jobs/storage/materialize_job.rb
+++ b/app/jobs/storage/materialize_job.rb
@@ -1,0 +1,10 @@
+class Storage::MaterializeJob < ApplicationJob
+  queue_as :default
+  limits_concurrency to: 1, key: ->(owner) { owner }
+
+  discard_on ActiveJob::DeserializationError
+
+  def perform(owner)
+    owner.materialize_storage
+  end
+end

--- a/app/jobs/storage/reconcile_job.rb
+++ b/app/jobs/storage/reconcile_job.rb
@@ -1,0 +1,14 @@
+class Storage::ReconcileJob < ApplicationJob
+  class ReconcileAborted < StandardError; end
+
+  queue_as :default
+  limits_concurrency to: 1, key: ->(owner) { owner }
+
+  discard_on ActiveJob::DeserializationError
+
+  retry_on ReconcileAborted, wait: 1.minute, attempts: 3
+
+  def perform(owner)
+    raise ReconcileAborted, "Could not get stable snapshot for #{owner.class}##{owner.id}" unless owner.reconcile_storage
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,5 @@
 class Account < ApplicationRecord
-  include Joinable, Storage
+  include Joinable, Account::Storage
 
   VALID_AUTH_METHODS = %w[password otp].freeze
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,5 @@
 class Account < ApplicationRecord
-  include Joinable
+  include Joinable, Storage
 
   VALID_AUTH_METHODS = %w[password otp].freeze
 

--- a/app/models/account/storage.rb
+++ b/app/models/account/storage.rb
@@ -1,0 +1,36 @@
+module Account::Storage
+  extend ActiveSupport::Concern
+  include Storage::Totaled
+
+  def exceeding_storage_limit?
+    bytes_used > Storage::WORKSPACE_LIMIT
+  end
+
+  def nearing_storage_limit?
+    bytes_used > Storage::WORKSPACE_LIMIT - 100.megabytes
+  end
+
+  def storage_percentage_used
+    [ (bytes_used.to_f / Storage::WORKSPACE_LIMIT * 100).round, 100 ].min
+  end
+
+  private
+    def calculate_real_storage_bytes
+      message_attachment_bytes + message_embed_bytes
+    end
+
+    def message_attachment_bytes
+      ActiveStorage::Attachment
+        .where(record_type: "Message", name: "attachment")
+        .joins(:blob).sum("active_storage_blobs.byte_size")
+    end
+
+    def message_embed_bytes
+      rich_text_ids = ActionText::RichText.where(record_type: "Message").ids
+      return 0 if rich_text_ids.empty?
+
+      ActiveStorage::Attachment
+        .where(record_type: "ActionText::RichText", name: "embeds", record_id: rich_text_ids)
+        .joins(:blob).sum("active_storage_blobs.byte_size")
+    end
+end

--- a/app/models/account/storage.rb
+++ b/app/models/account/storage.rb
@@ -3,11 +3,11 @@ module Account::Storage
   include Storage::Totaled
 
   def exceeding_storage_limit?
-    bytes_used > Storage::WORKSPACE_LIMIT
+    bytes_used >= Storage::WORKSPACE_LIMIT
   end
 
   def nearing_storage_limit?
-    bytes_used > Storage::WORKSPACE_LIMIT - 100.megabytes
+    bytes_used >= Storage::WORKSPACE_LIMIT - 100.megabytes
   end
 
   def storage_percentage_used
@@ -26,11 +26,9 @@ module Account::Storage
     end
 
     def message_embed_bytes
-      rich_text_ids = ActionText::RichText.where(record_type: "Message").ids
-      return 0 if rich_text_ids.empty?
-
       ActiveStorage::Attachment
-        .where(record_type: "ActionText::RichText", name: "embeds", record_id: rich_text_ids)
+        .where(record_type: "ActionText::RichText", name: "embeds")
+        .where(record_id: ActionText::RichText.where(record_type: "Message").select(:id))
         .joins(:blob).sum("active_storage_blobs.byte_size")
     end
 end

--- a/app/models/concerns/storage/totaled.rb
+++ b/app/models/concerns/storage/totaled.rb
@@ -1,0 +1,80 @@
+module Storage::Totaled
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :storage_total, as: :owner, class_name: "Storage::Total", dependent: :destroy
+  end
+
+  # All entries in the DB belong to this account (one DB per tenant)
+  def storage_entries
+    Storage::Entry.all
+  end
+
+  # Fast: materialized snapshot (may be slightly stale)
+  def bytes_used
+    storage_total&.bytes_stored || 0
+  end
+
+  # Exact: snapshot + pending entries
+  def bytes_used_exact
+    create_or_find_storage_total.current_usage
+  end
+
+  def materialize_storage_later
+    Storage::MaterializeJob.perform_later(self)
+  end
+
+  # Materialize all pending entries into snapshot
+  def materialize_storage
+    total = create_or_find_storage_total
+
+    total.with_lock do
+      latest_entry_id = storage_entries.maximum(:id)
+
+      if latest_entry_id && total.last_entry_id != latest_entry_id
+        scope = storage_entries.where(id: ..latest_entry_id)
+        scope = scope.where.not(id: ..total.last_entry_id) if total.last_entry_id
+        delta_sum = scope.sum(:delta)
+
+        total.update! bytes_stored: total.bytes_stored + delta_sum, last_entry_id: latest_entry_id
+      end
+    end
+  end
+
+  # Reconcile ledger against actual attachment storage.
+  #
+  # Uses two-cursor approach: capture cursor before AND after the scan.
+  # If they differ, entries were added during the scan and we abort.
+  def reconcile_storage
+    cursor_before = storage_entries.maximum(:id)
+    real_bytes = calculate_real_storage_bytes
+    cursor_after = storage_entries.maximum(:id)
+
+    if cursor_before != cursor_after
+      Rails.logger.warn "[Storage] Reconcile aborted for #{self.class}##{id}: cursor moved during scan"
+      false
+    else
+      ledger_bytes = cursor_after ? storage_entries.where(id: ..cursor_after).sum(:delta) : 0
+      diff = real_bytes - ledger_bytes
+
+      if diff.nonzero?
+        Rails.logger.info "[Storage] Reconcile #{self.class}##{id}: adjusting by #{diff} bytes"
+        Storage::Entry.record \
+          recordable: nil,
+          delta: diff,
+          operation: "reconcile"
+      end
+
+      true
+    end
+  end
+
+  private
+    def create_or_find_storage_total
+      self.storage_total ||= Storage::Total.create_or_find_by!(owner: self)
+    end
+
+    def calculate_real_storage_bytes
+      raise NotImplementedError, "Subclass must implement calculate_real_storage_bytes"
+    end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -101,6 +101,8 @@ class Message < ApplicationRecord
     end
   end
 
+  def storage_tracked_record = self
+
   private
     # Bots and API consumers don't generate client-side IDs for Turbo dedup
     def set_default_client_message_id

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -217,7 +217,8 @@ class Message < ApplicationRecord
     end
 
     def destroy_all_associated_records
-      # Delete all boosts, bookmarks, and notifications to satisfy FK constraints
+      # Delete all boosts, bookmarks, and notifications to satisfy FK constraints.
+      # Storage entries are intentionally preserved as an audit log (recordable is optional).
       Notification.where(message_id: id).delete_all
       Boost.where(message_id: id).delete_all
       Bookmark.where(message_id: id).delete_all

--- a/app/models/message/attachment.rb
+++ b/app/models/message/attachment.rb
@@ -21,6 +21,7 @@ module Message::Attachment
     end
 
     validate :acceptable_attachment, if: :attachment?
+    validate :within_storage_limit, on: :create, if: -> { Sabha.saas? && attachment? }
   end
 
   module ClassMethods
@@ -50,6 +51,12 @@ module Message::Attachment
 
       if attachment.blob.byte_size > MAX_ATTACHMENT_SIZE
         errors.add(:attachment, "is too large (max #{MAX_ATTACHMENT_SIZE / 1.megabyte}MB)")
+      end
+    end
+
+    def within_storage_limit
+      if Account.sole.exceeding_storage_limit?
+        errors.add(:attachment, "cannot be uploaded — workspace storage limit reached")
       end
     end
 

--- a/app/models/message/attachment.rb
+++ b/app/models/message/attachment.rb
@@ -55,7 +55,7 @@ module Message::Attachment
     end
 
     def within_storage_limit
-      if Account.sole.exceeding_storage_limit?
+      if Current.account&.exceeding_storage_limit?
         errors.add(:attachment, "cannot be uploaded — workspace storage limit reached")
       end
     end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -1,0 +1,5 @@
+module Storage
+  def self.table_name_prefix = "storage_"
+
+  WORKSPACE_LIMIT = 1.gigabyte
+end

--- a/app/models/storage/attachment_tracking.rb
+++ b/app/models/storage/attachment_tracking.rb
@@ -34,6 +34,9 @@ module Storage::AttachmentTracking
       @storage_snapshot = { recordable: storage_tracked_record }
     end
 
+    # Only tracks direct attachments on models that define storage_tracked_record (Message).
+    # ActionText embeds (rich text inline images) are NOT tracked in the ledger — they're
+    # insignificant in a chat app and caught by daily reconciliation via calculate_real_storage_bytes.
     def storage_tracked_record
       record.try(:storage_tracked_record)
     end

--- a/app/models/storage/attachment_tracking.rb
+++ b/app/models/storage/attachment_tracking.rb
@@ -1,0 +1,40 @@
+module Storage::AttachmentTracking
+  extend ActiveSupport::Concern
+
+  included do
+    before_destroy :snapshot_storage_context
+    after_create_commit :record_storage_attach
+    after_destroy_commit :record_storage_detach
+  end
+
+  private
+    def record_storage_attach
+      return unless storage_tracked_record
+
+      Storage::Entry.record \
+        recordable: storage_tracked_record,
+        blob: blob,
+        delta: blob.byte_size,
+        operation: "attach"
+    end
+
+    def record_storage_detach
+      return unless @storage_snapshot
+
+      Storage::Entry.record \
+        recordable: @storage_snapshot[:recordable],
+        blob: blob,
+        delta: -blob.byte_size,
+        operation: "detach"
+    end
+
+    def snapshot_storage_context
+      return unless storage_tracked_record
+
+      @storage_snapshot = { recordable: storage_tracked_record }
+    end
+
+    def storage_tracked_record
+      record.try(:storage_tracked_record)
+    end
+end

--- a/app/models/storage/entry.rb
+++ b/app/models/storage/entry.rb
@@ -1,0 +1,23 @@
+class Storage::Entry < ApplicationRecord
+  belongs_to :recordable, polymorphic: true, optional: true
+
+  scope :pending, ->(last_entry_id) { where.not(id: ..last_entry_id) if last_entry_id }
+
+  def self.record(delta:, operation:, recordable: nil, blob: nil)
+    return if delta.zero?
+    return unless Sabha.saas?
+
+    entry = create! \
+      recordable_type: recordable&.class&.name,
+      recordable_id: recordable&.id,
+      blob_id: blob&.id,
+      delta: delta,
+      operation: operation,
+      user_id: Current.user&.id,
+      request_id: Current.request&.request_id
+
+    Account.sole.materialize_storage_later
+
+    entry
+  end
+end

--- a/app/models/storage/entry.rb
+++ b/app/models/storage/entry.rb
@@ -16,7 +16,9 @@ class Storage::Entry < ApplicationRecord
       user_id: Current.user&.id,
       request_id: Current.request&.request_id
 
-    Account.sole.materialize_storage_later
+    # Current.account is memoized per-request; falls back to Account.sole
+    # in background jobs where Current isn't set (e.g. reconciliation).
+    (Current.account || Account.sole).materialize_storage_later
 
     entry
   end

--- a/app/models/storage/total.rb
+++ b/app/models/storage/total.rb
@@ -1,0 +1,11 @@
+class Storage::Total < ApplicationRecord
+  belongs_to :owner, polymorphic: true
+
+  def pending_entries
+    owner.storage_entries.pending(last_entry_id)
+  end
+
+  def current_usage
+    bytes_stored + pending_entries.sum(:delta)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,8 @@
       <%= render "shared/workspace_banner" %>
     <% end %>
 
+    <%= render "shared/storage_limit_banner" %>
+
     <a href="#main-content" class="skip-navigation btn" data-turbo="false">Skip to main content</a>
     <a href="#sidebar-toggle" class="skip-navigation btn" data-turbo="false">Skip to menu</a>
 

--- a/app/views/shared/_storage_limit_banner.html.erb
+++ b/app/views/shared/_storage_limit_banner.html.erb
@@ -1,4 +1,4 @@
-<% if Sabha.saas? && Current.user && Account.exists? && Account.sole.exceeding_storage_limit? %>
+<% if Sabha.saas? && Current.user && Current.account&.exceeding_storage_limit? %>
   <div class="banner banner--warning" role="alert">
     <span>This workspace has reached its 1 GB storage limit. File uploads are disabled.</span>
     <% if Current.user.administrator? %>

--- a/app/views/shared/_storage_limit_banner.html.erb
+++ b/app/views/shared/_storage_limit_banner.html.erb
@@ -1,0 +1,8 @@
+<% if Sabha.saas? && Current.user && Account.exists? && Account.sole.exceeding_storage_limit? %>
+  <div class="banner banner--warning" role="alert">
+    <span>This workspace has reached its 1 GB storage limit. File uploads are disabled.</span>
+    <% if Current.user.administrator? %>
+      <%= link_to "View usage", settings_path(script_name: ""), class: "btn btn--small" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shared/_storage_limit_banner.html.erb
+++ b/app/views/shared/_storage_limit_banner.html.erb
@@ -1,6 +1,6 @@
 <% if Sabha.saas? && Current.user && Current.account&.exceeding_storage_limit? %>
   <div class="banner banner--warning" role="alert">
-    <span>This workspace has reached its 1 GB storage limit. File uploads are disabled.</span>
+    <span>This workspace has reached its <%= number_to_human_size(Storage::WORKSPACE_LIMIT) %> storage limit. File uploads are disabled.</span>
     <% if Current.user.administrator? %>
       <%= link_to "View usage", settings_path(script_name: ""), class: "btn btn--small" %>
     <% end %>

--- a/config/initializers/direct_uploads.rb
+++ b/config/initializers/direct_uploads.rb
@@ -4,11 +4,18 @@ module ActiveStorageDirectUploadsControllerAuthentication
   included do
     include Authentication
     skip_before_action :deny_bots  # Bots don't upload files
+    before_action :check_storage_limit
 
     private
       # Override Authentication's redirect — this is a JSON API endpoint
       def request_authentication
         head :unauthorized
+      end
+
+      def check_storage_limit
+        if Sabha.saas? && Account.sole.exceeding_storage_limit?
+          head :unprocessable_entity
+        end
       end
   end
 end

--- a/config/initializers/direct_uploads.rb
+++ b/config/initializers/direct_uploads.rb
@@ -13,7 +13,7 @@ module ActiveStorageDirectUploadsControllerAuthentication
       end
 
       def check_storage_limit
-        if Sabha.saas? && Account.sole.exceeding_storage_limit?
+        if Sabha.saas? && Current.account&.exceeding_storage_limit?
           head :unprocessable_entity
         end
       end

--- a/config/initializers/storage_tracking.rb
+++ b/config/initializers/storage_tracking.rb
@@ -1,0 +1,3 @@
+Rails.application.config.to_prepare do
+  ActiveStorage::Attachment.include Storage::AttachmentTracking
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -14,3 +14,7 @@ production:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
 
+  reconcile_storage:
+    command: "Workspace.find_each { |w| ApplicationRecord.with_tenant(w.external_id.to_s) { Storage::ReconcileJob.perform_later(Account.sole) } } if Sabha.saas?"
+    schedule: every day at 3am
+

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,3 +1,5 @@
+<% require_relative "../lib/sabha" %>
+
 # examples:
 #   periodic_cleanup:
 #     class: CleanSoftDeletedRecordsJob
@@ -14,7 +16,9 @@ production:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
 
+<% if Sabha.saas? %>
   reconcile_storage:
-    command: "Workspace.find_each { |w| ApplicationRecord.with_tenant(w.external_id.to_s) { Storage::ReconcileJob.perform_later(Account.sole) } } if Sabha.saas?"
+    command: "Workspace.find_each { |w| ApplicationRecord.with_tenant(w.external_id.to_s) { Storage::ReconcileJob.perform_later(Account.sole) } }"
     schedule: every day at 3am
+<% end %>
 

--- a/db/migrate/20260306100000_create_storage_tables.rb
+++ b/db/migrate/20260306100000_create_storage_tables.rb
@@ -1,0 +1,20 @@
+class CreateStorageTables < ActiveRecord::Migration[8.2]
+  def change
+    create_table :storage_entries do |t|
+      t.references :recordable, polymorphic: true
+      t.references :blob, foreign_key: false
+      t.bigint :delta, null: false
+      t.string :operation, null: false
+      t.references :user, foreign_key: false
+      t.string :request_id
+      t.datetime :created_at, null: false
+    end
+
+    create_table :storage_totals do |t|
+      t.references :owner, polymorphic: true, null: false, index: { unique: true }
+      t.bigint :bytes_stored, null: false, default: 0
+      t.bigint :last_entry_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_02_23_200000) do
+ActiveRecord::Schema[8.2].define(version: 2026_03_06_100000) do
   create_table "account_join_codes", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "code", null: false
@@ -241,6 +241,30 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_23_200000) do
     t.integer "user_id", null: false
     t.index ["token"], name: "index_sessions_on_token", unique: true
     t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "storage_entries", force: :cascade do |t|
+    t.integer "blob_id"
+    t.datetime "created_at", null: false
+    t.bigint "delta", null: false
+    t.string "operation", null: false
+    t.integer "recordable_id"
+    t.string "recordable_type"
+    t.string "request_id"
+    t.integer "user_id"
+    t.index ["blob_id"], name: "index_storage_entries_on_blob_id"
+    t.index ["recordable_type", "recordable_id"], name: "index_storage_entries_on_recordable"
+    t.index ["user_id"], name: "index_storage_entries_on_user_id"
+  end
+
+  create_table "storage_totals", force: :cascade do |t|
+    t.bigint "bytes_stored", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.bigint "last_entry_id"
+    t.integer "owner_id", null: false
+    t.string "owner_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_type", "owner_id"], name: "index_storage_totals_on_owner", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -110,7 +110,7 @@ columns:
     default_function:
     collation:
     comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+  - &27 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: user_id
     cast_type: *3
@@ -901,6 +901,114 @@ columns:
   - *9
   - *26
   - *20
+  storage_entries:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: blob_id
+    cast_type: *3
+    sql_type_metadata: *4
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - *5
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: delta
+    cast_type: *13
+    sql_type_metadata: *14
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - *6
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: operation
+    cast_type: *7
+    sql_type_metadata: *8
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: recordable_id
+    cast_type: *3
+    sql_type_metadata: *4
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: recordable_type
+    cast_type: *7
+    sql_type_metadata: *8
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: request_id
+    cast_type: *7
+    sql_type_metadata: *8
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - *27
+  storage_totals:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: bytes_stored
+    cast_type: *13
+    sql_type_metadata: *14
+    'null': false
+    default: 0
+    default_function:
+    collation:
+    comment:
+  - *5
+  - *6
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: last_entry_id
+    cast_type: *13
+    sql_type_metadata: *14
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: owner_id
+    cast_type: *3
+    sql_type_metadata: *4
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: owner_type
+    cast_type: *7
+    sql_type_metadata: *8
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - *9
   users:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
@@ -1207,6 +1315,8 @@ primary_keys:
   schema_migrations: version
   searches: id
   sessions: id
+  storage_entries: id
+  storage_totals: id
   users: id
   webhook_events: id
   webhooks: id
@@ -1232,6 +1342,8 @@ data_sources:
   schema_migrations: true
   searches: true
   sessions: true
+  storage_entries: true
+  storage_totals: true
   users: true
   webhook_events: true
   webhooks: true
@@ -1732,6 +1844,23 @@ indexes:
     valid: true
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: memberships
+    name: index_memberships_on_user_id_and_starred
+    unique: false
+    columns:
+    - user_id
+    - starred
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: memberships
     name: index_memberships_on_user_unread_active
     unique: false
     columns:
@@ -2083,6 +2212,74 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
+  storage_entries:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: storage_entries
+    name: index_storage_entries_on_blob_id
+    unique: false
+    columns:
+    - blob_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: storage_entries
+    name: index_storage_entries_on_recordable
+    unique: false
+    columns:
+    - recordable_type
+    - recordable_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: storage_entries
+    name: index_storage_entries_on_user_id
+    unique: false
+    columns:
+    - user_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  storage_totals:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: storage_totals
+    name: index_storage_totals_on_owner
+    unique: true
+    columns:
+    - owner_type
+    - owner_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
   users:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: users
@@ -2166,4 +2363,4 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-version: 20260223200000
+version: 20260306100000

--- a/saas/app/views/saas/workspace_settings/show.html.erb
+++ b/saas/app/views/saas/workspace_settings/show.html.erb
@@ -11,6 +11,32 @@
     </p>
   </fieldset>
 
+  <%# Storage Usage Section (Admin only) %>
+  <% if @is_admin %>
+    <% account = Account.sole %>
+    <fieldset class="flex flex-column gap center-block pad max-inline-size">
+      <legend class="txt-medium txt-align-center"><strong>Storage</strong></legend>
+
+      <div class="flex flex-column gap-half">
+        <div style="background: var(--color-surface-alt); border-radius: 4px; height: 8px; overflow: hidden;">
+          <div style="background: <%= account.exceeding_storage_limit? ? 'var(--color-negative)' : account.nearing_storage_limit? ? 'var(--color-warning)' : 'var(--color-accent)' %>; height: 100%; width: <%= account.storage_percentage_used %>%; transition: width 0.3s;"></div>
+        </div>
+        <p class="txt-small txt-muted txt-align-center">
+          <%= number_to_human_size(account.bytes_used) %> of 1 GB used
+        </p>
+        <% if account.exceeding_storage_limit? %>
+          <p class="txt-small txt-negative txt-align-center">
+            Storage limit reached. File uploads are disabled.
+          </p>
+        <% elsif account.nearing_storage_limit? %>
+          <p class="txt-small txt-warning txt-align-center">
+            Approaching storage limit.
+          </p>
+        <% end %>
+      </div>
+    </fieldset>
+  <% end %>
+
   <%# Leave Workspace Section %>
   <fieldset class="flex flex-column gap center-block pad max-inline-size">
     <legend class="txt-medium txt-align-center"><strong>Leave workspace</strong></legend>

--- a/saas/app/views/saas/workspace_settings/show.html.erb
+++ b/saas/app/views/saas/workspace_settings/show.html.erb
@@ -22,7 +22,7 @@
           <div style="background: <%= account.exceeding_storage_limit? ? 'var(--color-negative)' : account.nearing_storage_limit? ? 'var(--color-warning)' : 'var(--color-accent)' %>; height: 100%; width: <%= account.storage_percentage_used %>%; transition: width 0.3s;"></div>
         </div>
         <p class="txt-small txt-muted txt-align-center">
-          <%= number_to_human_size(account.bytes_used) %> of 1 GB used
+          <%= number_to_human_size(account.bytes_used) %> of <%= number_to_human_size(Storage::WORKSPACE_LIMIT) %> used
         </p>
         <% if account.exceeding_storage_limit? %>
           <p class="txt-small txt-negative txt-align-center">

--- a/saas/app/views/saas/workspace_settings/show.html.erb
+++ b/saas/app/views/saas/workspace_settings/show.html.erb
@@ -13,7 +13,7 @@
 
   <%# Storage Usage Section (Admin only) %>
   <% if @is_admin %>
-    <% account = Account.sole %>
+    <% account = Current.account %>
     <fieldset class="flex flex-column gap center-block pad max-inline-size">
       <legend class="txt-medium txt-align-center"><strong>Storage</strong></legend>
 

--- a/test/jobs/storage/materialize_job_test.rb
+++ b/test/jobs/storage/materialize_job_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Storage::MaterializeJobTest < ActiveJob::TestCase
+  setup do
+    Sabha.stubs(:saas?).returns(true)
+    @account = accounts(:signal)
+  end
+
+  test "calls materialize_storage on account" do
+    Storage::Entry.record(delta: 1024, operation: "attach")
+
+    Storage::MaterializeJob.perform_now(@account)
+
+    assert_not_nil @account.storage_total
+    assert_equal 1024, @account.bytes_used
+  end
+
+  test "job is idempotent" do
+    Storage::Entry.record(delta: 1024, operation: "attach")
+
+    3.times { Storage::MaterializeJob.perform_now(@account) }
+
+    assert_equal 1024, @account.bytes_used
+  end
+
+  test "job processes entries added between runs" do
+    Storage::Entry.record(delta: 1000, operation: "attach")
+    Storage::MaterializeJob.perform_now(@account)
+
+    Storage::Entry.record(delta: 500, operation: "attach")
+    Storage::MaterializeJob.perform_now(@account)
+
+    assert_equal 1500, @account.bytes_used
+  end
+
+  test "job queued to default queue" do
+    assert_equal "default", Storage::MaterializeJob.new.queue_name
+  end
+end

--- a/test/jobs/storage/reconcile_job_test.rb
+++ b/test/jobs/storage/reconcile_job_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Storage::ReconcileJobTest < ActiveJob::TestCase
+  setup do
+    Sabha.stubs(:saas?).returns(true)
+    @account = accounts(:signal)
+    @message = messages(:first)
+  end
+
+  test "reconcile corrects drift when ledger undercounts" do
+    @message.attachment.attach io: StringIO.new("x" * 1000), filename: "test.png", content_type: "image/png"
+    Storage::Entry.delete_all
+
+    Storage::ReconcileJob.perform_now(@account)
+
+    entry = Storage::Entry.find_by(operation: "reconcile")
+    assert_not_nil entry
+    assert_equal 1000, entry.delta
+  end
+
+  test "reconcile corrects drift when ledger overcounts" do
+    Storage::Entry.create! \
+      delta: 5000,
+      operation: "attach"
+
+    Storage::ReconcileJob.perform_now(@account)
+
+    entry = Storage::Entry.find_by(operation: "reconcile")
+    assert_not_nil entry
+    assert_equal(-5000, entry.delta)
+  end
+
+  test "reconcile creates no entry when ledger matches reality" do
+    @message.attachment.attach io: StringIO.new("x" * 1000), filename: "test.png", content_type: "image/png"
+
+    assert_no_difference "Storage::Entry.where(operation: 'reconcile').count" do
+      Storage::ReconcileJob.perform_now(@account)
+    end
+  end
+
+  test "job queued to default queue" do
+    assert_equal "default", Storage::ReconcileJob.new.queue_name
+  end
+
+  test "job raises ReconcileAborted when reconcile fails" do
+    @account.define_singleton_method(:reconcile_storage) { false }
+
+    assert_raises Storage::ReconcileJob::ReconcileAborted do
+      Storage::ReconcileJob.new.perform(@account)
+    end
+  end
+end

--- a/test/models/account/storage_test.rb
+++ b/test/models/account/storage_test.rb
@@ -16,6 +16,11 @@ class Account::StorageTest < ActiveSupport::TestCase
     assert @account.exceeding_storage_limit?
   end
 
+  test "exceeding_storage_limit? returns true when exactly at limit" do
+    @account.create_storage_total!(bytes_stored: 1.gigabyte)
+    assert @account.exceeding_storage_limit?
+  end
+
   test "nearing_storage_limit? returns true when within 100MB of limit" do
     @account.create_storage_total!(bytes_stored: 950.megabytes.to_i)
     assert @account.nearing_storage_limit?

--- a/test/models/account/storage_test.rb
+++ b/test/models/account/storage_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Account::StorageTest < ActiveSupport::TestCase
+  setup do
+    Sabha.stubs(:saas?).returns(true)
+    @account = accounts(:signal)
+  end
+
+  test "exceeding_storage_limit? returns false when under limit" do
+    @account.create_storage_total!(bytes_stored: 500.megabytes)
+    assert_not @account.exceeding_storage_limit?
+  end
+
+  test "exceeding_storage_limit? returns true when over limit" do
+    @account.create_storage_total!(bytes_stored: 1.1.gigabytes.to_i)
+    assert @account.exceeding_storage_limit?
+  end
+
+  test "nearing_storage_limit? returns true when within 100MB of limit" do
+    @account.create_storage_total!(bytes_stored: 950.megabytes.to_i)
+    assert @account.nearing_storage_limit?
+  end
+
+  test "nearing_storage_limit? returns false when well under limit" do
+    @account.create_storage_total!(bytes_stored: 500.megabytes)
+    assert_not @account.nearing_storage_limit?
+  end
+
+  test "storage_percentage_used calculates correctly" do
+    @account.create_storage_total!(bytes_stored: 512.megabytes.to_i)
+    assert_equal 50, @account.storage_percentage_used
+  end
+
+  test "storage_percentage_used caps at 100" do
+    @account.create_storage_total!(bytes_stored: 2.gigabytes.to_i)
+    assert_equal 100, @account.storage_percentage_used
+  end
+
+  test "calculate_real_storage_bytes counts message attachments" do
+    message = messages(:first)
+    message.attachment.attach io: StringIO.new("x" * 2048), filename: "test.png", content_type: "image/png"
+
+    assert_equal 2048, @account.send(:calculate_real_storage_bytes)
+  end
+
+  test "calculate_real_storage_bytes excludes avatars" do
+    user = users(:david)
+    user.avatar.attach io: StringIO.new("x" * 1024), filename: "avatar.png", content_type: "image/png"
+
+    assert_equal 0, @account.send(:calculate_real_storage_bytes)
+  end
+end

--- a/test/models/storage/attachment_tracking_test.rb
+++ b/test/models/storage/attachment_tracking_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class Storage::AttachmentTrackingTest < ActiveSupport::TestCase
+  setup do
+    Sabha.stubs(:saas?).returns(true)
+    @account = accounts(:signal)
+    @message = messages(:first)
+  end
+
+  # Attachment Creation
+
+  test "attaching file creates storage entry with positive delta" do
+    assert_difference "Storage::Entry.count", +1 do
+      @message.attachment.attach io: StringIO.new("x" * 2048), filename: "test.png", content_type: "image/png"
+    end
+
+    entry = Storage::Entry.last
+    assert_equal 2048, entry.delta
+    assert_equal "attach", entry.operation
+    assert_equal @message.class.name, entry.recordable_type
+    assert_equal @message.id, entry.recordable_id
+    assert_equal @message.attachment.blob.id, entry.blob_id
+  end
+
+  test "attaching file enqueues MaterializeJob for account" do
+    assert_enqueued_with job: Storage::MaterializeJob, args: [ @account ] do
+      @message.attachment.attach io: StringIO.new("x" * 1024), filename: "test.png", content_type: "image/png"
+    end
+  end
+
+  # Attachment Deletion
+
+  test "destroying attachment creates storage entry with negative delta" do
+    @message.attachment.attach io: StringIO.new("x" * 2048), filename: "test.png", content_type: "image/png"
+    attachment = @message.attachment.attachment
+    blob_id = attachment.blob_id
+
+    attachment.destroy!
+
+    entry = Storage::Entry.find_by(operation: "detach", recordable: @message)
+    assert_not_nil entry, "Expected detach entry to be created"
+    assert_equal(-2048, entry.delta)
+    assert_equal "detach", entry.operation
+    assert_equal blob_id, entry.blob_id
+  end
+
+  test "destroying attachment uses snapshotted IDs from before_destroy" do
+    @message.attachment.attach io: StringIO.new("x" * 1024), filename: "test.png", content_type: "image/png"
+
+    expected_recordable_type = @message.class.name
+    expected_recordable_id = @message.id
+
+    attachment = @message.attachment.attachment
+    attachment.destroy!
+
+    entry = Storage::Entry.find_by(operation: "detach", recordable_id: expected_recordable_id)
+    assert_not_nil entry, "Expected detach entry to be created"
+    assert_equal expected_recordable_type, entry.recordable_type
+    assert_equal expected_recordable_id, entry.recordable_id
+  end
+
+  # Non-Trackable Records
+
+  test "does not track attachments on non-trackable records" do
+    Sabha.stubs(:saas?).returns(true)
+    user = users(:david)
+
+    assert_no_difference "Storage::Entry.count" do
+      user.avatar.attach io: StringIO.new("x" * 1024), filename: "avatar.png", content_type: "image/png"
+    end
+  end
+
+  # Edge Cases
+
+  test "replacing attachment creates detach and attach entries" do
+    @message.attachment.attach io: StringIO.new("x" * 1024), filename: "first.png", content_type: "image/png"
+
+    @message.attachment.attach io: StringIO.new("x" * 2048), filename: "second.png", content_type: "image/png"
+
+    entries = Storage::Entry.where(recordable: @message).order(:id).last(2)
+    attach_entry = entries.find { |e| e.operation == "attach" && e.delta == 2048 }
+    assert_not_nil attach_entry
+  end
+
+  # Cascading Deletes
+
+  test "attachment tracking handles message deletion gracefully" do
+    @message.attachment.attach io: StringIO.new("x" * 1024), filename: "test.png", content_type: "image/png"
+    message_id = @message.id
+
+    perform_enqueued_jobs do
+      assert_nothing_raised do
+        @message.destroy!
+      end
+    end
+
+    detach_entry = Storage::Entry.find_by(recordable_id: message_id, operation: "detach")
+    assert_not_nil detach_entry, "Expected detach entry for destroyed message"
+    assert_equal(-1024, detach_entry.delta)
+  end
+end

--- a/test/models/storage/entry_test.rb
+++ b/test/models/storage/entry_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class Storage::EntryTest < ActiveSupport::TestCase
+  setup do
+    Sabha.stubs(:saas?).returns(true)
+    @account = accounts(:signal)
+    @message = messages(:first)
+  end
+
+  test "record creates entry with positive delta" do
+    assert_difference "Storage::Entry.count", +1 do
+      entry = Storage::Entry.record \
+        recordable: @message,
+        delta: 1024,
+        operation: "attach"
+
+      assert_equal @message.class.name, entry.recordable_type
+      assert_equal @message.id, entry.recordable_id
+      assert_equal 1024, entry.delta
+      assert_equal "attach", entry.operation
+    end
+  end
+
+  test "record creates entry with negative delta" do
+    entry = Storage::Entry.record \
+      recordable: @message,
+      delta: -512,
+      operation: "detach"
+
+    assert_equal(-512, entry.delta)
+    assert_equal "detach", entry.operation
+  end
+
+  test "record returns nil and creates no entry when delta is zero" do
+    assert_no_difference "Storage::Entry.count" do
+      result = Storage::Entry.record \
+        recordable: @message,
+        delta: 0,
+        operation: "attach"
+
+      assert_nil result
+    end
+  end
+
+  test "record creates entry without recordable" do
+    entry = Storage::Entry.record \
+      recordable: nil,
+      delta: 1024,
+      operation: "reconcile"
+
+    assert_nil entry.recordable_type
+    assert_nil entry.recordable_id
+  end
+
+  test "record enqueues MaterializeJob for account" do
+    assert_enqueued_with job: Storage::MaterializeJob, args: [ @account ] do
+      Storage::Entry.record \
+        delta: 1024,
+        operation: "attach"
+    end
+  end
+
+  test "record skips when not in SaaS mode" do
+    Sabha.stubs(:saas?).returns(false)
+
+    assert_no_difference "Storage::Entry.count" do
+      result = Storage::Entry.record \
+        delta: 1024,
+        operation: "attach"
+
+      assert_nil result
+    end
+  end
+end

--- a/test/models/storage/totaled_test.rb
+++ b/test/models/storage/totaled_test.rb
@@ -1,0 +1,174 @@
+require "test_helper"
+
+class Storage::TotaledTest < ActiveSupport::TestCase
+  setup do
+    Sabha.stubs(:saas?).returns(true)
+    @account = accounts(:signal)
+  end
+
+  # bytes_used (fast snapshot)
+
+  test "bytes_used returns 0 when no storage_total exists" do
+    assert_nil @account.storage_total
+    assert_equal 0, @account.bytes_used
+  end
+
+  test "bytes_used returns snapshot value" do
+    @account.create_storage_total!(bytes_stored: 10_000)
+    assert_equal 10_000, @account.bytes_used
+  end
+
+  test "bytes_used does not include pending entries" do
+    @account.create_storage_total!(bytes_stored: 1000)
+    Storage::Entry.record(delta: 500, operation: "attach")
+
+    assert_equal 1000, @account.bytes_used
+  end
+
+  # bytes_used_exact (snapshot + pending)
+
+  test "bytes_used_exact creates storage_total if missing" do
+    assert_nil @account.storage_total
+    @account.bytes_used_exact
+    assert_not_nil @account.reload.storage_total
+  end
+
+  test "bytes_used_exact includes pending entries" do
+    entry = Storage::Entry.record(delta: 500, operation: "attach")
+    @account.create_storage_total!(bytes_stored: 500, last_entry_id: entry.id)
+
+    Storage::Entry.record(delta: 256, operation: "attach")
+
+    assert_equal 756, @account.bytes_used_exact
+  end
+
+  test "bytes_used_exact returns 0 when no entries and no snapshot" do
+    assert_equal 0, @account.bytes_used_exact
+  end
+
+  # materialize_storage
+
+  test "materialize_storage creates storage_total if missing" do
+    assert_nil @account.storage_total
+
+    Storage::Entry.record(delta: 1024, operation: "attach")
+    @account.materialize_storage
+
+    total = @account.reload.storage_total
+    assert_not_nil total
+    assert_equal 1024, total.bytes_stored
+  end
+
+  test "materialize_storage processes all pending entries" do
+    Storage::Entry.record(delta: 1000, operation: "attach")
+    Storage::Entry.record(delta: 2000, operation: "attach")
+    Storage::Entry.record(delta: -500, operation: "detach")
+
+    @account.materialize_storage
+
+    assert_equal 2500, @account.storage_total.bytes_stored
+    assert_equal 0, @account.storage_total.pending_entries.count
+  end
+
+  test "materialize_storage updates cursor to latest entry" do
+    Storage::Entry.record(delta: 1000, operation: "attach")
+    entry2 = Storage::Entry.record(delta: 500, operation: "attach")
+
+    @account.materialize_storage
+
+    assert_equal entry2.id, @account.storage_total.last_entry_id
+  end
+
+  test "materialize_storage is idempotent when no new entries" do
+    Storage::Entry.record(delta: 1000, operation: "attach")
+    @account.materialize_storage
+
+    initial_bytes = @account.storage_total.bytes_stored
+    initial_cursor = @account.storage_total.last_entry_id
+
+    @account.materialize_storage
+
+    assert_equal initial_bytes, @account.storage_total.bytes_stored
+    assert_equal initial_cursor, @account.storage_total.last_entry_id
+  end
+
+  test "materialize_storage processes only entries since cursor" do
+    Storage::Entry.record(delta: 1000, operation: "attach")
+    @account.materialize_storage
+
+    assert_equal 1000, @account.storage_total.bytes_stored
+
+    Storage::Entry.record(delta: 500, operation: "attach")
+    @account.materialize_storage
+
+    assert_equal 1500, @account.storage_total.bytes_stored
+  end
+
+  test "materialize_storage does nothing when no entries" do
+    @account.materialize_storage
+
+    total = @account.reload.storage_total
+    assert_not_nil total
+    assert_equal 0, total.bytes_stored
+    assert_nil total.last_entry_id
+  end
+
+  # reconcile_storage
+
+  test "reconcile_storage creates entry for drift" do
+    message = messages(:first)
+    message.attachment.attach io: StringIO.new("x" * 1000), filename: "test.png", content_type: "image/png"
+
+    Storage::Entry.delete_all
+
+    assert_difference "Storage::Entry.count", +1 do
+      @account.reconcile_storage
+    end
+
+    entry = Storage::Entry.find_by(operation: "reconcile")
+    assert_equal 1000, entry.delta
+  end
+
+  test "reconcile_storage no-op when ledger matches reality" do
+    message = messages(:first)
+    message.attachment.attach io: StringIO.new("x" * 1000), filename: "test.png", content_type: "image/png"
+
+    assert_no_difference "Storage::Entry.where(operation: 'reconcile').count" do
+      @account.reconcile_storage
+    end
+  end
+
+  test "reconcile_storage handles negative drift" do
+    Storage::Entry.create! \
+      delta: 5000,
+      operation: "attach"
+
+    @account.reconcile_storage
+
+    entry = Storage::Entry.find_by(operation: "reconcile")
+    assert_not_nil entry
+    assert_equal(-5000, entry.delta)
+  end
+
+  test "reconcile_storage aborts when entry added during scan" do
+    message = messages(:first)
+    message.attachment.attach io: StringIO.new("x" * 1000), filename: "test.png", content_type: "image/png"
+
+    Storage::Entry.delete_all
+
+    @account.define_singleton_method(:calculate_real_storage_bytes) do
+      Storage::Entry.create!(delta: 500, operation: "attach")
+      super()
+    end
+
+    assert_no_difference "Storage::Entry.where(operation: 'reconcile').count" do
+      result = @account.reconcile_storage
+      assert_equal false, result
+    end
+  end
+
+  test "reconcile_storage returns true on success" do
+    result = @account.reconcile_storage
+    assert_equal true, result
+  end
+end


### PR DESCRIPTION
## Summary

- Event-sourced storage ledger (`Storage::Entry`) with materialized snapshots (`Storage::Total`) for tracking per-workspace storage usage in SaaS mode
- 1 GB limit per workspace — blocks new uploads and shows banner when exceeded
- Only message attachments count (avatars/logos excluded, ActionText embeds caught by daily reconciliation)
- All tracking gated behind `Sabha.saas?` — zero overhead in self-hosted mode
- Ported from Fizzy, simplified for Sabha's single-Account-per-tenant model

## Test plan

- [x] `bin/rails test` — 955 tests, 0 failures
- [x] `SAAS=true bin/rails test saas/test/` — 176 tests, 0 failures
- [x] Brakeman — 0 warnings
- [x] In SaaS dev mode, upload a file → verify `storage_entries` row with positive delta
- [ ] Delete the message → verify detach entry with negative delta
- [ ] Temporarily set `Storage::WORKSPACE_LIMIT = 1.kilobyte` → upload → confirm blocked
- [ ] Confirm all users see banner when limit exceeded
- [ ] Confirm admins see usage bar on workspace settings page
- [ ] Self-hosted: confirm no entries created, no jobs enqueued

🤖 Generated with [Claude Code](https://claude.com/claude-code)