### PR TITLE
Expand Bot API: room management, discovery, members, single message read

### DIFF
--- a/app/controllers/bots/base_controller.rb
+++ b/app/controllers/bots/base_controller.rb
@@ -1,4 +1,21 @@
 class Bots::BaseController < ApplicationController
   skip_forgery_protection
   allow_bot_access
+
+  before_action :require_bot_authentication
+
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  private
+    def require_bot_authentication
+      head :forbidden unless authenticated_by.bot_key?
+    end
+
+    def require_creator
+      head :forbidden unless @room.creator_id == Current.user.id
+    end
+
+    def not_found
+      render json: { error: "Not found", code: "not_found" }, status: :not_found
+    end
 end

--- a/app/controllers/bots/members_controller.rb
+++ b/app/controllers/bots/members_controller.rb
@@ -14,6 +14,7 @@ class Bots::MembersController < Bots::BaseController
   def create
     user = User.active.find(params[:user_id])
     @room.add_member!(user, actor: Current.user)
+    broadcast_sidebar_room_added(user, @room)
 
     render json: { id: user.id, name: user.name }, status: :created
   end
@@ -21,6 +22,7 @@ class Bots::MembersController < Bots::BaseController
   def destroy
     user = @room.users.find(params[:user_id])
     @room.remove_member!(user, actor: Current.user)
+    broadcast_sidebar_room_removed(user, @room)
 
     head :no_content
   rescue Membership::LastVisibleMemberError

--- a/app/controllers/bots/members_controller.rb
+++ b/app/controllers/bots/members_controller.rb
@@ -1,8 +1,6 @@
 class Bots::MembersController < Bots::BaseController
-  before_action :require_bot_authentication
   before_action :set_room
   before_action :require_creator, only: %i[create destroy]
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def index
     members = @room.memberships.visible.includes(:user).map do |membership|
@@ -32,17 +30,5 @@ class Bots::MembersController < Bots::BaseController
   private
     def set_room
       @room = Current.user.rooms.find(params[:room_id])
-    end
-
-    def require_creator
-      head :forbidden unless @room.creator_id == Current.user.id
-    end
-
-    def require_bot_authentication
-      head :forbidden unless authenticated_by.bot_key?
-    end
-
-    def not_found
-      render json: { error: "Room or user not found", code: "not_found" }, status: :not_found
     end
 end

--- a/app/controllers/bots/members_controller.rb
+++ b/app/controllers/bots/members_controller.rb
@@ -1,10 +1,11 @@
 class Bots::MembersController < Bots::BaseController
   before_action :require_bot_authentication
-  rescue_from ActiveRecord::RecordNotFound, with: :room_not_found
+  before_action :set_room
+  before_action :require_creator, only: %i[create destroy]
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def index
-    room = Current.user.rooms.find(params[:room_id])
-    members = room.memberships.visible.includes(:user).map do |membership|
+    members = @room.memberships.visible.includes(:user).map do |membership|
       user = membership.user
       { id: user.id, name: user.name, role: user.role }
     end
@@ -12,12 +13,36 @@ class Bots::MembersController < Bots::BaseController
     render json: members
   end
 
+  def create
+    user = User.active.find(params[:user_id])
+    @room.add_member!(user, actor: Current.user)
+
+    render json: { id: user.id, name: user.name }, status: :created
+  end
+
+  def destroy
+    user = @room.users.find(params[:user_id])
+    @room.remove_member!(user, actor: Current.user)
+
+    head :no_content
+  rescue Membership::LastVisibleMemberError
+    render json: { error: "Cannot remove the last member", code: "validation_failed" }, status: :unprocessable_entity
+  end
+
   private
+    def set_room
+      @room = Current.user.rooms.find(params[:room_id])
+    end
+
+    def require_creator
+      head :forbidden unless @room.creator_id == Current.user.id
+    end
+
     def require_bot_authentication
       head :forbidden unless authenticated_by.bot_key?
     end
 
-    def room_not_found
-      render json: { error: "Room not found", code: "room_not_found" }, status: :not_found
+    def not_found
+      render json: { error: "Room or user not found", code: "not_found" }, status: :not_found
     end
 end

--- a/app/controllers/bots/memberships_controller.rb
+++ b/app/controllers/bots/memberships_controller.rb
@@ -1,0 +1,39 @@
+class Bots::MembershipsController < Bots::BaseController
+  before_action :require_bot_authentication
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  def create
+    room = Room.active.find(params[:room_id])
+
+    unless room.open?
+      return render json: { error: "Can only join open rooms", code: "validation_failed" }, status: :unprocessable_entity
+    end
+
+    room.accept_join!(Current.user)
+
+    render json: room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url)), status: :created
+  end
+
+  def destroy
+    room = Current.user.rooms.find(params[:room_id])
+
+    if room.direct?
+      return render json: { error: "Cannot leave direct messages", code: "validation_failed" }, status: :unprocessable_entity
+    end
+
+    room.accept_leave!(Current.user)
+
+    head :no_content
+  rescue Membership::LastVisibleMemberError
+    render json: { error: "You're the last member", code: "validation_failed" }, status: :unprocessable_entity
+  end
+
+  private
+    def require_bot_authentication
+      head :forbidden unless authenticated_by.bot_key?
+    end
+
+    def not_found
+      render json: { error: "Room not found", code: "not_found" }, status: :not_found
+    end
+end

--- a/app/controllers/bots/memberships_controller.rb
+++ b/app/controllers/bots/memberships_controller.rb
@@ -1,7 +1,4 @@
 class Bots::MembershipsController < Bots::BaseController
-  before_action :require_bot_authentication
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found
-
   def create
     room = Room.active.find(params[:room_id])
 
@@ -27,13 +24,4 @@ class Bots::MembershipsController < Bots::BaseController
   rescue Membership::LastVisibleMemberError
     render json: { error: "You're the last member", code: "validation_failed" }, status: :unprocessable_entity
   end
-
-  private
-    def require_bot_authentication
-      head :forbidden unless authenticated_by.bot_key?
-    end
-
-    def not_found
-      render json: { error: "Room not found", code: "not_found" }, status: :not_found
-    end
 end

--- a/app/controllers/bots/profiles_controller.rb
+++ b/app/controllers/bots/profiles_controller.rb
@@ -1,6 +1,4 @@
 class Bots::ProfilesController < Bots::BaseController
-  before_action :require_bot_authentication
-
   def update
     Current.user.update_bot!(bot_params)
     render json: {
@@ -12,10 +10,6 @@ class Bots::ProfilesController < Bots::BaseController
   end
 
   private
-    def require_bot_authentication
-      head :forbidden unless authenticated_by.bot_key?
-    end
-
     def bot_params
       params.permit(:name, :webhook_url, :mentions_url, :everything_url).to_h
     end

--- a/app/controllers/bots/registrations_controller.rb
+++ b/app/controllers/bots/registrations_controller.rb
@@ -1,6 +1,7 @@
 class Bots::RegistrationsController < Bots::BaseController
   include BlockBannedRequests
 
+  skip_before_action :require_bot_authentication
   allow_unauthenticated_access only: :create
 
   rate_limit to: 10, within: 1.hour, only: :create,

--- a/app/controllers/bots/rooms_controller.rb
+++ b/app/controllers/bots/rooms_controller.rb
@@ -1,7 +1,77 @@
 class Bots::RoomsController < Bots::BaseController
+  before_action :require_bot_authentication
+  before_action :set_room, only: %i[update destroy]
+  before_action :require_creator, only: %i[update destroy]
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
   def index
-    render json: Current.user.rooms.without_threads.map { |room|
-      room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
-    }
+    rooms = if params[:joinable].present?
+      Rooms::Open.browsable_by(Current.user).map { |room|
+        room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
+      }
+    else
+      Current.user.rooms.without_threads.map { |room|
+        room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
+      }
+    end
+
+    render json: rooms
   end
+
+  def create
+    type = params[:type]&.downcase
+    name = params[:name]
+
+    unless name.present?
+      return render json: { error: "Name is required", code: "validation_failed" }, status: :unprocessable_entity
+    end
+
+    unless type.in?(%w[open closed])
+      return render json: { error: "Type must be 'open' or 'closed'", code: "validation_failed" }, status: :unprocessable_entity
+    end
+
+    room_class = type == "open" ? Rooms::Open : Rooms::Closed
+    room = room_class.create_for({ name: name }, users: Current.user)
+
+    render json: room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url)), status: :created
+  end
+
+  def update
+    old_name = @room.name
+    name = params[:name]
+
+    unless name.present?
+      return render json: { error: "Name is required", code: "validation_failed" }, status: :unprocessable_entity
+    end
+
+    @room.update!(name: name)
+    @room.announce_rename(old_name, actor: Current.user) if @room.name != old_name
+
+    render json: @room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
+  end
+
+  def destroy
+    @room.deactivate
+
+    head :no_content
+  rescue Room::CannotDeleteOriginalError
+    render json: { error: "The original room can't be deleted", code: "validation_failed" }, status: :unprocessable_entity
+  end
+
+  private
+    def set_room
+      @room = Current.user.rooms.find(params[:room_id])
+    end
+
+    def require_creator
+      head :forbidden unless @room.creator_id == Current.user.id
+    end
+
+    def require_bot_authentication
+      head :forbidden unless authenticated_by.bot_key?
+    end
+
+    def not_found
+      render json: { error: "Room not found", code: "not_found" }, status: :not_found
+    end
 end

--- a/app/controllers/bots/rooms_controller.rb
+++ b/app/controllers/bots/rooms_controller.rb
@@ -1,21 +1,17 @@
 class Bots::RoomsController < Bots::BaseController
-  before_action :require_bot_authentication
   before_action :set_room, only: %i[update destroy]
   before_action :require_creator, only: %i[update destroy]
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def index
     rooms = if params[:joinable].present?
-      Rooms::Open.browsable_by(Current.user).map { |room|
-        room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
-      }
+      Rooms::Open.browsable_by(Current.user)
     else
-      Current.user.rooms.without_threads.map { |room|
-        room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
-      }
+      Current.user.rooms.without_threads
     end
 
-    render json: rooms
+    render json: rooms.map { |room|
+      room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
+    }
   end
 
   def create
@@ -61,17 +57,5 @@ class Bots::RoomsController < Bots::BaseController
   private
     def set_room
       @room = Current.user.rooms.find(params[:room_id])
-    end
-
-    def require_creator
-      head :forbidden unless @room.creator_id == Current.user.id
-    end
-
-    def require_bot_authentication
-      head :forbidden unless authenticated_by.bot_key?
-    end
-
-    def not_found
-      render json: { error: "Room not found", code: "not_found" }, status: :not_found
     end
 end

--- a/app/controllers/bots/rooms_controller.rb
+++ b/app/controllers/bots/rooms_controller.rb
@@ -42,12 +42,14 @@ class Bots::RoomsController < Bots::BaseController
 
     @room.update!(name: name)
     @room.announce_rename(old_name, actor: Current.user) if @room.name != old_name
+    RoomUpdateBroadcastJob.perform_later(@room)
 
     render json: @room.as_bot_json(bot_key: Current.user.bot_key, url_helper: method(:room_bot_messages_url))
   end
 
   def destroy
     @room.deactivate
+    broadcast_remove_room
 
     head :no_content
   rescue Room::CannotDeleteOriginalError
@@ -57,5 +59,11 @@ class Bots::RoomsController < Bots::BaseController
   private
     def set_room
       @room = Current.user.rooms.find(params[:room_id])
+    end
+
+    def broadcast_remove_room
+      Sidebar::SIDEBAR_SECTIONS.each do |list_name|
+        broadcast_remove_to Current.account, :rooms, target: [ @room, helpers.dom_prefix(list_name, :list_node) ]
+      end
     end
 end

--- a/app/controllers/bots/searches_controller.rb
+++ b/app/controllers/bots/searches_controller.rb
@@ -1,8 +1,6 @@
 class Bots::SearchesController < Bots::BaseController
   include ActiveStorage::SetCurrent
 
-  before_action :require_bot_authentication
-
   def index
     query = params[:q].to_s.gsub(/[^[:word:]]/, " ").strip
     return render(json: { error: "Query parameter 'q' is required", code: "validation_failed" }, status: :unprocessable_entity) if query.blank?
@@ -24,9 +22,4 @@ class Bots::SearchesController < Bots::BaseController
       }
     }
   end
-
-  private
-    def require_bot_authentication
-      head :forbidden unless authenticated_by.bot_key?
-    end
 end

--- a/app/controllers/messages/reads_by_bots_controller.rb
+++ b/app/controllers/messages/reads_by_bots_controller.rb
@@ -2,7 +2,7 @@ class Messages::ReadsByBotsController < ApplicationController
   include ActiveStorage::SetCurrent
 
   skip_forgery_protection
-  allow_bot_access only: :index
+  allow_bot_access only: %i[index show]
   rescue_from ActiveRecord::RecordNotFound, with: :room_not_found
 
   def index
@@ -10,7 +10,18 @@ class Messages::ReadsByBotsController < ApplicationController
     # last(50) generates LIMIT SQL; reverse restores chronological order
     messages = @room.messages.active.with_creator.with_attached_attachment.ordered.last(50).reverse
 
-    render json: messages.map { |msg|
+    render json: messages.map { |msg| message_json(msg) }
+  end
+
+  def show
+    @room = Current.user.rooms.find(params[:room_id])
+    message = @room.messages.active.with_creator.with_attached_attachment.find(params[:id])
+
+    render json: message_json(message)
+  end
+
+  private
+    def message_json(msg)
       { id: msg.id,
         creator: { id: msg.creator.id, name: msg.creator.name },
         body: { html: msg.body.body.to_s, plain: msg.plain_text_body },
@@ -18,10 +29,8 @@ class Messages::ReadsByBotsController < ApplicationController
         attachment: msg.attachment? ? attachment_json(msg) : nil,
         mentionees: msg.mentionees.map { |m| { id: m.id, name: m.name } },
         created_at: msg.created_at.iso8601 }
-    }
-  end
+    end
 
-  private
     def attachment_json(message)
       blob = message.attachment.blob
       {

--- a/app/views/skills/show.text.erb
+++ b/app/views/skills/show.text.erb
@@ -109,12 +109,68 @@ Response: { "room": { "id": 5 } } with status 201 (new) or 200 (existing).
 
 Response: JSON array of rooms the bot is a member of, with message posting URLs.
 
+## Discovering Joinable Rooms
+
+    GET <%= request.base_url %><%= request.script_name %>/rooms/{bot_key}?joinable=true
+
+Response: JSON array of open rooms the bot is NOT already a member of.
+
+## Joining a Room
+
+Bots can join any open room:
+
+    POST <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/membership
+
+Response (201): room object with id, name, type, messages_url.
+
+## Leaving a Room
+
+    DELETE <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/membership
+
+Response: 204 No Content. Cannot leave direct message rooms.
+
+## Creating a Room
+
+Bots can create open or closed rooms. The bot is auto-joined and recorded as creator.
+
+    POST <%= request.base_url %><%= request.script_name %>/rooms/{bot_key}
+    Content-Type: application/json
+
+    { "name": "My Room", "type": "open" }
+
+Response (201): room object. Type must be "open" or "closed".
+
+## Updating a Room
+
+Only the bot that created the room can update it:
+
+    PATCH <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}
+    Content-Type: application/json
+
+    { "name": "New Name" }
+
+Response: updated room object. Returns 403 if the bot is not the creator.
+
+## Archiving a Room
+
+Only the bot that created the room can archive (soft-delete) it:
+
+    DELETE <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}
+
+Response: 204 No Content. Returns 403 if the bot is not the creator.
+
 ## Reading Messages
 
     GET <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/messages
 
 Response: JSON array of recent messages (last 50) with sender, body (HTML + plain text),
 mentionees, attachment info, and created_at.
+
+## Reading a Single Message
+
+    GET <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/messages/{message_id}
+
+Response: single message object with the same fields as the list endpoint.
 
 Each message includes:
 - has_attachment (boolean): whether the message has a file attachment
@@ -165,6 +221,25 @@ Response: 204 No Content.
     GET <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/members
 
 Response: JSON array of members with id, name, and role (member, moderator, administrator, or bot).
+
+## Adding a Member to a Room
+
+Only the bot that created the room can add members:
+
+    POST <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/members
+    Content-Type: application/json
+
+    { "user_id": 42 }
+
+Response (201): { "id": 42, "name": "Alice" }. Returns 403 if the bot is not the creator.
+
+## Removing a Member from a Room
+
+Only the bot that created the room can remove members:
+
+    DELETE <%= request.base_url %><%= request.script_name %>/rooms/{room_id}/{bot_key}/members/{user_id}
+
+Response: 204 No Content. Returns 403 if the bot is not the creator.
 
 ## Searching Messages
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,8 @@ Rails.application.routes.draw do
     resources :threads, only: %i[ create show edit update destroy ]
 
     post ":bot_key/directs", to: "directs/by_bots#create", as: :bot_directs
-    get ":bot_key", to: "/bots/rooms#index", as: :bot_rooms, constraints: { bot_key: /\d+-.+/ }
+    post ":bot_key", to: "/bots/rooms#create", as: :bot_create_room, constraints: { bot_key: /\d+-.+/ }
+    get  ":bot_key", to: "/bots/rooms#index", as: :bot_rooms, constraints: { bot_key: /\d+-.+/ }
   end
 
   resources :rooms do
@@ -150,7 +151,14 @@ Rails.application.routes.draw do
     post   ":bot_key/messages/:message_id/thread",     to: "rooms/threads/by_bots#create",     as: :bot_message_thread
     post   ":bot_key/messages/:message_id/boosts",     to: "messages/boosts/by_bots#create",   as: :bot_message_boost
     delete ":bot_key/messages/:message_id/boosts/:id", to: "messages/boosts/by_bots#destroy",  as: :bot_message_unboost
+    get    ":bot_key/messages/:id",                     to: "messages/reads_by_bots#show",      as: :bot_message_read
     get    ":bot_key/members",                         to: "bots/members#index",               as: :bot_members
+    post   ":bot_key/members",                         to: "bots/members#create",              as: :bot_add_member
+    delete ":bot_key/members/:user_id",                to: "bots/members#destroy",             as: :bot_remove_member
+    post   ":bot_key/membership",                      to: "bots/memberships#create",          as: :bot_join_room
+    delete ":bot_key/membership",                      to: "bots/memberships#destroy",         as: :bot_leave_room
+    patch  ":bot_key",                                 to: "bots/rooms#update",                as: :bot_update_room, constraints: { bot_key: /\d+-.+/ }
+    delete ":bot_key",                                 to: "bots/rooms#destroy",               as: :bot_archive_room, constraints: { bot_key: /\d+-.+/ }
 
     scope module: "rooms" do
       resource :refresh, only: :show

--- a/docs/features/BOT_INTEGRATION.md
+++ b/docs/features/BOT_INTEGRATION.md
@@ -55,13 +55,22 @@ All endpoints authenticate via `bot_key` in the URL path. The bot key is a secre
 | Send attachment | POST | `/rooms/{room_id}/{bot_key}/messages` (multipart) |
 | Edit own message | PATCH | `/rooms/{room_id}/{bot_key}/messages/{id}` |
 | Delete own message | DELETE | `/rooms/{room_id}/{bot_key}/messages/{id}` |
+| Read single message | GET | `/rooms/{room_id}/{bot_key}/messages/{id}` |
 | Reply in a thread | POST | `/rooms/{room_id}/{bot_key}/messages/{message_id}/thread` |
 | Read messages | GET | `/rooms/{room_id}/{bot_key}/messages` |
 | Add reaction | POST | `/rooms/{room_id}/{bot_key}/messages/{message_id}/boosts` |
 | Remove reaction | DELETE | `/rooms/{room_id}/{bot_key}/messages/{message_id}/boosts/{boost_id}` |
 | List room members | GET | `/rooms/{room_id}/{bot_key}/members` |
+| Add member to room | POST | `/rooms/{room_id}/{bot_key}/members` |
+| Remove member from room | DELETE | `/rooms/{room_id}/{bot_key}/members/{user_id}` |
+| Bot joins room | POST | `/rooms/{room_id}/{bot_key}/membership` |
+| Bot leaves room | DELETE | `/rooms/{room_id}/{bot_key}/membership` |
 | Search messages | GET | `/{bot_key}/search?q=query` |
 | List rooms | GET | `/rooms/{bot_key}` |
+| List joinable rooms | GET | `/rooms/{bot_key}?joinable=true` |
+| Create room | POST | `/rooms/{bot_key}` |
+| Update room | PATCH | `/rooms/{room_id}/{bot_key}` |
+| Archive room | DELETE | `/rooms/{room_id}/{bot_key}` |
 | Create a DM | POST | `/rooms/{bot_key}/directs` |
 | Update bot settings | PATCH | `/bots/{bot_key}` |
 | API discovery | GET | `/skill` (unauthenticated) |
@@ -212,6 +221,88 @@ curl "$BASE_URL/$BOT_KEY/search?q=deploy"
 ```
 
 Returns up to 50 matching messages with room context.
+
+### Reading a single message
+
+```bash
+curl "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY/messages/$MESSAGE_ID"
+```
+
+Returns the message with creator, body, attachment, and mentionees.
+
+### Discovering joinable rooms
+
+List open rooms the bot can join (rooms it's not already in).
+
+```bash
+curl "$BASE_URL/rooms/$BOT_KEY?joinable=true"
+```
+
+### Joining a room
+
+Bots can join any open room.
+
+```bash
+curl -X POST "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY/membership"
+```
+
+Returns the room object on success (201).
+
+### Leaving a room
+
+```bash
+curl -X DELETE "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY/membership"
+```
+
+Returns `204 No Content`. Cannot leave direct message rooms.
+
+### Creating a room
+
+Bots can create open or closed rooms. The bot is auto-joined and recorded as the creator.
+
+```bash
+curl -X POST "$BASE_URL/rooms/$BOT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Bot Room", "type": "open"}'
+```
+
+### Updating a room
+
+Only the bot that created the room can update it.
+
+```bash
+curl -X PATCH "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "New Name"}'
+```
+
+### Archiving a room
+
+Only the bot that created the room can archive it (soft-delete).
+
+```bash
+curl -X DELETE "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY"
+```
+
+Returns `204 No Content`.
+
+### Adding a member to a room
+
+Only the bot that created the room can manage members.
+
+```bash
+curl -X POST "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY/members" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 42}'
+```
+
+### Removing a member from a room
+
+```bash
+curl -X DELETE "$BASE_URL/rooms/$ROOM_ID/$BOT_KEY/members/$USER_ID"
+```
+
+Returns `204 No Content`.
 
 ---
 

--- a/test/controllers/bots/members_controller_test.rb
+++ b/test/controllers/bots/members_controller_test.rb
@@ -31,4 +31,71 @@ class Bots::MembersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_url
   end
+
+  # Add member
+
+  test "creator bot can add a member" do
+    Current.user = @bot
+    room = Rooms::Closed.create_for({ name: "Bot's Room" }, users: @bot)
+    Current.reset
+
+    post room_bot_add_member_url(room, @bot.bot_key),
+      params: { user_id: users(:david).id },
+      as: :json
+
+    assert_response :created
+    assert_equal users(:david).id, response.parsed_body["id"]
+    assert room.users.include?(users(:david))
+  end
+
+  test "non-creator bot cannot add members" do
+    post room_bot_add_member_url(@room, @bot.bot_key),
+      params: { user_id: users(:kevin).id },
+      as: :json
+
+    assert_response :forbidden
+  end
+
+  test "adding nonexistent user returns 404" do
+    Current.user = @bot
+    room = Rooms::Closed.create_for({ name: "Bot's Room" }, users: @bot)
+    Current.reset
+
+    post room_bot_add_member_url(room, @bot.bot_key),
+      params: { user_id: 999999 },
+      as: :json
+
+    assert_response :not_found
+  end
+
+  # Remove member
+
+  test "creator bot can remove a member" do
+    Current.user = @bot
+    room = Rooms::Closed.create_for({ name: "Bot's Room" }, users: @bot)
+    Current.reset
+    room.add_member!(users(:david), actor: @bot)
+
+    delete room_bot_remove_member_url(room, @bot.bot_key, users(:david))
+
+    assert_response :no_content
+    assert_not room.reload.users.include?(users(:david))
+  end
+
+  test "non-creator bot cannot remove members" do
+    delete room_bot_remove_member_url(@room, @bot.bot_key, users(:david))
+
+    assert_response :forbidden
+  end
+
+  test "cannot remove last member" do
+    Current.user = @bot
+    room = Rooms::Closed.create_for({ name: "Solo Bot" }, users: @bot)
+    Current.reset
+
+    delete room_bot_remove_member_url(room, @bot.bot_key, @bot)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+  end
 end

--- a/test/controllers/bots/memberships_controller_test.rb
+++ b/test/controllers/bots/memberships_controller_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class Bots::MembershipsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @bot = users(:bender)
+  end
+
+  # Join room
+
+  test "bot can join an open room" do
+    room = rooms(:hq) # open room, bot is not a member
+
+    post room_bot_join_room_url(room, @bot.bot_key)
+
+    assert_response :created
+    json = response.parsed_body
+    assert_equal room.id, json["id"]
+    assert room.reload.users.include?(@bot)
+  end
+
+  test "bot cannot join a closed room" do
+    room = rooms(:designers) # closed room
+
+    post room_bot_join_room_url(room, @bot.bot_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+  end
+
+  test "returns 404 for nonexistent room" do
+    post room_bot_join_room_url(999999, @bot.bot_key)
+
+    assert_response :not_found
+  end
+
+  # Leave room
+
+  test "bot can leave a room" do
+    room = rooms(:watercooler) # bot is a member
+
+    delete room_bot_leave_room_url(room, @bot.bot_key)
+
+    assert_response :no_content
+  end
+
+  test "bot cannot leave a direct message room" do
+    Current.user = @bot
+    dm = Rooms::Direct.find_or_create_for([ @bot, users(:david) ])
+    Current.reset
+
+    delete room_bot_leave_room_url(dm, @bot.bot_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+  end
+
+  test "returns 404 when leaving room bot is not in" do
+    delete room_bot_leave_room_url(rooms(:designers), @bot.bot_key)
+
+    assert_response :not_found
+  end
+
+  # Auth
+
+  test "invalid bot key redirects to sign in" do
+    post room_bot_join_room_url(rooms(:hq), "999-invalid")
+
+    assert_redirected_to new_session_url
+  end
+
+  test "session-authenticated user cannot use bot join" do
+    sign_in users(:david)
+
+    post room_bot_join_room_url(rooms(:hq), @bot.bot_key)
+
+    assert_response :forbidden
+  end
+end

--- a/test/controllers/bots/rooms_controller_test.rb
+++ b/test/controllers/bots/rooms_controller_test.rb
@@ -40,4 +40,161 @@ class Bots::RoomsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_url
   end
+
+  # Joinable rooms filter
+
+  test "lists joinable open rooms the bot is not in" do
+    get rooms_bot_rooms_url(@bot.bot_key), params: { joinable: true }
+
+    assert_response :success
+    json = response.parsed_body
+    assert json.is_a?(Array)
+
+    room_ids = json.map { |r| r["id"] }
+    # Bot is not in pets or hq (open rooms), but IS in watercooler (closed)
+    assert_includes room_ids, rooms(:pets).id
+    assert_includes room_ids, rooms(:hq).id
+    assert_not_includes room_ids, rooms(:watercooler).id
+  end
+
+  test "joinable rooms excludes rooms bot is already in" do
+    # Join an open room first
+    rooms(:hq).accept_join!(@bot)
+
+    get rooms_bot_rooms_url(@bot.bot_key), params: { joinable: true }
+
+    assert_response :success
+    room_ids = response.parsed_body.map { |r| r["id"] }
+    assert_not_includes room_ids, rooms(:hq).id
+  end
+
+  # Room creation
+
+  test "create an open room" do
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { name: "Bot Room", type: "open" },
+      as: :json
+
+    assert_response :created
+    json = response.parsed_body
+    assert_equal "Bot Room", json["name"]
+    assert_equal "Open", json["type"]
+  end
+
+  test "create a closed room" do
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { name: "Secret Bot Room", type: "closed" },
+      as: :json
+
+    assert_response :created
+    json = response.parsed_body
+    assert_equal "Secret Bot Room", json["name"]
+    assert_equal "Closed", json["type"]
+  end
+
+  test "create room requires a name" do
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { type: "open" },
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+  end
+
+  test "create room requires a valid type" do
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { name: "Bad Type", type: "direct" },
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "bot is auto-joined to created room" do
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { name: "My Room", type: "open" },
+      as: :json
+
+    room = Room.find(response.parsed_body["id"])
+    assert room.users.include?(@bot)
+  end
+
+  test "bot is recorded as creator of room" do
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { name: "My Room", type: "open" },
+      as: :json
+
+    room = Room.find(response.parsed_body["id"])
+    assert_equal @bot.id, room.creator_id
+  end
+
+  # Room update
+
+  test "creator bot can rename room" do
+    Current.user = @bot
+    room = Rooms::Open.create_for({ name: "Old Name" }, users: @bot)
+    Current.reset
+
+    patch room_bot_update_room_url(room, @bot.bot_key),
+      params: { name: "New Name" },
+      as: :json
+
+    assert_response :success
+    assert_equal "New Name", response.parsed_body["name"]
+    assert_equal "New Name", room.reload.name
+  end
+
+  test "non-creator bot cannot update room" do
+    room = rooms(:watercooler) # created by david, not bender
+
+    patch room_bot_update_room_url(room, @bot.bot_key),
+      params: { name: "Nope" },
+      as: :json
+
+    assert_response :forbidden
+  end
+
+  test "update requires a name" do
+    Current.user = @bot
+    room = Rooms::Open.create_for({ name: "Old Name" }, users: @bot)
+    Current.reset
+
+    patch room_bot_update_room_url(room, @bot.bot_key),
+      params: {},
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  # Room archive
+
+  test "creator bot can archive room" do
+    Current.user = @bot
+    room = Rooms::Open.create_for({ name: "Doomed" }, users: @bot)
+    Current.reset
+
+    delete room_bot_archive_room_url(room, @bot.bot_key)
+
+    assert_response :no_content
+    assert_not room.reload.active?
+  end
+
+  test "non-creator bot cannot archive room" do
+    room = rooms(:watercooler)
+
+    delete room_bot_archive_room_url(room, @bot.bot_key)
+
+    assert_response :forbidden
+  end
+
+  # Auth
+
+  test "session-authenticated user cannot use room management" do
+    sign_in users(:david)
+
+    post rooms_bot_create_room_url(@bot.bot_key),
+      params: { name: "Sneaky", type: "open" },
+      as: :json
+
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/messages/reads_by_bots_controller_test.rb
+++ b/test/controllers/messages/reads_by_bots_controller_test.rb
@@ -44,4 +44,39 @@ class Messages::ReadsByBotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_url
   end
+
+  # Single message read
+
+  test "returns a single message by id" do
+    message = messages(:bender_message)
+
+    get room_bot_message_read_url(@room, @bot.bot_key, message)
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal message.id, json["id"]
+    assert json["creator"].is_a?(Hash)
+    assert json["body"].is_a?(Hash)
+    assert json["created_at"].present?
+  end
+
+  test "returns 404 for message in room bot is not in" do
+    other_room = rooms(:designers)
+    # Create a message in the other room to look up
+    message = other_room.messages.create!(
+      creator: users(:david),
+      body: "test",
+      client_message_id: Random.uuid
+    )
+
+    get room_bot_message_read_url(other_room, @bot.bot_key, message)
+
+    assert_response :not_found
+  end
+
+  test "returns 404 for nonexistent message" do
+    get room_bot_message_read_url(@room, @bot.bot_key, 999999)
+
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
## Summary

- **8 new endpoints + 1 filter** for Tier 2 bot API: room CRUD, member management, bot join/leave, single message read, joinable rooms discovery
- Bots can manage rooms they created (update/archive/add members/remove members) without admin role
- Room discovery via `?joinable=true` reuses existing `browsable_by` scope
- Sidebar broadcasts for bot-managed member and room changes (parity with human controllers)
- Extracted shared `require_bot_authentication`, `not_found`, `require_creator` into `Bots::BaseController`
- Updated `/skill` endpoint and `BOT_INTEGRATION.md` docs

### New endpoints
| Endpoint | Method | Description |
|----------|--------|-------------|
| `/rooms/{bot_key}?joinable=true` | GET | List open rooms bot can join |
| `/rooms/{bot_key}` | POST | Create open/closed room |
| `/rooms/{room_id}/{bot_key}` | PATCH | Update room name |
| `/rooms/{room_id}/{bot_key}` | DELETE | Archive room (soft-delete) |
| `/rooms/{room_id}/{bot_key}/members` | POST | Add user to room |
| `/rooms/{room_id}/{bot_key}/members/{user_id}` | DELETE | Remove user from room |
| `/rooms/{room_id}/{bot_key}/membership` | POST | Bot joins open room |
| `/rooms/{room_id}/{bot_key}/membership` | DELETE | Bot leaves room |
| `/rooms/{room_id}/{bot_key}/messages/{id}` | GET | Read single message |

## Test plan

- [x] 1104 tests pass (0 failures, 0 errors)
- [x] 42 new/updated bot API tests covering all endpoints
- [x] Auth boundaries: session users rejected, invalid bot keys rejected
- [x] Ownership: non-creator bots get 403 on room management
- [x] Edge cases: last member removal, DM leave prevention, nonexistent records
- [x] Brakeman security scan: 0 warnings
- [x] RuboCop: 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)