### PR TITLE
Memoize Current.user in SaaS mode to kill per-row sidebar with_tenant churn

### DIFF
--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -24,6 +24,11 @@ class Current < ActiveSupport::CurrentAttributes
     end
   end
 
+  def workspace_membership=(value)
+    super
+    @user = nil
+  end
+
   # Delegate to global_identity from global_session (SaaS mode)
   def global_identity
     global_session&.global_identity
@@ -33,7 +38,7 @@ class Current < ActiveSupport::CurrentAttributes
   # In single-tenant mode, user is set directly from session
   def user
     if Sabha.saas? && workspace_membership.present?
-      workspace_membership.user
+      @user ||= workspace_membership.user
     else
       super
     end
@@ -66,5 +71,6 @@ class Current < ActiveSupport::CurrentAttributes
     super
     @workspace = nil
     @account = nil
+    @user = nil
   end
 end


### PR DESCRIPTION
## Summary

In SaaS mode `Current#user` was unmemoized — every call resolved through `WorkspaceMembership#user`, which opens a `with_tenant` block and does `User.find_by(id: user_id)`. The Rails query cache hides the SQL but not the `with_tenant` ceremony (connection-pool switch, context push/pop, query-log retag).

`room_display_name(room, for_user: Current.user)` is called once per sidebar room row, so a sidebar with ~20 rooms paid this cost 20 times per render. Logs showed `CACHE User Load ... ↳ workspace_membership.rb:61` repeating per row.

This PR adds `@user ||=` memoization on `Current#user` (matching the existing pattern for `Current#account`) and clears the cache in `reset` and on `workspace_membership=` reassignment.

## Measured impact (dev server, same workload)

`Users::SidebarsController#show`:

| metric                           | before              | after        |
|----------------------------------|---------------------|--------------|
| `workspace_membership.rb:61` hits per request | 20+ | 0–4 |
| total queries                    | 96–112 (58–66 cached) | 13–25 (1–8 cached) |
| layout render                    | 228–612ms           | 25–65ms      |

`RoomsController#show`:

| metric                           | before  | after |
|----------------------------------|---------|-------|
| `workspace_membership.rb:61` hits | high    | 2–3   |

The remaining 2–3 hits per request are direct `Current.workspace_membership.user` calls from `Authentication` (line 126), not the per-row loop.

## Safety

- `Current` is `ActiveSupport::CurrentAttributes` — per-request thread-local, reset between requests. The cached `@user` cannot leak across tenants (one request runs in one tenant context per the TenantSelector middleware).
- `workspace_membership=` setter clears `@user` so manual reassignment (e.g. `users_controller.rb:59` after workspace join) recomputes correctly.
- `reset` clears `@user` alongside `@workspace` and `@account`.

## Test plan

- [x] `bin/rails test` — 1203 runs, 0 failures
- [x] `unset UNTENANTED_DATABASE_URL && SAAS=true bin/rails test saas/test/` — 266 runs, 0 failures
- [x] Manual: sidebar reloads in dev show drastically reduced `workspace_membership.rb:61` hit counts (20+ → 0–4)