### PR TITLE
Kill activity-tab bookmark N+1 and cache Room.original

### DIFF
--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -88,8 +88,18 @@ class InboxesController < ApplicationController
 
     def find_notifications
       paginate(Inbox::ActivityQuery.new(Current.user).call).tap do |notifications|
-        Message.with_thread_participants(notifications.map(&:message))
+        messages = notifications.filter_map(&:message)
+        Message.with_thread_participants(messages)
+        preload_bookmark_status(messages)
       end
+    end
+
+    def preload_bookmark_status(messages)
+      return if messages.empty?
+
+      bookmarked_ids = Bookmark.where(user: Current.user, message_id: messages.map(&:id))
+                               .pluck(:message_id).to_set
+      messages.each { |m| m.bookmarked = bookmarked_ids.include?(m.id) }
     end
 
     def set_notification_pagination_anchors

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -72,7 +72,9 @@ class Room < ApplicationRecord
     end
 
     def original
-      unscoped.order(:created_at).first
+      Rails.cache.fetch([ "rooms", "original", ApplicationRecord.try(:current_tenant) ], skip_nil: true) do
+        unscoped.order(:created_at).first
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Two small perf fixes from the recent log audit. Both are local changes, no architectural shifts.

### Activity tab bookmark N+1 — `InboxesController#find_notifications`

`find_notifications` loaded `notifications.map(&:message)` without routing those messages through the `with_bookmark_status_for(Current.user)` scope. So `Message#bookmarked_by_current_user?` (`message.rb:87`) fell through to `bookmarks.exists?(user_id: …)` once per message — 25 fresh \`Bookmark Exists?\` queries per activity render, plus 2 cached calls per message from `_bookmark_indicator`/`_bookmark`/`_actions` (each path independently checks).

Fix: one batched `Bookmark.where(user: Current.user, message_id: ids).pluck(:message_id).to_set`, then `m.bookmarked = …` per message. Uses the existing `attr_writer :bookmarked` on Message (line 62) and the `@bookmarked` instance-var fast path in `bookmarked_by_current_user?` (line 92). Same idiom as `find_bookmarked_messages` already uses for the bookmarks tab.

### `Room.original` cache

`Room.original` (`unscoped.order(:created_at).first`) ran on every chat page from `_welcome.html.erb`. The original room never changes after creation (`Room#deactivate` raises `CannotDeleteOriginalError` for the original).

Fix: wrap in `Rails.cache.fetch([..., current_tenant], skip_nil: true)`. `skip_nil` matters: `db/seeds/self_hosted.rb` creates verified users (which trigger `User#post_welcome_message` → `Room.original`) before the General room is created. Without `skip_nil`, the empty result would be cached and break `Room#original?` and `CannotDeleteOriginalError` for the lifetime of the cache.

## Test plan

- [x] `bin/rails test` — 1204 runs, 0 failures
- [x] `unset UNTENANTED_DATABASE_URL && SAAS=true bin/rails test saas/test/` — 266 runs, 0 failures