### PR TITLE
Replace only the link, not the full row, on mention sidebar broadcasts

### DIFF
--- a/app/jobs/broadcast_mentionee_sidebar_updates_job.rb
+++ b/app/jobs/broadcast_mentionee_sidebar_updates_job.rb
@@ -16,8 +16,8 @@ class BroadcastMentioneeSidebarUpdatesJob < ApplicationJob
       list_name = membership.sidebar_list_name
       Turbo::StreamsChannel.broadcast_replace_to(
         membership.user, :rooms,
-        target: dom_id(membership.room, dom_prefix(list_name, :list_node)),
-        partial: "users/sidebars/rooms/shared",
+        target: dom_id(membership.room, dom_prefix(list_name, :list_node_link)),
+        partial: "users/sidebars/rooms/shared_link",
         locals: { list_name:, membership: }
       )
     end

--- a/app/views/users/sidebars/rooms/_shared.html.erb
+++ b/app/views/users/sidebars/rooms/_shared.html.erb
@@ -1,9 +1,5 @@
 <% room = local_assigns[:room] || local_assigns[:membership].room %>
 <% starred = local_assigns[:membership]&.starred? %>
-<% muted = local_assigns[:membership]&.involved_in_nothing? %>
-<% unread = local_assigns[:membership]&.unread? %>
-<% notifications_count = local_assigns[:membership]&.unread_notifications_count.to_i %>
-<% has_notifications = notifications_count > 0 %>
 
 <div id="<%= dom_id(room, dom_prefix(list_name, :list_node)) %>"
      data-sorted-list-target="item"
@@ -12,12 +8,7 @@
      data-updated-at="<%= room.last_active_at.iso8601 %>"
      data-type="list_node"
      class="room-row flex align-center gap-half">
-  <%= link_to_room room,
-        class: [ "room btn txt-nowrap flex-item-grow", "unread": unread, "badge": has_notifications ] do %>
-    <span class="overflow-ellipsis"><%= room_type_indicator(room) %> <%= room_display_name(room) %></span>
-    <% if notifications_count > 0 %><span class="notification-badge"><%= notifications_count %></span><% end %>
-    <% if muted %><span class="muted-indicator"><%= icon_tag "bell-off" %></span><% end %>
-  <% end %>
+  <%= render "users/sidebars/rooms/shared_link", list_name: list_name, membership: local_assigns[:membership] %>
 
   <% if local_assigns[:membership] %>
     <% if starred %>

--- a/app/views/users/sidebars/rooms/_shared_link.html.erb
+++ b/app/views/users/sidebars/rooms/_shared_link.html.erb
@@ -1,0 +1,10 @@
+<% room = membership.room %>
+<% notifications_count = membership.unread_notifications_count.to_i %>
+
+<%= link_to_room room,
+      id: dom_id(room, dom_prefix(list_name, :list_node_link)),
+      class: [ "room btn txt-nowrap flex-item-grow", "unread": membership.unread?, "badge": notifications_count > 0 ] do %>
+  <span class="overflow-ellipsis"><%= room_type_indicator(room) %> <%= room_display_name(room) %></span>
+  <% if notifications_count > 0 %><span class="notification-badge"><%= notifications_count %></span><% end %>
+  <% if membership.involved_in_nothing? %><span class="muted-indicator"><%= icon_tag "bell-off" %></span><% end %>
+<% end %>

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -68,6 +68,27 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "mentioning a user in a room they're not viewing refreshes their sidebar sort metadata" do
+    # Regression: BroadcastMentioneeSidebarUpdatesJob now replaces only the inner link partial,
+    # not the full row. The cross-room mention case (user disconnected from the mentioned room)
+    # must still receive roomSize/roomUpdatedAt via UserUnreadRoomsChannel through
+    # Room#broadcast_unread_to_disconnected_users, otherwise the sidebar sort goes stale.
+    jason_membership = @room.memberships.find_by(user: users(:jason))
+    jason_membership.update!(unread_at: nil, connected_at: nil)
+
+    stream_name = UserUnreadRoomsChannel.broadcasting_for(users(:jason))
+    payloads = capture_broadcasts(stream_name) do
+      post room_messages_url(@room, format: :turbo_stream),
+        params: { message: { body: "<div>Hey #{mention_attachment_for(:jason)}</div>", client_message_id: SecureRandom.uuid } }
+    end
+
+    sort_payload = payloads.find { |p| p["forceUnread"] == true }
+    assert sort_payload, "expected a UserUnreadRoomsChannel payload with forceUnread for the disconnected mentionee"
+    assert_equal @room.id, sort_payload["roomId"]
+    assert_equal @room.reload.messages_count, sort_payload["roomSize"]
+    assert_equal @room.last_active_at.iso8601, sort_payload["roomUpdatedAt"]
+  end
+
   test "creating a message never broadcasts to global unread_rooms channel" do
     # CRIT-3: Regression test to ensure thundering herd fix stays in place
     other_member = @room.memberships.visible.where.not(user: users(:david)).first


### PR DESCRIPTION
## Summary

`BroadcastMentioneeSidebarUpdatesJob` previously replaced the full sidebar row partial (`users/sidebars/rooms/_shared.html.erb`) per affected user on every @mention. That row contains a star button, sort `data-*` attrs, and the link — but only the link content changes for badge/count updates. Per-user full-row renders added up on mention-heavy rooms.

This PR extracts the inner link into its own partial and points the broadcast at it. Same Hotwire/Turbo path, same trigger sites, smaller render and smaller payload per recipient.

- Extracted `<a>` from `_shared.html.erb` into `_shared_link.html.erb` with its own `dom_id(room, dom_prefix(list_name, :list_node_link))`.
- Job replaces the link target/partial; outer row `<div>`, sort metadata, and star button stay put.
- No JS or channel changes; instant `.badge` toggle via `UnreadNotificationsChannel` is unchanged.

Live in dev: render time per recipient dropped to ~0.1ms; @everyone fanout to ~30 users completes in under 900ms.

### Residual scope decision

Users viewing the same room they're being @mentioned in won't get an immediate refresh of their own row's `data-updated-at` / `data-size`. Self-healing on next message activity, and sort position is invisible to them while inside the room. The "viewing another room" case is unaffected — those users are disconnected from the mention's room and still flow through `Room#broadcast_unread_to_disconnected_users`. A regression test covers this path.

## Test plan

- [x] `bin/rails test` — 1203 runs, 0 failures
- [x] `unset UNTENANTED_DATABASE_URL && SAAS=true bin/rails test saas/test/` — 266 runs, 0 failures
- [x] New regression test in `test/controllers/messages_controller_test.rb` asserting that mentioning a disconnected user broadcasts `UserUnreadRoomsChannel` with `roomId`/`roomSize`/`roomUpdatedAt`/`forceUnread` (cross-room sort metadata still refreshes)
- [x] Manual: two-browser sanity — @mention from window A appears as a badge on window B's sidebar without flashing the star button or the row container
- [x] Dev log inspection: every broadcast now targets `*_list_node_link` and renders `_shared_link.html.erb` in 0.1ms