### PR TITLE
Add welcome messages for new members

### DIFF
--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -850,6 +850,25 @@ img.message__attachment {
     "loading_down";
 }
 
+/* Welcome message (new member joined) */
+.message--welcome {
+  .message__welcome {
+    background-color: oklch(var(--lch-green) / 0.08);
+    border-radius: 0.66em;
+    padding: var(--content-padding-block) var(--content-padding-inline);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: oklch(var(--lch-green) / 0.15);
+    }
+  }
+
+  .message__welcome-text {
+    font-size: 0.95rem;
+    line-height: 1.4;
+    flex: 1;
+  }
+}
+
 .message--mentioned {
   .message__body-content {
     --message-background: oklch(var(--lch-red) / 0.1);

--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -850,8 +850,16 @@ img.message__attachment {
     "loading_down";
 }
 
-/* Welcome message (new member joined) */
+/* Welcome message (new member joined) — also has message--event for formatter */
 .message--welcome {
+  grid-template-columns: var(--inline-space-double) 1fr min-content;
+  grid-template-areas:
+    "loading_up loading_up loading_up"
+    "new new new"
+    "sep sep sep"
+    "avatar body body"
+    "loading_down loading_down loading_down";
+
   .message__welcome {
     background-color: oklch(var(--lch-green) / 0.08);
     border-radius: 0.66em;

--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -850,16 +850,8 @@ img.message__attachment {
     "loading_down";
 }
 
-/* Welcome message (new member joined) — also has message--event for formatter */
+/* Welcome message (new member joined) */
 .message--welcome {
-  grid-template-columns: var(--inline-space-double) 1fr min-content;
-  grid-template-areas:
-    "loading_up loading_up loading_up"
-    "new new new"
-    "sep sep sep"
-    "avatar body body"
-    "loading_down loading_down loading_down";
-
   .message__welcome {
     background-color: oklch(var(--lch-green) / 0.08);
     border-radius: 0.66em;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @recent_messages = Current.user.reachable_messages.created_by(@user).with_creator.ordered.last(5).reverse
+    @recent_messages = Current.user.reachable_messages.user_authored.created_by(@user).with_creator.ordered.last(5).reverse
     @activity_statuses = Membership.activity_statuses_for([ @user.id ])
   end
 

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -85,13 +85,13 @@ module MessagesHelper
       inbox_target: "message"
     }
 
-    unless message.event?
+    if !message.event? || message.welcome? # Welcome messages are events but support replies
       data[:controller] = "reply"
       data[:reply_composer_outlet] = "##{composer_id}"
     end
 
     tag.div id: dom_id(message),
-      class: class_names("message", "message--event": message.event?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
+      class: class_names("message", "message--event": message.event? && !message.welcome?, "message--welcome": message.welcome?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
       data: data, &
   rescue Exception => e
     Sentry.capture_exception(e, extra: { message: message })

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -91,7 +91,7 @@ module MessagesHelper
     end
 
     tag.div id: dom_id(message),
-      class: class_names("message", "message--event": message.event? && !message.welcome?, "message--welcome": message.welcome?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
+      class: class_names("message", "message--event": message.event?, "message--welcome": message.welcome?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
       data: data, &
   rescue Exception => e
     Sentry.capture_exception(e, extra: { message: message })

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -85,13 +85,15 @@ module MessagesHelper
       inbox_target: "message"
     }
 
-    if !message.event? || message.welcome? # Welcome messages are events but support replies
+    if message.repliable?
       data[:controller] = "reply"
       data[:reply_composer_outlet] = "##{composer_id}"
     end
 
+    data[:message_event] = true if message.event?
+
     tag.div id: dom_id(message),
-      class: class_names("message", "message--event": message.event?, "message--welcome": message.welcome?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
+      class: class_names("message", "message--event": message.event? && !message.welcome?, "message--welcome": message.welcome?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
       data: data, &
   rescue Exception => e
     Sentry.capture_exception(e, extra: { message: message })

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -93,7 +93,7 @@ module MessagesHelper
     data[:message_event] = true if message.event?
 
     tag.div id: dom_id(message),
-      class: class_names("message", "message--event": message.event? && !message.welcome?, "message--welcome": message.welcome?, "message--emoji": !message.event? && message.plain_text_body.all_emoji?),
+      class: class_names("message", "message--event": message.event?, "message--welcome": message.welcome?, "message--emoji": !message.event? && !message.welcome? && message.plain_text_body.all_emoji?),
       data: data, &
   rescue Exception => e
     Sentry.capture_exception(e, extra: { message: message })

--- a/app/javascript/models/message_formatter.js
+++ b/app/javascript/models/message_formatter.js
@@ -18,7 +18,7 @@ export default class MessageFormatter {
   }
 
   format(message, threadstyle) {
-    const isEvent = message.classList.contains("message--event")
+    const isEvent = message.dataset.messageEvent !== undefined
 
     if (!isEvent) {
       this.#setMeClass(message)
@@ -61,7 +61,7 @@ export default class MessageFormatter {
 
   #threadMessage(message) {
     if (message.previousElementSibling) {
-      const prevIsEvent = message.previousElementSibling.classList.contains("message--event")
+      const prevIsEvent = message.previousElementSibling.dataset.messageEvent !== undefined
       const isSameUser = message.previousElementSibling.dataset.userId == message.dataset.userId
       const previousMessageIsRecent = this.#previousMessageIsRecent(message)
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -197,6 +197,7 @@ class Message < ApplicationRecord
     end
 
     def create_mention_notifications
+      return if event?
       return if room.direct? || room.parent_room&.direct?
 
       recipient_ids = if mentions_everyone?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -32,6 +32,7 @@ class Message < ApplicationRecord
 
   scope :ordered, -> { order(:created_at) }
   scope :without_events, -> { where(event: nil) }
+  scope :user_authored, -> { where(event: nil, welcome: false) }
   scope :with_creator, -> { includes(creator: [ :badge, { avatar_attachment: { blob: :variant_records } } ]) }
   # Lightweight thread loading - fetches threads but NOT their messages
   # The partial uses Rooms::Thread#participant_creators for efficient participant fetching
@@ -65,12 +66,8 @@ class Message < ApplicationRecord
     event.present?
   end
 
-  def welcome?
-    event == "member_welcomed"
-  end
-
   def repliable?
-    !event? || welcome?
+    !event?
   end
 
   def bookmarked_by_current_user?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -70,7 +70,7 @@ class Message < ApplicationRecord
   end
 
   def repliable?
-    !event?
+    !event? || welcome?
   end
 
   def bookmarked_by_current_user?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -65,6 +65,10 @@ class Message < ApplicationRecord
     event.present?
   end
 
+  def welcome?
+    event == "member_welcomed"
+  end
+
   def bookmarked_by_current_user?
     # Scope path: with_bookmark_status_for LEFT JOIN sets is_bookmarked
     # Use ActiveRecord::Type::Boolean to handle SQLite's 0/1/"0"/"1" values
@@ -114,7 +118,7 @@ class Message < ApplicationRecord
     end
 
     def update_creator_streak
-      return if room.direct? || room.parent_room&.direct?
+      return if room.direct? || room.parent_room&.direct? || welcome?
       creator.recalculate_streak!(excluding_message: self)
     end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -69,6 +69,10 @@ class Message < ApplicationRecord
     event == "member_welcomed"
   end
 
+  def repliable?
+    !event?
+  end
+
   def bookmarked_by_current_user?
     # Scope path: with_bookmark_status_for LEFT JOIN sets is_bookmarked
     # Use ActiveRecord::Type::Boolean to handle SQLite's 0/1/"0"/"1" values

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -224,6 +224,15 @@ class Room < ApplicationRecord
     post_system_message(event: "member_joined", body: "joined", actor: user)
   end
 
+  def post_welcome_message(user:)
+    messages.create!(
+      creator: user,
+      event: "member_welcomed",
+      body: "joined the community. Say hello!",
+      client_message_id: Random.uuid
+    )
+  end
+
   def ensure_visible_members_remain!(excluding:)
     return if open?
     remaining = memberships.visible.where.not(user_id: Array(excluding)).count

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -224,12 +224,10 @@ class Room < ApplicationRecord
     post_system_message(event: "member_joined", body: "joined", actor: user)
   end
 
-  # Uses create! (not post_system_message) because welcome messages are social
-  # objects — they need ActionCable broadcast, boosts, and replies via callbacks.
   def post_welcome_message(user:)
     messages.create!(
       creator: user,
-      event: "member_welcomed",
+      welcome: true,
       body: "joined the community. Say hello!",
       client_message_id: Random.uuid
     )

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -224,6 +224,8 @@ class Room < ApplicationRecord
     post_system_message(event: "member_joined", body: "joined", actor: user)
   end
 
+  # Uses create! (not post_system_message) because welcome messages are social
+  # objects — they need ActionCable broadcast, boosts, and replies via callbacks.
   def post_welcome_message(user:)
     messages.create!(
       creator: user,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -370,8 +370,9 @@ class User < ApplicationRecord
 
     def post_welcome_message
       return if bot?
+      return unless room = Room.original
 
-      Room.original&.post_welcome_message(user: self)
+      room.post_welcome_message(user: self)
     end
 
     def dm_room_with(other_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,6 +134,7 @@ class User < ApplicationRecord
   before_validation :normalize_social_urls
   before_save :transliterate_name, if: :name_changed?
   after_create_commit :grant_membership_to_open_rooms
+  after_create_commit :post_welcome_message
 
   scope :ordered, -> { order(arel_table[:role].desc, arel_table[:name].lower) }
   scope :recent_posters_first, ->(room_id = nil) do
@@ -365,10 +366,12 @@ class User < ApplicationRecord
       Rooms::Thread.joins(:parent_room).where(parent_room: { type: "Rooms::Open", auto_join: true }).find_each do |thread|
         thread.memberships.grant_to(self)
       end
+    end
 
-      # Welcome message goes in the first open room (after membership is granted above)
-      welcome_room = Rooms::Open.active.where(auto_join: true).order(:created_at).first
-      welcome_room.post_welcome_message(user: self) if welcome_room && !bot?
+    def post_welcome_message
+      return if bot?
+
+      Room.original&.post_welcome_message(user: self)
     end
 
     def dm_room_with(other_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,6 +142,8 @@ class User < ApplicationRecord
     users_table = active.arel_table
 
     left_join_condition = messages_table[:creator_id].eq(users_table[:id])
+      .and(messages_table[:event].eq(nil))
+      .and(messages_table[:welcome].eq(false))  # Mirrors Message.user_authored scope
     left_join_condition = left_join_condition.and(messages_table[:room_id].eq(room_id)) if room_id.present?
 
     left_join = users_table.join(messages_table, Arel::Nodes::OuterJoin).on(left_join_condition)
@@ -225,6 +227,7 @@ class User < ApplicationRecord
 
   def total_message_count
     Message.active
+           .user_authored
            .joins(:room)
            .where(creator_id: id)
            .where("rooms.type != ?", "Rooms::Direct")
@@ -246,7 +249,7 @@ class User < ApplicationRecord
                     .where.not(rooms: { type: "Rooms::Direct" })
                     .where("parent_rooms.type IS NULL OR parent_rooms.type != ?", "Rooms::Direct")
                     .where("DATE(messages.created_at) = ?", date)
-                    .without_events
+                    .user_authored
     scope = scope.where.not(id: excluding.id) if excluding
     scope.exists?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -365,6 +365,10 @@ class User < ApplicationRecord
       Rooms::Thread.joins(:parent_room).where(parent_room: { type: "Rooms::Open", auto_join: true }).find_each do |thread|
         thread.memberships.grant_to(self)
       end
+
+      # Welcome message goes in the first open room (after membership is granted above)
+      welcome_room = Rooms::Open.active.where(auto_join: true).order(:created_at).first
+      welcome_room.post_welcome_message(user: self) if welcome_room && !bot?
     end
 
     def dm_room_with(other_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -246,6 +246,7 @@ class User < ApplicationRecord
                     .where.not(rooms: { type: "Rooms::Direct" })
                     .where("parent_rooms.type IS NULL OR parent_rooms.type != ?", "Rooms::Direct")
                     .where("DATE(messages.created_at) = ?", date)
+                    .without_events
     scope = scope.where.not(id: excluding.id) if excluding
     scope.exists?
   end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -16,7 +16,23 @@
       <h2 class="message-separator message__day-separator"><%= local_datetime_tag message.created_at, style: :date %></h2>
     <% end %>
 
-    <% if message.event? %>
+    <% if message.welcome? %>
+      <div class="avatar message__avatar">
+        <%= render 'users/popup', user: message.creator %>
+      </div>
+
+      <div class="message__body">
+        <div class="message__body-content message__welcome">
+          <div class="message__meta">
+            <div class="message__welcome-text">
+              <strong><%= message.creator.name %></strong> <%= message.plain_text_body %>
+            </div>
+            <%= render "messages/actions", message: message, current_room: current_room %>
+          </div>
+          <%= render "messages/boosts/boosts", message: message %>
+        </div>
+      </div>
+    <% elsif message.event? %>
       <div class="message-separator message__event-separator">
         <span><strong><%= message.creator.name %></strong> <%= message.plain_text_body %></span>
       </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -21,17 +21,20 @@
         <%= render 'users/popup', user: message.creator %>
       </div>
 
-      <div class="message__body">
-        <div class="message__body-content message__welcome">
-          <div class="message__meta">
-            <div class="message__welcome-text">
-              <strong><%= message.creator.name %></strong> <%= message.plain_text_body %>
+      <turbo-frame id="<%= dom_id(message, :edit) %>">
+        <div class="message__body">
+          <div class="message__body-content message__welcome">
+            <div class="message__meta">
+              <div class="message__welcome-text">
+                <strong><%= message.creator.name %></strong> <%= message.plain_text_body %>
+                <%= link_to message_timestamp(message, style: timestamp_style, class: "message__timestamp"), message_permalink_path(message), target: "_top", class: "message__permalink" %>
+              </div>
+              <%= render "messages/actions", message: message, current_room: current_room %>
             </div>
-            <%= render "messages/actions", message: message, current_room: current_room %>
+            <%= render "messages/boosts/boosts", message: message %>
           </div>
-          <%= render "messages/boosts/boosts", message: message %>
         </div>
-      </div>
+      </turbo-frame>
     <% elsif message.event? %>
       <div class="message-separator message__event-separator">
         <span><strong><%= message.creator.name %></strong> <%= message.plain_text_body %></span>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -17,24 +17,7 @@
     <% end %>
 
     <% if message.welcome? %>
-      <div class="avatar message__avatar">
-        <%= render 'users/popup', user: message.creator %>
-      </div>
-
-      <turbo-frame id="<%= dom_id(message, :edit) %>">
-        <div class="message__body">
-          <div class="message__body-content message__welcome">
-            <div class="message__meta">
-              <div class="message__welcome-text">
-                <strong><%= message.creator.name %></strong> <%= message.plain_text_body %>
-                <%= link_to message_timestamp(message, style: timestamp_style, class: "message__timestamp"), message_permalink_path(message), target: "_top", class: "message__permalink" %>
-              </div>
-              <%= render "messages/actions", message: message, current_room: current_room %>
-            </div>
-            <%= render "messages/boosts/boosts", message: message %>
-          </div>
-        </div>
-      </turbo-frame>
+      <%= render "messages/welcome", message: message, current_room: current_room, timestamp_style: timestamp_style, composer_id: composer_id %>
     <% elsif message.event? %>
       <div class="message-separator message__event-separator">
         <span><strong><%= message.creator.name %></strong> <%= message.plain_text_body %></span>

--- a/app/views/messages/_welcome.html.erb
+++ b/app/views/messages/_welcome.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (message:, current_room: nil, timestamp_style: :time, composer_id: "composer") -%>
+
+<div class="avatar message__avatar">
+  <%= render 'users/popup', user: message.creator %>
+</div>
+
+<turbo-frame id="<%= dom_id(message, :edit) %>">
+  <div class="message__body">
+    <div class="message__body-content message__welcome">
+      <div class="message__meta">
+        <div class="message__welcome-text">
+          <strong><%= message.creator.name %></strong> <%= message.plain_text_body %>
+          <%= link_to message_timestamp(message, style: timestamp_style, class: "message__timestamp"), message_permalink_path(message), target: "_top", class: "message__permalink" %>
+        </div>
+        <%= render "messages/actions", message: message, current_room: current_room %>
+      </div>
+      <%= render "messages/boosts/boosts", message: message %>
+    </div>
+  </div>
+</turbo-frame>

--- a/app/views/messages/_welcome.html.erb
+++ b/app/views/messages/_welcome.html.erb
@@ -9,11 +9,12 @@
     <div class="message__body-content message__welcome">
       <div class="message__meta">
         <div class="message__welcome-text">
-          <strong><%= message.creator.name %></strong> <%= message.plain_text_body %>
-          <%= link_to message_timestamp(message, style: timestamp_style, class: "message__timestamp"), message_permalink_path(message), target: "_top", class: "message__permalink" %>
+          <strong data-reply-target="author"><%= message.creator.name %></strong> <%= message.plain_text_body %>
+          <%= link_to message_timestamp(message, style: timestamp_style, class: "message__timestamp"), message_permalink_path(message), target: "_top", class: "message__permalink", data: { reply_target: "link" } %>
         </div>
         <%= render "messages/actions", message: message, current_room: current_room %>
       </div>
+      <div data-reply-target="body" class="hidden"><div class="trix-content"><%= message.plain_text_body %></div></div>
       <%= render "messages/boosts/boosts", message: message %>
     </div>
   </div>

--- a/app/views/rooms/_unified_form.html.erb
+++ b/app/views/rooms/_unified_form.html.erb
@@ -31,8 +31,8 @@
 
     <div data-room-form-target="autoJoinOption" class="pad-inline-double" <%= "hidden" if local_assigns[:default_type] == "closed" %>>
       <label class="flex align-center gap cursor-pointer">
-        <%= form.check_box :auto_join %>
-        <span class="txt-small">Add all existing members</span>
+        <%= form.check_box :auto_join, name: "room[auto_join]" %>
+        <span class="txt-small">Add all members automatically</span>
       </label>
     </div>
 

--- a/db/migrate/20260315175342_add_welcome_to_messages.rb
+++ b/db/migrate/20260315175342_add_welcome_to_messages.rb
@@ -1,0 +1,5 @@
+class AddWelcomeToMessages < ActiveRecord::Migration[8.2]
+  def change
+    add_column :messages, :welcome, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_03_06_100000) do
+ActiveRecord::Schema[8.2].define(version: 2026_03_15_175342) do
   create_table "account_join_codes", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "code", null: false
@@ -165,6 +165,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_06_100000) do
     t.boolean "mentions_everyone", default: false, null: false
     t.integer "room_id", null: false
     t.datetime "updated_at", null: false
+    t.boolean "welcome", default: false, null: false
     t.index ["active", "room_id", "created_at"], name: "index_messages_on_active_room_created"
     t.index ["created_at"], name: "index_messages_on_created_at"
     t.index ["creator_id"], name: "index_messages_on_creator_id"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -632,6 +632,16 @@ columns:
     comment:
   - *25
   - *9
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: welcome
+    cast_type: *23
+    sql_type_metadata: *24
+    'null': false
+    default: false
+    default_function:
+    collation:
+    comment:
   notifications:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
@@ -2363,4 +2373,4 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-version: 20260306100000
+version: 20260315175342

--- a/test/controllers/rooms/opens_controller_test.rb
+++ b/test/controllers/rooms/opens_controller_test.rb
@@ -33,6 +33,16 @@ class Rooms::OpensControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to room_url(Room.last)
   end
 
+  test "create with auto_join persists flag so future users are auto-joined" do
+    post rooms_opens_url, params: { room: { name: "Persistent Auto Room", auto_join: true } }
+    room = Room.last
+
+    new_user = User.create!(name: "Future User", email_address: "future@example.com", password: "secret123456")
+
+    assert room.auto_join?, "Room should persist auto_join flag"
+    assert room.memberships.exists?(user: new_user), "Future user should be auto-joined"
+  end
+
   test "only admins or creators can update" do
     sign_in :jz
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -283,6 +283,29 @@ class MessageTest < ActiveSupport::TestCase
     assert_includes message.errors[:attachment], "is too large (max 50MB)"
   end
 
+  # Welcome messages
+
+  test "welcome? returns true for member_welcomed event" do
+    message = Message.new(event: "member_welcomed")
+    assert message.welcome?
+    assert message.event?
+  end
+
+  test "welcome? returns false for other events" do
+    assert_not Message.new(event: "member_joined").welcome?
+    assert_not Message.new(event: "room_renamed").welcome?
+    assert_not Message.new.welcome?
+  end
+
+  test "welcome message does not update creator streak" do
+    user = users(:rachel)
+    user.update_column(:current_streak, 0)
+
+    rooms(:hq).post_welcome_message(user: user)
+
+    assert_equal 0, user.reload.current_streak
+  end
+
   test "mentioning a non-member does not add them to the room" do
     room = rooms(:pets)
     jz = users(:jz)

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -297,9 +297,9 @@ class MessageTest < ActiveSupport::TestCase
     assert_not Message.new.welcome?
   end
 
-  test "repliable? is true for regular messages but false for all events" do
+  test "repliable? is true for regular messages and welcome events but false for other events" do
     assert Message.new.repliable?
-    assert_not Message.new(event: "member_welcomed").repliable?
+    assert Message.new(event: "member_welcomed").repliable?
     assert_not Message.new(event: "member_joined").repliable?
     assert_not Message.new(event: "room_renamed").repliable?
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -285,21 +285,21 @@ class MessageTest < ActiveSupport::TestCase
 
   # Welcome messages
 
-  test "welcome? returns true for member_welcomed event" do
-    message = Message.new(event: "member_welcomed")
+  test "welcome? returns true for welcome messages" do
+    message = Message.new(welcome: true)
     assert message.welcome?
-    assert message.event?
+    assert_not message.event?
   end
 
-  test "welcome? returns false for other events" do
+  test "welcome? returns false for events and regular messages" do
     assert_not Message.new(event: "member_joined").welcome?
     assert_not Message.new(event: "room_renamed").welcome?
     assert_not Message.new.welcome?
   end
 
-  test "repliable? is true for regular messages and welcome events but false for other events" do
+  test "repliable? is true for regular and welcome messages but false for events" do
     assert Message.new.repliable?
-    assert Message.new(event: "member_welcomed").repliable?
+    assert Message.new(welcome: true).repliable?
     assert_not Message.new(event: "member_joined").repliable?
     assert_not Message.new(event: "room_renamed").repliable?
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -297,6 +297,13 @@ class MessageTest < ActiveSupport::TestCase
     assert_not Message.new.welcome?
   end
 
+  test "repliable? is true for regular messages but false for all events" do
+    assert Message.new.repliable?
+    assert_not Message.new(event: "member_welcomed").repliable?
+    assert_not Message.new(event: "member_joined").repliable?
+    assert_not Message.new(event: "room_renamed").repliable?
+  end
+
   test "welcome message does not update creator streak" do
     user = users(:rachel)
     user.update_column(:current_streak, 0)

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -287,6 +287,18 @@ class RoomTest < ActiveSupport::TestCase
     assert_equal room.object_id, result.object_id
   end
 
+  test "post_welcome_message creates a member_welcomed event" do
+    room = rooms(:hq)
+    user = users(:kevin)
+
+    message = room.post_welcome_message(user: user)
+
+    assert message.persisted?
+    assert_equal "member_welcomed", message.event
+    assert_equal user, message.creator
+    assert message.welcome?
+  end
+
   test "active_member_count excludes inactive users" do
     room = rooms(:watercooler)
     initial_count = room.active_member_count

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -287,16 +287,16 @@ class RoomTest < ActiveSupport::TestCase
     assert_equal room.object_id, result.object_id
   end
 
-  test "post_welcome_message creates a member_welcomed event" do
+  test "post_welcome_message creates a welcome message" do
     room = rooms(:hq)
     user = users(:kevin)
 
     message = room.post_welcome_message(user: user)
 
     assert message.persisted?
-    assert_equal "member_welcomed", message.event
-    assert_equal user, message.creator
     assert message.welcome?
+    assert_not message.event?
+    assert_equal user, message.creator
   end
 
   test "active_member_count excludes inactive users" do

--- a/test/models/rooms/open_test.rb
+++ b/test/models/rooms/open_test.rb
@@ -25,4 +25,20 @@ class Rooms::OpenTest < ActiveSupport::TestCase
     room.save!
     assert_equal original_count, room.users.count
   end
+
+  test "new users are auto-joined to existing auto_join rooms" do
+    room = Rooms::Open.create!(name: "Auto Room", creator: users(:david), auto_join: true)
+
+    new_user = User.create!(name: "Newcomer", email_address: "newcomer@example.com", password: "secret123456")
+
+    assert room.memberships.exists?(user: new_user), "New user should be auto-joined to existing auto_join room"
+  end
+
+  test "new users are not auto-joined to rooms without auto_join" do
+    room = Rooms::Open.create!(name: "Manual Room", creator: users(:david))
+
+    new_user = User.create!(name: "Newcomer", email_address: "newcomer@example.com", password: "secret123456")
+
+    assert_not room.memberships.exists?(user: new_user), "New user should not be auto-joined to non-auto_join room"
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -29,18 +29,18 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test "creating a user posts a welcome message in the first auto-join room" do
-    rooms(:hq).update!(auto_join: true)
+  test "creating a user posts a welcome message in the original room" do
+    original_room = Room.original
 
-    assert_difference -> { Message.unscoped.where(room: rooms(:hq), event: "member_welcomed").count } do
+    assert_difference -> { Message.unscoped.where(room: original_room, event: "member_welcomed").count } do
       create_new_user
     end
   end
 
   test "creating a bot does not post a welcome message" do
-    rooms(:hq).update!(auto_join: true)
+    original_room = Room.original
 
-    assert_no_difference -> { Message.unscoped.where(room: rooms(:hq), event: "member_welcomed").count } do
+    assert_no_difference -> { Message.unscoped.where(room: original_room, event: "member_welcomed").count } do
       User.create!(name: "Test Bot", bot_token: User.generate_bot_token, role: :bot)
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -35,7 +35,7 @@ class UserTest < ActiveSupport::TestCase
   test "creating a user posts a welcome message in the original room" do
     original_room = Room.original
 
-    assert_difference -> { Message.unscoped.where(room: original_room, event: "member_welcomed").count } do
+    assert_difference -> { Message.unscoped.where(room: original_room, welcome: true).count } do
       create_new_user
     end
   end
@@ -43,7 +43,7 @@ class UserTest < ActiveSupport::TestCase
   test "creating a bot does not post a welcome message" do
     original_room = Room.original
 
-    assert_no_difference -> { Message.unscoped.where(room: original_room, event: "member_welcomed").count } do
+    assert_no_difference -> { Message.unscoped.where(room: original_room, welcome: true).count } do
       User.create!(name: "Test Bot", bot_token: User.generate_bot_token, role: :bot)
     end
   end
@@ -435,7 +435,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.posted_on?(Date.current)
   end
 
-  test "posted_on? excludes event messages like welcome" do
+  test "posted_on? excludes welcome messages" do
     user = users(:rachel)
     rooms(:hq).post_welcome_message(user: user)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -23,10 +23,13 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "creating users grants membership to auto_join open rooms only" do
-    auto_join_count = Rooms::Open.active.where(auto_join: true).count
-    assert_difference -> { Membership.count }, +auto_join_count do
-      create_new_user
-    end
+    auto_join_room = Rooms::Open.create!(name: "Auto Room", creator: users(:david), auto_join: true)
+    non_auto_room = Rooms::Open.create!(name: "Manual Room", creator: users(:david))
+
+    user = create_new_user
+
+    assert user.member_of?(auto_join_room), "New user should be auto-joined to auto_join rooms"
+    assert_not user.member_of?(non_auto_room), "New user should not be auto-joined to non-auto_join rooms"
   end
 
   test "creating a user posts a welcome message in the original room" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -29,6 +29,22 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "creating a user posts a welcome message in the first auto-join room" do
+    rooms(:hq).update!(auto_join: true)
+
+    assert_difference -> { Message.unscoped.where(room: rooms(:hq), event: "member_welcomed").count } do
+      create_new_user
+    end
+  end
+
+  test "creating a bot does not post a welcome message" do
+    rooms(:hq).update!(auto_join: true)
+
+    assert_no_difference -> { Message.unscoped.where(room: rooms(:hq), event: "member_welcomed").count } do
+      User.create!(name: "Test Bot", bot_token: User.generate_bot_token, role: :bot)
+    end
+  end
+
   test "deactivating a user deletes push subscriptions, searches, and deactivates all memberships including direct rooms" do
     user = users(:david)
     non_direct_count = user.memberships.without_direct_rooms.count

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -435,6 +435,24 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.posted_on?(Date.current)
   end
 
+  test "posted_on? excludes event messages like welcome" do
+    user = users(:rachel)
+    rooms(:hq).post_welcome_message(user: user)
+
+    assert_not user.posted_on?(Date.current)
+  end
+
+  test "welcome message does not prevent first real post from starting streak" do
+    user = users(:rachel)
+    user.update_column(:current_streak, 0)
+
+    rooms(:hq).post_welcome_message(user: user)
+    assert_equal 0, user.reload.current_streak
+
+    create_message(user: user, room: rooms(:hq))
+    assert_equal 1, user.reload.current_streak
+  end
+
   test "posted_on? excludes direct messages" do
     user = users(:rachel)
     dm = Rooms::Direct.create!(creator: user)


### PR DESCRIPTION
## Summary

- When a new user joins, a welcome message ("joined the community. Say hello!") is posted in the original room
- Welcome messages are **social objects** — boostable, quotable, repliable via threads, visible in inbox and room previews
- Uses a dedicated `welcome` boolean column (not the `event` field) so they behave like real messages while being excluded from user stats and streaks
- Bots don't generate welcome messages

## Also in this PR

- **Fix `auto_join` checkbox**: Form param name was `rooms_open[auto_join]` but controller expected `room[auto_join]` — checkbox value was silently dropped on every room creation
- **Fix user stats bug**: `total_message_count`, `recent_posters_first`, and profile recent messages now exclude system-generated messages via new `Message.user_authored` scope (preexisting bug where system events were counted)
- **Add `Message.user_authored` scope**: `where(event: nil, welcome: false)` — single source of truth for "real user messages"

## Test plan

- [ ] Sign up as new user → welcome message appears in original room
- [ ] Welcome message has avatar, timestamp, boost reactions, quote action, and reply thread
- [ ] Bot users don't generate welcome messages
- [ ] Welcome message visible in inbox and room previews
- [ ] User profile shows 0 messages for new user (welcome not counted)
- [ ] Streak stays at 0 after welcome, starts at 1 after first real post
- [ ] Create public room with "Add all members automatically" checked → new users auto-join

🤖 Generated with [Claude Code](https://claude.com/claude-code)