### PR TITLE
Fix thread bot event delivery and cache staleness

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -30,7 +30,7 @@ class SearchesController < ApplicationController
     end
 
     def find_paged_messages
-      base = messages.with_creator.with_bookmark_status_for(Current.user)
+      base = messages.with_creator.with_thread_summary.with_bookmark_status_for(Current.user)
       case
       when params[:before].present?
         base.page_before(messages.find(params[:before]))

--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -25,7 +25,7 @@ class Users::MessagesController < ApplicationController
     end
 
     def find_paged_messages
-      base = messages.with_creator.with_bookmark_status_for(Current.user)
+      base = messages.with_creator.with_thread_summary.with_bookmark_status_for(Current.user)
       case
       when params[:before].present?
         base.page_before(messages.find(params[:before]))

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -134,7 +134,8 @@ module MessagesHelper
       is_unread,
       is_parent,
       show_room_name,
-      composer_id
+      composer_id,
+      message.thread_fingerprint
     ]
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -84,6 +84,11 @@ class Message < ApplicationRecord
     body.to_plain_text.presence || attachment&.filename&.to_s || ""
   end
 
+  def thread_fingerprint
+    threads.loaded? ? threads.map { |t| [ t.id, t.messages_count, t.active ] }
+                    : threads.pluck(:id, :messages_count, :active)
+  end
+
   def to_key
     [ client_message_id ]
   end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -269,7 +269,7 @@ class Room < ApplicationRecord
       .where(user_id: bot_ids)
       .includes(user: :webhook)
 
-    if direct?
+    if direct? || thread?
       eligible.to_a
     elsif item.is_a?(Message) && event == :created
       eligible.to_a.select { |m| item.mentionees.include?(m.user) || item.mentions_everyone? }

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -328,6 +328,19 @@ class MessageTest < ActiveSupport::TestCase
     assert_not room.memberships.exists?(user: jz), "Non-member should not be added to room via mention"
   end
 
+  test "thread_fingerprint rotates when a thread is created on the message" do
+    message = rooms(:watercooler).messages.create!(creator: users(:david), body: "Hello", client_message_id: "fp-1")
+
+    before = message.thread_fingerprint
+
+    Current.set(user: users(:david)) do
+      Rooms::Thread.find_or_create_for(message, users: rooms(:watercooler).users)
+        .messages.create!(body: "Reply", creator: users(:david), client_message_id: "fp-2")
+    end
+
+    assert_not_equal before, message.reload.thread_fingerprint
+  end
+
   private
     def create_new_message_in(room)
       room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "123")

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -352,4 +352,21 @@ class RoomTest < ActiveSupport::TestCase
     result = room.bot_memberships_for_events(message, :created)
     assert_includes result.map(&:user_id), bender.id
   end
+
+  test "bot_memberships_for_events notifies thread bot members without requiring a mention" do
+    parent_room = rooms(:watercooler)
+    bender = users(:bender)
+    parent_message = parent_room.messages.create!(body: "Starting a thread", creator: bender, client_message_id: "wh-thread-1")
+
+    thread = Current.set(user: bender) do
+      Rooms::Thread.find_or_create_for(parent_message, users: parent_room.users)
+    end
+    thread.involve_user(bender, unread: false)
+
+    message = thread.messages.create!(body: "Follow-up from user", creator: users(:david), client_message_id: "wh-thread-2")
+    message.stubs(:mentionees).returns(User.none)
+
+    result = thread.bot_memberships_for_events(message, :created)
+    assert_includes result.map(&:user_id), bender.id, "bot in a thread should receive message events even without a mention"
+  end
 end


### PR DESCRIPTION
## Summary
Two related bugs affecting bot integration in thread conversations:

- **`Room#bot_memberships_for_events`** — threads fell into the non-DM branch that required an `@mention` for `message_created` events, so a bot that started a thread never received follow-up replies. Threads are now treated like DMs: eligible bot members (`involvement: :mentions` or `:everything`) receive all thread events.
- **Message fragment cache** — `message_cache_key` depended only on `messages.updated_at`, which stays put when a child thread is created or a reply is added (counter-cache writes the thread row; `Room.belongs_to :parent_message` has no `touch: true` by design). The cached HTML kept an empty `threads` div; Turbo Streams patched the live DOM but refreshes read the stale fragment, so the thread link "disappeared." A `message_thread_fingerprint(message)` of `[id, messages_count, active]` per thread now rotates the key. Uses the preloaded `:threads` association when available, pluck fallback otherwise.

## Test plan
- [x] `bin/rails test test/models/room_test.rb` — new test asserts thread bot members receive events without a mention
- [x] `bin/rails test test/controllers/rooms/threads/by_bots_controller_test.rb`
- [x] Manual repro in `bin/rails runner` with caching on: before fix, parent message's cached HTML kept an empty `<div id="threads_message_…"></div>` after a bot reply; after fix, refresh renders the `thread__link` with reply count and last-reply timestamp.