### PR TITLE
Block disposable emails on SaaS signups with valid_email2

### DIFF
--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -21,5 +21,8 @@ gem "aws-sdk-sesv2"
 # S3-compatible storage for workspace backups (Cloudflare R2)
 gem "aws-sdk-s3"
 
+# Email validation with disposable domain blocking
+gem "valid_email2"
+
 # SaaS engine
 gem "sabha-saas", path: "saas"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -476,6 +476,9 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    valid_email2 (7.0.15)
+      activemodel (>= 6.0)
+      mail (~> 2.5)
     web-push (3.1.0)
       jwt (~> 3.0)
       openssl (>= 3.0)
@@ -547,6 +550,7 @@ DEPENDENCIES
   stimulus-rails
   thruster
   turbo-rails
+  valid_email2
   web-push
   webmock
 
@@ -731,6 +735,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  valid_email2 (7.0.15) sha256=f3fe1c4b87b9a405bb2e8de060b736cce168e476e4c72725c5d05e11321ff4a1
   web-push (3.1.0) sha256=501ab00340c58fb70dabda59f28a86b3cccb0930c6f1f30721b2a5b24de7187d
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131

--- a/saas/app/models/global_identity.rb
+++ b/saas/app/models/global_identity.rb
@@ -19,13 +19,13 @@ class GlobalIdentity < UntenantedRecord
 
   validates :email_address, presence: true,
                            uniqueness: { case_sensitive: false },
-                           format: { with: URI::MailTo::EMAIL_REGEXP }
+                           'valid_email_2/email': { disposable: true }
 
   normalizes :name, with: ->(name) { name&.strip.presence }
   normalizes :email_address, with: ->(email) { email.strip.downcase }
   normalizes :unconfirmed_email, with: ->(email) { email&.strip&.downcase }
 
-  validates :unconfirmed_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+  validates :unconfirmed_email, 'valid_email_2/email': { disposable: true }, allow_blank: true
 
   scope :verified, -> { where.not(verified_at: nil) }
   scope :superadmin, -> { where(superadmin: true) }

--- a/saas/test/models/global_identity_test.rb
+++ b/saas/test/models/global_identity_test.rb
@@ -15,6 +15,12 @@ class GlobalIdentityTest < ActiveSupport::TestCase
     assert_includes identity.errors[:email_address], "is invalid"
   end
 
+  test "rejects disposable email addresses" do
+    identity = GlobalIdentity.new(email_address: "test@mailinator.com")
+    assert_not identity.valid?
+    assert_includes identity.errors[:email_address], "is invalid"
+  end
+
   test "normalizes email to lowercase" do
     identity = GlobalIdentity.new(email_address: "  TEST@Example.COM  ")
     assert_equal "test@example.com", identity.email_address


### PR DESCRIPTION
## Summary
- Adds `valid_email2` gem (SaaS only) for stricter email validation and disposable domain blocking
- Replaces `URI::MailTo::EMAIL_REGEXP` with `valid_email2` validator on `GlobalIdentity` email fields
- Blocks signups from disposable email providers (mailinator, guerrillamail, etc.)

## Test plan
- [x] `SAAS=true bin/rails test saas/test/models/global_identity_test.rb` — 19 tests, 0 failures
- [ ] Try signing up with a disposable email (e.g. mailinator.com) — should be rejected
- [ ] Try signing up with a real email — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)