### PR TITLE
Replace bot self-registration with single-use invite codes

### DIFF
--- a/app/controllers/accounts/bot_invite_codes_controller.rb
+++ b/app/controllers/accounts/bot_invite_codes_controller.rb
@@ -1,0 +1,12 @@
+class Accounts::BotInviteCodesController < ApplicationController
+  before_action :ensure_can_administer
+
+  def create
+    @bot_invite_code, @regenerated = Current.account.generate_bot_invite_code!
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to account_bots_url }
+    end
+  end
+end

--- a/app/controllers/accounts/bots_controller.rb
+++ b/app/controllers/accounts/bots_controller.rb
@@ -4,6 +4,7 @@ class Accounts::BotsController < ApplicationController
 
   def index
     @bots = User.active_bots.ordered
+    @bot_invite_code = Current.account.join_codes.bot.active.order(created_at: :desc).first
   end
 
   def new

--- a/app/controllers/accounts/bots_controller.rb
+++ b/app/controllers/accounts/bots_controller.rb
@@ -4,7 +4,7 @@ class Accounts::BotsController < ApplicationController
 
   def index
     @bots = User.active_bots.ordered
-    @bot_invite_code = Current.account.join_codes.bot.active.order(created_at: :desc).first
+    @bot_invite_code = Current.account.active_bot_invite_code
   end
 
   def new

--- a/app/controllers/bots/registrations_controller.rb
+++ b/app/controllers/bots/registrations_controller.rb
@@ -8,7 +8,6 @@ class Bots::RegistrationsController < Bots::BaseController
     with: -> { render json: { error: "Too many attempts", code: "rate_limited" }, status: :too_many_requests }
 
   before_action :reject_banned_ip, only: :create
-  before_action :verify_self_registration_enabled
   before_action :set_join_code!
   before_action :verify_join_code_active
 
@@ -29,14 +28,8 @@ class Bots::RegistrationsController < Bots::BaseController
   end
 
   private
-    def verify_self_registration_enabled
-      unless Current.account.settings.allow_bot_self_registration?
-        render json: { error: "Bot self-registration is not enabled", code: "self_registration_disabled" }, status: :forbidden
-      end
-    end
-
     def set_join_code!
-      @join_code = Current.account.join_codes.find_by!(code: params[:join_code])
+      @join_code = Current.account.join_codes.bot.find_by!(code: params[:join_code])
     end
 
     def verify_join_code_active

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -107,7 +107,7 @@ class UsersController < ApplicationController
     end
 
     def set_join_code
-      @join_code = Current.account.join_codes.find_by(code: params[:join_code])
+      @join_code = Current.account.join_codes.human.find_by(code: params[:join_code])
       redirect_to root_url, alert: "This invite link is not valid. Please request a new one." unless @join_code
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,7 +7,7 @@ class Account < ApplicationRecord
   InvalidLogoType = Class.new(StandardError)
 
   has_one_attached :logo
-  has_json :settings, restrict_room_creation_to_administrators: false, restrict_direct_messages_to_administrators: false, allow_users_to_create_invite_links: true, allow_bot_self_registration: false
+  has_json :settings, restrict_room_creation_to_administrators: false, restrict_direct_messages_to_administrators: false, allow_users_to_create_invite_links: true
 
   after_save :invalidate_personal_invite_links, if: :invite_links_disabled?
   after_commit :sync_name_to_workspace, if: :saved_change_to_name?

--- a/app/models/account/join_code.rb
+++ b/app/models/account/join_code.rb
@@ -2,6 +2,8 @@ class Account::JoinCode < ApplicationRecord
   CODE_LENGTH = 12
   DEFAULT_EXPIRATION = 7.days
 
+  enum :kind, human: "human", bot: "bot"
+
   belongs_to :account
   belongs_to :user, optional: true
 
@@ -14,6 +16,7 @@ class Account::JoinCode < ApplicationRecord
   before_validation :generate_code, on: :create, if: -> { code.blank? }
   before_validation :set_default_expiration, on: :create, if: :personal?
   before_validation :set_default_account, on: :create, if: -> { account_id.blank? }
+  before_validation :set_bot_defaults, on: :create, if: :bot?
 
   class InactiveCodeError < StandardError; end
 
@@ -77,5 +80,9 @@ class Account::JoinCode < ApplicationRecord
 
     def set_default_account
       self.account = Account.sole
+    end
+
+    def set_bot_defaults
+      self.usage_limit = 1
     end
 end

--- a/app/models/account/join_code.rb
+++ b/app/models/account/join_code.rb
@@ -10,7 +10,7 @@ class Account::JoinCode < ApplicationRecord
   validates :code, uniqueness: true
 
   scope :active, -> { where("(usage_limit IS NULL OR usage_count < usage_limit) AND (expires_at IS NULL OR expires_at > ?)", Time.current) }
-  scope :global, -> { where(user_id: nil) }
+  scope :global, -> { human.where(user_id: nil) }
   scope :personal, -> { where.not(user_id: nil) }
 
   before_validation :generate_code, on: :create, if: -> { code.blank? }

--- a/app/models/account/joinable.rb
+++ b/app/models/account/joinable.rb
@@ -7,7 +7,6 @@ module Account::Joinable
     after_create :create_global_join_code
   end
 
-  # Returns the global (admin) join code for backward compatibility
   def join_code
     join_codes.global.first
   end
@@ -16,8 +15,12 @@ module Account::Joinable
     join_code.regenerate_code
   end
 
+  def active_bot_invite_code
+    join_codes.bot.active.order(created_at: :desc).first
+  end
+
   def generate_bot_invite_code!
-    regenerated = join_codes.bot.active.delete_all > 0
+    regenerated = join_codes.bot.active.destroy_all.any?
     code = join_codes.create!(kind: :bot)
     [ code, regenerated ]
   end

--- a/app/models/account/joinable.rb
+++ b/app/models/account/joinable.rb
@@ -16,6 +16,12 @@ module Account::Joinable
     join_code.regenerate_code
   end
 
+  def generate_bot_invite_code!
+    regenerated = join_codes.bot.active.delete_all > 0
+    code = join_codes.create!(kind: :bot)
+    [ code, regenerated ]
+  end
+
   private
     def create_global_join_code
       join_codes.create!

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -226,10 +226,12 @@ class Room < ApplicationRecord
   end
 
   def post_welcome_message(user:)
+    body = user.bot? ? "has been added as a bot." : "joined the community. Say hello!"
+
     messages.create!(
       creator: user,
       welcome: true,
-      body: "joined the community. Say hello!",
+      body: body,
       client_message_id: Random.uuid
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -385,8 +385,7 @@ class User < ApplicationRecord
     end
 
     def post_welcome_message
-      return if bot?
-      return unless verified?
+      return unless bot? || verified?
       return unless room = Room.original
 
       room.post_welcome_message(user: self)

--- a/app/views/accounts/bot_invite_codes/_bot_invite_code.html.erb
+++ b/app/views/accounts/bot_invite_codes/_bot_invite_code.html.erb
@@ -1,12 +1,5 @@
 <%# locals: (bot_invite_code: nil, regenerated: false) %>
-<div id="bot_invite_code" class="flex flex-column gap">
-  <div class="flex align-center gap">
-    <div class="flex-item-grow">
-      <div class="txt-small"><strong>Bot invite URL</strong></div>
-      <div class="txt-small txt-muted">Generate a one-time URL to let a bot register via the API. <%= link_to "Install a bot", "https://github.com/sabha-co/openclaw-sabha?tab=readme-ov-file#install", target: "_blank", class: "txt-underlined" %></div>
-    </div>
-  </div>
-
+<div id="bot_invite_code">
   <% if bot_invite_code %>
     <div class="flex align-center gap">
       <input type="text" class="input input--small flex-item-grow fill-white txt-small" value="<%= join_bot_url(bot_invite_code.code) %>" readonly>
@@ -21,7 +14,7 @@
     </div>
 
     <% if regenerated %>
-      <p class="txt-small txt-muted margin-none">Previous invite URL has been expired. Use this regenerated invite URL.</p>
+      <p class="txt-x-small txt-muted margin-none">Previous URL expired. Share this new one.</p>
     <% end %>
   <% else %>
     <%= button_to account_bot_invite_code_path, class: "btn btn--reversed btn--small" do %>

--- a/app/views/accounts/bot_invite_codes/_bot_invite_code.html.erb
+++ b/app/views/accounts/bot_invite_codes/_bot_invite_code.html.erb
@@ -1,0 +1,32 @@
+<%# locals: (bot_invite_code: nil, regenerated: false) %>
+<div id="bot_invite_code" class="flex flex-column gap">
+  <div class="flex align-center gap">
+    <div class="flex-item-grow">
+      <div class="txt-small"><strong>Bot invite URL</strong></div>
+      <div class="txt-small txt-muted">Generate a one-time URL to let a bot register via the API. <%= link_to "Install a bot", "https://github.com/sabha-co/openclaw-sabha?tab=readme-ov-file#install", target: "_blank", class: "txt-underlined" %></div>
+    </div>
+  </div>
+
+  <% if bot_invite_code %>
+    <div class="flex align-center gap">
+      <input type="text" class="input input--small flex-item-grow fill-white txt-small" value="<%= join_bot_url(bot_invite_code.code) %>" readonly>
+      <%= button_to_copy_to_clipboard(join_bot_url(bot_invite_code.code)) do %>
+        <%= icon_tag "copy-paste" %>
+        <span class="for-screen-reader">Copy bot invite URL</span>
+      <% end %>
+      <%= button_to account_bot_invite_code_path, class: "btn", aria: { label: "Generate new bot invite URL" } do %>
+        <%= icon_tag "refresh" %>
+        <span class="for-screen-reader">Generate new bot invite URL</span>
+      <% end %>
+    </div>
+
+    <% if regenerated %>
+      <p class="txt-small txt-muted margin-none">Previous invite URL has been expired. Use this regenerated invite URL.</p>
+    <% end %>
+  <% else %>
+    <%= button_to account_bot_invite_code_path, class: "btn btn--reversed btn--small" do %>
+      <%= icon_tag "add" %>
+      <span>Generate</span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/accounts/bot_invite_codes/create.turbo_stream.erb
+++ b/app/views/accounts/bot_invite_codes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bot_invite_code" do %>
+  <%= render "accounts/bot_invite_codes/bot_invite_code", bot_invite_code: @bot_invite_code, regenerated: @regenerated %>
+<% end %>

--- a/app/views/accounts/bots/_form.html.erb
+++ b/app/views/accounts/bots/_form.html.erb
@@ -21,14 +21,16 @@
   </label>
 </div>
 
-<div class="flex align-center gap">
-  <%= translation_button(:webhook_url) %>
-  <label class="flex align-center gap flex-item-grow txt-large input input--actor">
-    <%= form.url_field :webhook_url, class: "input", placeholder: "Webhook URL" %>
-    <%= icon_tag "web" %>
-  </label>
-</div>
-
-<p class="txt-x-small txt-muted margin-none">Sabha will POST events to this URL when the bot is mentioned.</p>
+<details <%= "open" if bot.webhook_url.present? %>>
+  <summary class="txt-small txt-muted txt-underlined" style="cursor: pointer;">Add a webhook URL</summary>
+  <div class="flex align-center gap pad-block-half">
+    <%= translation_button(:webhook_url) %>
+    <label class="flex align-center gap flex-item-grow txt-large input input--actor">
+      <%= form.url_field :webhook_url, class: "input", placeholder: "https://example.com/webhook" %>
+      <%= icon_tag "web" %>
+    </label>
+  </div>
+  <p class="txt-x-small txt-muted margin-none">Sabha will POST events here as a fallback when WebSocket is unavailable.</p>
+</details>
 
 <%= profile_form_submit_button %>

--- a/app/views/accounts/bots/index.html.erb
+++ b/app/views/accounts/bots/index.html.erb
@@ -29,23 +29,5 @@
 
   <hr class="separator full-width" style="--border-style: solid">
 
-  <div class="flex align-center gap">
-    <%= form_with model: Current.account, url: account_path, method: :put, data: { controller: "form" }, class: "flex align-center gap flex-item-grow" do |form| %>
-      <%= form.fields_for :settings, Current.account.settings do |settings_form| %>
-        <%= settings_form.hidden_field :allow_bot_self_registration,
-            value: !Current.account.settings.allow_bot_self_registration? %>
-      <% end %>
-      <label class="switch flex-item-no-shrink">
-        <input type="checkbox"
-              class="switch__input"
-              <%= "checked" if Current.account.settings.allow_bot_self_registration? %>
-              data-action="change->form#submit">
-        <span class="switch__btn"></span>
-      </label>
-      <div>
-        <div class="txt-small"><strong>Allow bot self-registration</strong></div>
-        <div class="txt-small txt-muted">Bots can join automatically when you share join code.</div>
-      </div>
-    <% end %>
-  </div>
+  <%= render "accounts/bot_invite_codes/bot_invite_code", bot_invite_code: @bot_invite_code %>
 </section>

--- a/app/views/accounts/bots/index.html.erb
+++ b/app/views/accounts/bots/index.html.erb
@@ -7,21 +7,12 @@
 <% end %>
 
 <section class="panel flex flex-column gap" style="view-transition-name: chat-bots">
-  <div class="flex align-center gap">
-    <div class="flex flex-column gap-half flex-item-grow">
-      <h1 class="txt-large margin-none"><strong>Chat bots</strong></h1>
-      <p class="txt-small txt-muted margin-none">Other sites and services can post updates directly to Sabha via bots. <%= link_to "API docs", skill_path, target: "_blank", class: "txt-underlined" %></p>
-    </div>
-
-    <%= link_to new_account_bot_path, class: "btn btn--reversed flex-item-no-shrink", aria: { label: "Add a chat bot" } do %>
-      <%= icon_tag "add" %>
-      <span>Add bot</span>
-    <% end %>
+  <div class="flex flex-column gap-half">
+    <h1 class="txt-large margin-none"><strong>Chat bots</strong></h1>
+    <p class="txt-small txt-muted margin-none">Bots post messages and respond to mentions via the API. <%= link_to "API docs", skill_path, target: "_blank", class: "txt-underlined" %></p>
   </div>
 
   <% if @bots.any? %>
-    <hr class="separator full-width" style="--border-style: solid">
-
     <menu class="flex flex-column gap-half margin-none pad-none">
       <%= render partial: "accounts/bots/bot", collection: @bots %>
     </menu>
@@ -29,5 +20,24 @@
 
   <hr class="separator full-width" style="--border-style: solid">
 
-  <%= render "accounts/bot_invite_codes/bot_invite_code", bot_invite_code: @bot_invite_code %>
+  <div class="flex flex-column gap">
+    <h2 class="txt-small txt-muted margin-none"><strong>Add a bot</strong></h2>
+
+    <div class="fill-shade border-radius pad flex flex-column gap-half">
+      <div class="txt-small"><strong>Invite URL</strong></div>
+      <div class="txt-x-small txt-muted">Generate a one-time URL to register a bot via the API. <%= link_to "Install a bot", "https://github.com/sabha-co/openclaw-sabha?tab=readme-ov-file#install", target: "_blank", class: "txt-underlined" %></div>
+      <%= render "accounts/bot_invite_codes/bot_invite_code", bot_invite_code: @bot_invite_code %>
+    </div>
+
+    <div class="fill-shade border-radius pad flex align-center gap">
+      <div class="flex-item-grow min-width">
+        <div class="txt-small"><strong>Create manually</strong></div>
+        <div class="txt-x-small txt-muted">Set up a bot yourself with a name and optional webhook URL.</div>
+      </div>
+      <%= link_to new_account_bot_path, class: "btn btn--small flex-item-no-shrink", aria: { label: "Create a bot manually" } do %>
+        <%= icon_tag "add" %>
+        <span>Create bot</span>
+      <% end %>
+    </div>
+  </div>
 </section>

--- a/app/views/accounts/bots/show.html.erb
+++ b/app/views/accounts/bots/show.html.erb
@@ -14,7 +14,7 @@
 
     <div class="min-width flex-item-grow">
       <h1 class="margin-none txt-x-large"><%= @bot.name %></h1>
-      <p class="txt-small txt-muted margin-none">Post messages to rooms via the API, receive webhooks when mentioned.</p>
+      <p class="txt-small txt-muted margin-none">Post messages to rooms via the API, receive events in real-time.</p>
     </div>
 
     <%= link_to edit_account_bot_path(@bot), class: "btn", aria: { label: "Edit #{@bot.name}" } do %>
@@ -22,30 +22,43 @@
     <% end %>
   </div>
 
-  <% if @bot.webhook_url.present? %>
-    <div class="pad-inline flex flex-column gap-half">
-      <label class="txt-small txt-muted">Webhook URL — Sabha sends events here when the bot is mentioned</label>
+  <hr class="separator full-width" style="--border-style: solid">
+
+  <div class="pad-inline flex flex-column gap-half">
+    <h2 class="txt-small txt-muted margin-none">Credentials</h2>
+
+    <label class="flex flex-column gap-half">
+      <span class="txt-x-small txt-muted">Base URL</span>
       <div class="flex align-center gap">
         <div class="flex-item-grow min-width">
-          <input type="text" class="input full-width fill-white txt-small" value="<%= @bot.webhook_url %>" readonly>
+          <input type="text" class="input input--small full-width fill-white txt-small" value="<%= request.base_url %><%= request.script_name %>" readonly>
         </div>
-        <%= button_to_copy_to_clipboard(@bot.webhook_url) do %>
+        <%= button_to_copy_to_clipboard("#{request.base_url}#{request.script_name}") do %>
           <%= icon_tag "copy-paste" %>
-          <span class="for-screen-reader">Copy webhook URL</span>
+          <span class="for-screen-reader">Copy base URL</span>
         <% end %>
       </div>
-    </div>
-  <% else %>
-    <div class="pad-inline">
-      <p class="txt-small txt-muted margin-none">No webhook URL set. <%= link_to "Add one", edit_account_bot_path(@bot), class: "txt-underlined" %> to receive events when the bot is mentioned.</p>
-    </div>
-  <% end %>
+    </label>
+
+    <label class="flex flex-column gap-half">
+      <span class="txt-x-small txt-muted">Bot key</span>
+      <div class="flex align-center gap">
+        <div class="flex-item-grow min-width">
+          <input type="text" class="input input--small full-width fill-white txt-small" value="<%= @bot.bot_key %>" readonly>
+        </div>
+        <%= button_to_copy_to_clipboard(@bot.bot_key) do %>
+          <%= icon_tag "copy-paste" %>
+          <span class="for-screen-reader">Copy bot key</span>
+        <% end %>
+      </div>
+    </label>
+  </div>
 
   <hr class="separator full-width" style="--border-style: solid">
 
   <div class="pad-inline flex flex-column gap-half">
     <h2 class="txt-small txt-muted margin-none">Rooms</h2>
-    <p class="txt-small txt-muted margin-none">Select a room to configure webhook delivery and copy its message URL.</p>
+    <p class="txt-small txt-muted margin-none">Select a room to configure event delivery and copy its message URL.</p>
 
     <% if @bot_memberships.any? %>
       <menu class="flex flex-column gap-half margin-none pad-none">
@@ -92,16 +105,16 @@
   <hr class="separator full-width" style="--border-style: solid">
 
   <div class="pad-inline">
-    <p class="txt-small txt-muted margin-none"><%= link_to "API docs", skill_path, target: "_blank", class: "txt-underlined" %> — full reference for posting messages, reading history, and webhook payloads.</p>
+    <p class="txt-small txt-muted margin-none"><%= link_to "API docs", skill_path, target: "_blank", class: "txt-underlined" %> — full reference for posting messages, reading history, and event payloads.</p>
   </div>
 
   <hr class="separator full-width" style="--border-style: solid">
 
   <div class="pad-inline flex flex-column gap-half">
     <%= button_to account_bot_key_path(@bot), method: :put, class: "btn full-width txt-small btn--negative",
-          data: { turbo_confirm: "Are you sure you want to rotate the API key? All integrations using this bot must be updated." } do %>
+          data: { turbo_confirm: "Are you sure you want to rotate the bot key? All integrations using this bot must be updated." } do %>
       <%= icon_tag "refresh" %>
-      <span>Rotate API key</span>
+      <span>Rotate bot key</span>
     <% end %>
 
     <%= button_to account_bot_path(@bot), method: :delete, class: "btn full-width txt-small btn--negative",

--- a/app/views/skills/show.text.erb
+++ b/app/views/skills/show.text.erb
@@ -2,9 +2,9 @@
 
 This document describes how to interact with <%= Current.account.name %> as a bot.
 
-## Self-Registration
+## Registration via Invite URL
 
-To register as a bot, POST JSON to the join URL with a valid join code:
+To register a bot, ask an admin to generate a bot invite URL, then POST JSON to it:
 
     POST <%= request.base_url %><%= request.script_name %>/join/JOIN_CODE
     Accept: application/json
@@ -356,4 +356,4 @@ All errors return JSON with `error` (human-readable) and `code` (machine-stable)
     { "error": "Join code has expired", "code": "join_code_expired" }
 
 Common codes: join_code_not_found, join_code_expired, join_code_inactive,
-self_registration_disabled, rate_limited, validation_failed, forbidden, not_found.
+rate_limited, validation_failed, forbidden, not_found.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resource :bot_invite_code, only: :create, controller: "bot_invite_codes"
+
       resource :join_code, only: :create
       resource :logo, only: %i[ show destroy ]
       resource :custom_styles, only: %i[ edit update ]
@@ -121,7 +123,7 @@ Rails.application.routes.draw do
   resource :skill, only: :show, controller: "skills"
 
   # Join routes for signup via invite link
-  # Bot self-registration (JSON) must come before human signup route
+  # Bot registration via invite URL (JSON) must come before human signup route
   post "join/:join_code", to: "bots/registrations#create", constraints: ->(req) { req.format.json? }, as: :join_bot
 
   get "join/:join_code", to: "users#new", as: :join

--- a/db/migrate/20260413052010_add_kind_to_account_join_codes.rb
+++ b/db/migrate/20260413052010_add_kind_to_account_join_codes.rb
@@ -1,0 +1,6 @@
+class AddKindToAccountJoinCodes < ActiveRecord::Migration[8.2]
+  def change
+    add_column :account_join_codes, :kind, :string, default: "human", null: false
+    add_index :account_join_codes, [ :account_id, :kind ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_04_07_043859) do
+ActiveRecord::Schema[8.2].define(version: 2026_04_13_052010) do
   create_table "account_join_codes", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "code", null: false
     t.datetime "created_at", null: false
     t.datetime "expires_at"
+    t.string "kind", default: "human", null: false
     t.datetime "updated_at", null: false
     t.integer "usage_count", default: 0, null: false
     t.integer "usage_limit"
     t.integer "user_id"
+    t.index ["account_id", "kind"], name: "index_account_join_codes_on_account_id_and_kind"
     t.index ["account_id"], name: "index_account_join_codes_on_account_id"
     t.index ["code"], name: "index_account_join_codes_on_code", unique: true
     t.index ["user_id"], name: "index_account_join_codes_on_user_id"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -24,13 +24,13 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: code
-    cast_type: &7 !ruby/object:ActiveModel::Type::String
+    cast_type: &5 !ruby/object:ActiveModel::Type::String
       true: t
       false: f
       precision:
       scale:
       limit:
-    sql_type_metadata: &8 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+    sql_type_metadata: &6 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
       sql_type: varchar
       type: :string
       limit:
@@ -41,7 +41,7 @@ columns:
     default_function:
     collation:
     comment:
-  - &5 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+  - &7 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: created_at
     cast_type: &1 !ruby/object:ActiveRecord::Type::DateTime
@@ -70,13 +70,23 @@ columns:
     default_function:
     collation:
     comment:
-  - &6 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+  - &8 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment: true
     name: id
     cast_type: *3
     sql_type_metadata: *4
     'null': false
     default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: kind
+    cast_type: *5
+    sql_type_metadata: *6
+    'null': false
+    default: human
     default_function:
     collation:
     comment:
@@ -139,7 +149,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: custom_styles
@@ -160,12 +170,12 @@ columns:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - &12 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: name
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -211,8 +221,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - *12
   - &15 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
@@ -237,8 +247,8 @@ columns:
   - &16 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: record_type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -256,8 +266,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - *12
   - *15
   - *16
@@ -275,8 +285,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: checksum
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -285,30 +295,30 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: content_type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: filename
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - &18 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: key
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -327,8 +337,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: service_name
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -336,26 +346,26 @@ columns:
     comment:
   active_storage_variant_records:
   - *17
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: variation_digest
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
     collation:
     comment:
   ar_internal_metadata:
-  - *5
+  - *7
   - *18
   - *9
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: value
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -365,21 +375,21 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: code
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - *19
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: token
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -410,35 +420,35 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: color
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: icon
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - *12
   - *9
   bans:
-  - *5
-  - *6
+  - *7
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: ip_address
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -467,12 +477,12 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - *9
   bookmarks:
-  - *5
-  - *6
+  - *7
+  - *8
   - &21 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: message_id
@@ -516,8 +526,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - *21
   - *9
   memberships:
@@ -542,13 +552,13 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: involvement
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default: mentions
     default_function:
@@ -591,14 +601,14 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: client_message_id
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: creator_id
@@ -612,14 +622,14 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: event
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: mentions_everyone
@@ -646,8 +656,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: activity_type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -673,8 +683,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - *21
   - *9
   - *20
@@ -682,30 +692,30 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: auth_key
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: endpoint
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: p256dh_key
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -715,8 +725,8 @@ columns:
   - &26 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: user_agent
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -735,7 +745,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: creator_id
@@ -756,7 +766,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: last_active_at
@@ -770,8 +780,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: members_hash
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -790,8 +800,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: name
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -810,8 +820,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: slug
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -820,8 +830,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: sortable_name
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -830,8 +840,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -842,15 +852,15 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: version
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
     collation:
     comment:
   searches:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: creator_id
@@ -861,12 +871,12 @@ columns:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: query
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -875,14 +885,14 @@ columns:
   - *9
   - *20
   sessions:
-  - *5
+  - *7
   - *19
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: ip_address
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -901,8 +911,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: token
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -922,7 +932,7 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: delta
@@ -933,12 +943,12 @@ columns:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: operation
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -957,8 +967,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: recordable_type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -967,8 +977,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: request_id
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -986,8 +996,8 @@ columns:
     default_function:
     collation:
     comment:
-  - *5
-  - *6
+  - *7
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: last_entry_id
@@ -1011,8 +1021,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: owner_type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': false
     default:
     default_function:
@@ -1023,8 +1033,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: ascii_name
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1043,8 +1053,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: avatar_url
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1073,14 +1083,14 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: bot_token
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: current_streak
@@ -1094,14 +1104,14 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: email_address
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: last_authenticated_at
@@ -1115,8 +1125,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: linkedin_url
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1125,8 +1135,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: linkedin_username
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1136,8 +1146,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: password_digest
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1146,8 +1156,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: personal_url
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1185,9 +1195,28 @@ columns:
     comment:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
+    name: streak_updated_on
+    cast_type: !ruby/object:ActiveRecord::Type::Date
+      precision:
+      scale:
+      limit:
+      timezone:
+    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      sql_type: date
+      type: :date
+      limit:
+      precision:
+      scale:
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
     name: twitter_url
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1196,8 +1225,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: twitter_username
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1206,8 +1235,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: unconfirmed_email
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1235,18 +1264,18 @@ columns:
     collation:
     comment:
   webhook_events:
-  - *5
+  - *7
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: event_type
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
     collation:
     comment:
-  - *6
+  - *8
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: payload
@@ -1270,8 +1299,8 @@ columns:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: source
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -1279,14 +1308,14 @@ columns:
     comment:
   - *9
   webhooks:
-  - *5
-  - *6
+  - *7
+  - *8
   - *9
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: url
-    cast_type: *7
-    sql_type_metadata: *8
+    cast_type: *5
+    sql_type_metadata: *6
     'null': true
     default:
     default_function:
@@ -2363,4 +2392,4 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-version: 20260330103742
+version: 20260413052010

--- a/test/controllers/bots/registrations_controller_test.rb
+++ b/test/controllers/bots/registrations_controller_test.rb
@@ -2,9 +2,8 @@ require "test_helper"
 
 class Bots::RegistrationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @join_code = account_join_codes(:signal)
+    @join_code = account_join_codes(:signal_bot)
     @account = accounts(:signal)
-    @account.update!(settings: { "allow_bot_self_registration" => "true" })
   end
 
   test "successful bot registration returns 201 with bot_key and rooms" do
@@ -37,16 +36,14 @@ class Bots::RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "returns 403 when bot self-registration is disabled" do
-    @account.update!(settings: { "allow_bot_self_registration" => "false" })
+  test "returns 404 for human join code" do
+    human_code = account_join_codes(:signal)
 
-    post join_bot_url(@join_code.code),
-      params: { name: "Blocked" },
+    post join_bot_url(human_code.code),
+      params: { name: "Sneaky" },
       as: :json
 
-    assert_response :forbidden
-    json = response.parsed_body
-    assert_equal "self_registration_disabled", json["code"]
+    assert_response :not_found
   end
 
   test "returns 404 for invalid join code" do
@@ -104,7 +101,8 @@ class Bots::RegistrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "HTML request falls through to UsersController" do
-    get join_url(@join_code.code)
+    human_code = account_join_codes(:signal)
+    get join_url(human_code.code)
     assert_response :success
     assert_includes response.body, "html"
   end
@@ -135,13 +133,6 @@ class Bots::RegistrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "all error responses include code field" do
-    @account.update!(settings: { "allow_bot_self_registration" => "false" })
-
-    post join_bot_url(@join_code.code), params: { name: "X" }, as: :json
-    assert response.parsed_body["code"].present?
-
-    @account.update!(settings: { "allow_bot_self_registration" => "true" })
-
     post join_bot_url("BAD-CODE"), params: { name: "X" }, as: :json
     assert response.parsed_body["code"].present?
   end

--- a/test/controllers/skills_controller_test.rb
+++ b/test/controllers/skills_controller_test.rb
@@ -12,7 +12,7 @@ class SkillsControllerTest < ActionDispatch::IntegrationTest
     get skill_url
 
     assert_includes response.body, "Bot API"
-    assert_includes response.body, "Self-Registration"
+    assert_includes response.body, "Registration via Invite URL"
     assert_includes response.body, "Authentication"
     assert_includes response.body, "Posting Messages"
     assert_includes response.body, "Creating Direct Messages"

--- a/test/fixtures/account/join_codes.yml
+++ b/test/fixtures/account/join_codes.yml
@@ -1,6 +1,7 @@
 signal:
   account_id: <%= ActiveRecord::FixtureSet.identify(:signal) %>
   code: CRMu-l8Ge-KB9B
+  kind: human
   usage_count: 0
   usage_limit:
   user_id:
@@ -23,6 +24,7 @@ signal_personal:
   account_id: <%= ActiveRecord::FixtureSet.identify(:signal) %>
   user_id: <%= ActiveRecord::FixtureSet.identify(:david) %>
   code: PERS-ONAL-CODE
+  kind: human
   usage_count: 0
   usage_limit:
   expires_at: <%= 7.days.from_now %>

--- a/test/fixtures/account/join_codes.yml
+++ b/test/fixtures/account/join_codes.yml
@@ -8,6 +8,17 @@ signal:
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
+signal_bot:
+  account_id: <%= ActiveRecord::FixtureSet.identify(:signal) %>
+  code: BOT1-INVT-CODE
+  kind: bot
+  usage_count: 0
+  usage_limit: 1
+  user_id:
+  expires_at:
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
 signal_personal:
   account_id: <%= ActiveRecord::FixtureSet.identify(:signal) %>
   user_id: <%= ActiveRecord::FixtureSet.identify(:david) %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -49,12 +49,14 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test "creating a bot does not post a welcome message" do
+  test "creating a bot posts a welcome message" do
     original_room = Room.original
 
-    assert_no_difference -> { Message.unscoped.where(room: original_room, welcome: true).count } do
+    assert_difference -> { Message.unscoped.where(room: original_room, welcome: true).count }, 1 do
       User.create!(name: "Test Bot", bot_token: User.generate_bot_token, role: :bot)
     end
+
+    assert_equal "has been added as a bot.", Message.unscoped.where(room: original_room, welcome: true).last.body.to_plain_text
   end
 
   test "deactivating a user deletes push subscriptions, searches, and deactivates all memberships including direct rooms" do


### PR DESCRIPTION
## Summary

- Replace the global `allow_bot_self_registration` toggle with per-bot single-use invite codes (`kind` enum on `Account::JoinCode`)
- Redesign bot admin UI: two clear registration paths (invite URL vs manual), credentials section with base URL and bot key, WebSocket-first copy throughout
- Webhook URL demoted to optional disclosure on bot form — WebSocket is now the default transport
- Bots now post a welcome message ("has been added as a bot.") in the default room on creation

## Test plan

- [ ] Generate a bot invite URL at `/account/bots`, copy it, verify it works with `POST /join/{code}` (JSON)
- [ ] Confirm the invite URL is single-use — second registration attempt returns 404
- [ ] Regenerate invite URL, confirm old one is expired
- [ ] Create a bot manually via the form, verify it appears in the list
- [ ] Verify human join codes still work for user signup and don't work for bot registration (404)
- [ ] Check bot show page displays base URL and bot key with copy buttons
- [ ] Verify webhook URL field is collapsed by default on new bot form, open on edit if set
- [ ] Confirm welcome message appears in default room when a bot is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)