### PR TITLE
Add inline DM compose form to DM index page

### DIFF
--- a/app/assets/stylesheets/application/autocomplete.css
+++ b/app/assets/stylesheets/application/autocomplete.css
@@ -149,17 +149,20 @@ suggestion-option {
   --input-padding: 0.3em 0;
 
   @media (min-width: 120ch) {
-    /* In Library overlay, --sidebar-width is 0; avoid collapsing width */
-    body.library-collapsed & {
-      max-inline-size: 100% !important;
-      inline-size: 100%;
-    }
-    /* Default pages keep previous calculation */
-    body:not(.library-collapsed) & {
-      max-inline-size: calc(
-        var(--sidebar-width) - (var(--btn-size) * 2) - (var(--column-gap) * 2) -
-          (var(--sidebar-inline-space) * 2)
-      );
+    /* Sidebar-specific sizing — only constrain when inside the sidebar new-DM form */
+    .directs--new & {
+      /* In Library overlay, --sidebar-width is 0; avoid collapsing width */
+      body.library-collapsed & {
+        max-inline-size: 100%;
+        inline-size: 100%;
+      }
+      /* Default pages keep previous calculation */
+      body:not(.library-collapsed) & {
+        max-inline-size: calc(
+          var(--sidebar-width) - (var(--btn-size) * 2) - (var(--column-gap) * 2) -
+            (var(--sidebar-inline-space) * 2)
+        );
+      }
     }
   }
 }

--- a/app/assets/stylesheets/application/dm_conversations.css
+++ b/app/assets/stylesheets/application/dm_conversations.css
@@ -37,9 +37,8 @@
 
   /* When compose form is present, dm-list doesn't need navbar offset */
   ~ .dm-list {
-    --dm-content-inset: 0.5rem;
+    padding-block-start: 0.5rem;
     border-block-start: 1px solid var(--color-border-dark);
-    margin-block-start: 0.5rem;
   }
 }
 

--- a/app/assets/stylesheets/application/dm_conversations.css
+++ b/app/assets/stylesheets/application/dm_conversations.css
@@ -1,19 +1,27 @@
+/*
+ * DM inbox layout uses --dm-content-inset for the first element's top padding,
+ * accounting for the fixed navbar. Both the compose form and dm-list use it
+ * so only one place needs updating if the navbar changes.
+ */
+.dm-list,
+.dm-compose {
+  --dm-content-inset: var(--navbar-height);
+
+  @media (max-width: 120ch) {
+    --dm-content-inset: calc(var(--navbar-height) + var(--inline-space));
+  }
+}
+
 /* DM Inbox conversation list */
 .dm-list {
-  --dm-list-block-start: var(--navbar-height);
-
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   padding: var(--inline-space);
-  padding-block-start: var(--dm-list-block-start);
+  padding-block-start: var(--dm-content-inset);
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-
-  @media (max-width: 120ch) {
-    --dm-list-block-start: calc(var(--navbar-height) + var(--inline-space));
-  }
 }
 
 /* DM compose form — sits above the dm-list, outside of it */
@@ -22,18 +30,14 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem var(--inline-space);
-  padding-block-start: calc(var(--navbar-height) + 0.5rem);
+  padding-block-start: var(--dm-content-inset);
   border-radius: 0.66em;
   position: relative;
   z-index: 1;
 
-  @media (max-width: 120ch) {
-    padding-block-start: calc(var(--navbar-height) + var(--inline-space));
-  }
-
   /* When compose form is present, dm-list doesn't need navbar offset */
   ~ .dm-list {
-    --dm-list-block-start: 0.5rem;
+    --dm-content-inset: 0.5rem;
     border-block-start: 1px solid var(--color-border-dark);
     margin-block-start: 0.5rem;
   }

--- a/app/assets/stylesheets/application/dm_conversations.css
+++ b/app/assets/stylesheets/application/dm_conversations.css
@@ -1,16 +1,18 @@
 /* DM Inbox conversation list */
 .dm-list {
+  --dm-list-block-start: var(--navbar-height);
+
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   padding: var(--inline-space);
-  padding-block-start: var(--navbar-height);
+  padding-block-start: var(--dm-list-block-start);
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
 
   @media (max-width: 120ch) {
-    padding-block-start: calc(var(--navbar-height) + var(--inline-space));
+    --dm-list-block-start: calc(var(--navbar-height) + var(--inline-space));
   }
 }
 
@@ -28,13 +30,13 @@
   @media (max-width: 120ch) {
     padding-block-start: calc(var(--navbar-height) + var(--inline-space));
   }
-}
 
-/* When compose form is present, dm-list doesn't need navbar offset */
-.dm-compose ~ .dm-list {
-  padding-block-start: 0.5rem !important;
-  border-block-start: 1px solid var(--color-border-dark);
-  margin-block-start: 0.5rem;
+  /* When compose form is present, dm-list doesn't need navbar offset */
+  ~ .dm-list {
+    --dm-list-block-start: 0.5rem;
+    border-block-start: 1px solid var(--color-border-dark);
+    margin-block-start: 0.5rem;
+  }
 }
 
 .dm-compose__container {

--- a/app/assets/stylesheets/application/dm_conversations.css
+++ b/app/assets/stylesheets/application/dm_conversations.css
@@ -31,14 +31,10 @@
 }
 
 /* When compose form is present, dm-list doesn't need navbar offset */
-.dm-compose + .dm-list {
-  padding-block-start: 0.5rem;
+.dm-compose ~ .dm-list {
+  padding-block-start: 0.5rem !important;
   border-block-start: 1px solid var(--color-border-dark);
   margin-block-start: 0.5rem;
-
-  @media (max-width: 120ch) {
-    padding-block-start: 0.5rem;
-  }
 }
 
 .dm-compose__container {

--- a/app/assets/stylesheets/application/dm_conversations.css
+++ b/app/assets/stylesheets/application/dm_conversations.css
@@ -32,10 +32,12 @@
 
 /* When compose form is present, dm-list doesn't need navbar offset */
 .dm-compose + .dm-list {
-  padding-block-start: 0;
+  padding-block-start: 0.5rem;
+  border-block-start: 1px solid var(--color-border-dark);
+  margin-block-start: 0.5rem;
 
   @media (max-width: 120ch) {
-    padding-block-start: 0;
+    padding-block-start: 0.5rem;
   }
 }
 

--- a/app/assets/stylesheets/application/dm_conversations.css
+++ b/app/assets/stylesheets/application/dm_conversations.css
@@ -14,9 +14,37 @@
   }
 }
 
-/* Hide empty state when DM list has conversations */
-.message-area:has(.dm-list .dm-conversation) .message-area--empty {
-  display: none;
+/* DM compose form — sits above the dm-list, outside of it */
+.dm-compose {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem var(--inline-space);
+  padding-block-start: calc(var(--navbar-height) + 0.5rem);
+  border-radius: 0.66em;
+  position: relative;
+  z-index: 1;
+
+  @media (max-width: 120ch) {
+    padding-block-start: calc(var(--navbar-height) + var(--inline-space));
+  }
+}
+
+/* When compose form is present, dm-list doesn't need navbar offset */
+.dm-compose + .dm-list {
+  padding-block-start: 0;
+
+  @media (max-width: 120ch) {
+    padding-block-start: 0;
+  }
+}
+
+.dm-compose__container {
+  flex: 1;
+}
+
+.dm-compose__submit {
+  flex-shrink: 0;
 }
 
 .dm-conversation {

--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -2,13 +2,14 @@
   display: contents;
 
   &:has(.message),
-  &:has(.dm-conversation) {
+  &:has(.dm-conversation),
+  &:has(.dm-compose) {
     .message-area--empty {
       display: none;
     }
   }
 
-  &:not(:has(.message)):not(:has(.dm-conversation)) {
+  &:not(:has(.message)):not(:has(.dm-conversation)):not(:has(.dm-compose)) {
     --opacity: 0.2;
 
     block-size: 100vh;

--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -2,14 +2,13 @@
   display: contents;
 
   &:has(.message),
-  &:has(.dm-conversation),
-  &:has(.dm-compose) {
+  &:has(.dm-conversation) {
     .message-area--empty {
       display: none;
     }
   }
 
-  &:not(:has(.message)):not(:has(.dm-conversation)):not(:has(.dm-compose)) {
+  &:not(:has(.message)):not(:has(.dm-conversation)) {
     --opacity: 0.2;
 
     block-size: 100vh;
@@ -17,7 +16,7 @@
     place-content: center stretch;
     place-items: center center;
 
-    > * {
+    > *:not(.dm-compose) {
       grid-area: 1/1;
     }
 

--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -12,21 +12,25 @@
     --opacity: 0.2;
 
     block-size: 100vh;
-    display: grid;
-    place-content: center stretch;
-    place-items: center center;
-
-    > *:not(.dm-compose) {
-      grid-area: 1/1;
-    }
-
-    .message-area--empty > figure img,
-    .message-area--empty > figure .icon {
-      inline-size: 30dvw;
-    }
+    display: flex;
+    flex-direction: column;
 
     .message-area--empty {
+      flex: 1;
+      display: grid;
+      place-content: center;
+      place-items: center;
       animation: empty-state-in 350ms cubic-bezier(0.25, 1, 0.5, 1) both;
+      order: 1;
+
+      > figure img,
+      > figure .icon {
+        inline-size: 30dvw;
+      }
+    }
+
+    .dm-compose {
+      order: 0;
     }
   }
 }

--- a/app/assets/stylesheets/application/messages.css
+++ b/app/assets/stylesheets/application/messages.css
@@ -8,6 +8,12 @@
     }
   }
 
+  /*
+   * Empty state layout: switches from display:contents to a flex column so
+   * the DM compose form stays pinned at the top while the empty state message
+   * centers in the remaining space. Uses order to place compose (from yielded
+   * content) above the empty state (which comes first in the DOM).
+   */
   &:not(:has(.message)):not(:has(.dm-conversation)) {
     --opacity: 0.2;
 

--- a/app/assets/stylesheets/application/sidebar.css
+++ b/app/assets/stylesheets/application/sidebar.css
@@ -184,6 +184,7 @@
     inset-block-start: var(--block-space);
 
     @media (max-width: 120ch) {
+      display: none;
       inset-inline-start: var(--sidebar-inline-space);
 
       & img {
@@ -298,10 +299,8 @@
         oklch(0% 0 0 / 1) 85%,
         oklch(0% 0 0 / 0) 99%
       );
-      padding-inline-start: calc(
-        var(--btn-size) + var(--sidebar-inline-space) +
-          (var(--column-gap) * 2.5)
-      );
+      padding-block-start: var(--block-space-half);
+      padding-inline-start: var(--sidebar-inline-space);
     }
   }
 

--- a/app/assets/stylesheets/application/sidebar.css
+++ b/app/assets/stylesheets/application/sidebar.css
@@ -748,11 +748,6 @@
   }
 }
 
-/* Hide empty state when DM list has conversations */
-.message-area:has(.dm-list .dm-conversation) .message-area--empty {
-  display: none;
-}
-
 .dm-conversation {
   display: grid;
   grid-template-columns: auto 1fr auto;

--- a/app/assets/stylesheets/application/sidebar.css
+++ b/app/assets/stylesheets/application/sidebar.css
@@ -368,6 +368,10 @@
   .avatar {
     margin-inline: 0;
   }
+
+  @media (max-width: 120ch) {
+    display: none;
+  }
 }
 
 .direct__author {

--- a/app/views/inboxes/direct_messages.html.erb
+++ b/app/views/inboxes/direct_messages.html.erb
@@ -28,7 +28,8 @@
        data-controller="dm-list"
        data-dm-list-target="conversations"
        data-dm-list-loading-class="dm-conversation--loading"
-       data-dm-list-page-url-value="<%= paged_inbox_direct_messages_url %>">
+       data-dm-list-page-url-value="<%= paged_inbox_direct_messages_url %>"
+       <%= "hidden" unless @memberships.present? %>>
     <%= render partial: "inboxes/direct_messages/conversation",
                collection: @memberships,
                as: :membership,

--- a/app/views/inboxes/direct_messages.html.erb
+++ b/app/views/inboxes/direct_messages.html.erb
@@ -7,6 +7,22 @@
 <% end %>
 
 <% content_for :messages do %>
+  <% if Current.user.can_create_direct_messages? %>
+    <%= form_with url: rooms_directs_path, class: "dm-compose" do |form| %>
+      <section class="autocomplete__container dm-compose__container">
+        <div class="autocomplete__input input flex flex-wrap position-relative"
+            data-controller="autocomplete" data-autocomplete-url-value="<%= autocompletable_users_path %>">
+          <%= render "users/autocompletables/user_select", form: form, placeholder: "Type a name…" %>
+        </div>
+      </section>
+
+      <%= button_tag class: "btn btn--reversed dm-compose__submit", type: "submit" do %>
+        <%= icon_tag "arrow-right" %>
+        <span class="for-screen-reader">Start conversation</span>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <div id="inbox"
        class="dm-list"
        data-controller="dm-list"

--- a/app/views/inboxes/direct_messages.html.erb
+++ b/app/views/inboxes/direct_messages.html.erb
@@ -12,7 +12,7 @@
       <section class="autocomplete__container dm-compose__container">
         <div class="autocomplete__input input flex flex-wrap position-relative"
             data-controller="autocomplete" data-autocomplete-url-value="<%= autocompletable_users_path %>">
-          <%= render "users/autocompletables/user_select", form: form, placeholder: "Type a name…" %>
+          <%= render "users/autocompletables/user_select", form: form, placeholder: "New message to…" %>
         </div>
       </section>
 

--- a/app/views/inboxes/direct_messages/_conversation.html.erb
+++ b/app/views/inboxes/direct_messages/_conversation.html.erb
@@ -39,7 +39,7 @@
 
   <div class="dm-conversation__meta">
     <span class="dm-conversation__time">
-      <%= time_ago_in_words(membership.room.last_active_at) %>
+      <%= time_ago_in_words(membership.room.last_active_at) %> ago
     </span>
     <% if membership.unread? %>
       <span class="dm-conversation__badge"></span>

--- a/app/views/inboxes/show.html.erb
+++ b/app/views/inboxes/show.html.erb
@@ -15,7 +15,7 @@
     {
       icon: "messages",
       headline: "No conversations yet",
-      description: "Type a name above to start one."
+      description: Current.user.can_create_direct_messages? ? "Type a name above to start one." : "Direct messages will appear here."
     }
   when "threads"
     {

--- a/app/views/inboxes/show.html.erb
+++ b/app/views/inboxes/show.html.erb
@@ -4,26 +4,26 @@
 <% content_for :sidebar, sidebar_turbo_frame_tag(src: user_sidebar_path) %>
 
 <%
-  empty_state = case @page_title
-  when "Activity"
+  empty_state = case action_name
+  when "activity"
     {
       icon: "mentions",
       headline: "No activity yet",
       description: "Mentions, boosts, and thread replies will appear here."
     }
-  when "Direct Messages"
+  when "direct_messages"
     {
       icon: "messages",
       headline: "No conversations yet",
-      description: "Start a conversation by clicking the + DM button in the sidebar."
+      description: "Type a name above to start one."
     }
-  when "Threads"
+  when "threads"
     {
       icon: "threads",
       headline: "No threads yet",
       description: "Replies to messages you've participated in will appear here."
     }
-  when "Bookmarks"
+  when "bookmarks"
     {
       icon: "bookmark",
       headline: "No bookmarks yet",

--- a/app/views/rooms/directs/new.html.erb
+++ b/app/views/rooms/directs/new.html.erb
@@ -10,13 +10,7 @@
       <section class="autocomplete__container unpad input input--actor">
         <div class="autocomplete__input input flex flex-wrap position-relative flex-item-grow"
             data-controller="autocomplete" data-autocomplete-url-value="<%= autocompletable_users_path %>">
-          <select name="user_ids[]" data-autocomplete-target="select" data-template-id="autocompletable-user" multiple="true" hidden required></select>
-
-          <%= render "users/autocompletables/template" %>
-
-          <%= form.text_field "user_ids_input",
-                autocomplete: "off", autocorrect: "off", "data-1p-ignore": "true", class: "autocomplete__input input flex flex-wrap position-relative",
-                data: { autocomplete_target: "input", action: "input->autocomplete#search keydown->autocomplete#didPressKey" } %>
+          <%= render "users/autocompletables/user_select", form: form, placeholder: nil %>
         </div>
       </section>
 

--- a/app/views/users/autocompletables/_user_select.html.erb
+++ b/app/views/users/autocompletables/_user_select.html.erb
@@ -1,0 +1,9 @@
+<select name="user_ids[]" data-autocomplete-target="select" data-template-id="autocompletable-user" multiple="true" hidden required></select>
+
+<%= render "users/autocompletables/template" %>
+
+<%= form.text_field "user_ids_input",
+      placeholder: placeholder,
+      autocomplete: "off", autocorrect: "off", "data-1p-ignore": "true",
+      class: "autocomplete__input input flex flex-wrap position-relative",
+      data: { autocomplete_target: "input", action: "input->autocomplete#search keydown->autocomplete#didPressKey" } %>


### PR DESCRIPTION
## Summary
- Adds an inline autocomplete compose form at the top of the DM index page, so users can start new conversations without navigating to a separate form
- Extracts shared autocomplete markup into `users/autocompletables/_user_select` partial
- Switches empty state logic from brittle `@page_title` string matching to `action_name`
- Permission-aware empty state copy — restricted users see appropriate messaging
- Hides sidebar `+ DM` button on mobile (compose form on DM page replaces it)
- Fixes empty state layout so compose form pins to top while empty state centers below

## Test plan
- [x] Visit DM index page — compose form appears above conversation list
- [x] Type a name in the compose form — autocomplete suggestions appear
- [x] Select user(s) and submit — redirects to the DM room
- [x] Visit DM index with no conversations — empty state shows below compose form
- [x] Test as a user without DM permissions — compose form hidden, empty state says "Direct messages will appear here."
- [x] Mobile: sidebar `+ DM` button is hidden, hamburger menu hidden when sidebar open
- [x] Desktop: sidebar `+ DM` button works as before
- [x] Verify other inbox views (Activity, Threads, Bookmarks) empty states still work