### PR TITLE
Move Current.user resolution into setter cascade

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -120,13 +120,15 @@ module Authentication
       end
     end
 
-    # In SaaS mode, create the workspace User if it doesn't exist yet
+    # In SaaS mode, create the workspace User if it doesn't exist yet.
+    # Current.workspace_membership= eagerly assigns Current.user; if that
+    # was nil we create the user now and re-assign so the request sees it.
     def ensure_workspace_user_exists
       return unless Current.workspace_membership.present?
-      return if Current.workspace_membership.user_id.present? && Current.workspace_membership.user.present?
+      return if Current.user.present?
 
-      # Create User in this workspace from GlobalIdentity
       Current.workspace_membership.create_user!
+      Current.user = Current.workspace_membership.user
     end
 
     def terminate_current_session

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -120,15 +120,14 @@ module Authentication
       end
     end
 
-    # In SaaS mode, create the workspace User if it doesn't exist yet.
-    # Current.workspace_membership= eagerly assigns Current.user; if that
-    # was nil we create the user now and re-assign so the request sees it.
+    # In SaaS mode, create the workspace User on first visit.
+    # WorkspaceMembership#create_user! updates Current.user when the membership
+    # is the active one, so the request sees the freshly-created user.
     def ensure_workspace_user_exists
       return unless Current.workspace_membership.present?
       return if Current.user.present?
 
       Current.workspace_membership.create_user!
-      Current.user = Current.workspace_membership.user
     end
 
     def terminate_current_session

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,10 +6,9 @@ class Current < ActiveSupport::CurrentAttributes
 
   delegate :host, :protocol, to: :request, prefix: true, allow_nil: true
 
-  # Single-tenant mode: session sets user directly
   def session=(value)
     super
-    self.user = value&.user unless Sabha.saas?
+    self.user = value&.user
   end
 
   # SaaS mode: global_session sets workspace_membership

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -24,9 +24,13 @@ class Current < ActiveSupport::CurrentAttributes
     end
   end
 
+  # Mirror session=: derive Current.user from the canonical input.
+  # Caller must ensure ApplicationRecord.current_tenant is set first —
+  # WorkspaceMembership#user wraps its own with_tenant block, but value
+  # must be the membership for the active tenant.
   def workspace_membership=(value)
     super
-    @user = nil
+    self.user = value&.user
   end
 
   # Delegate to global_identity from global_session (SaaS mode)
@@ -34,29 +38,16 @@ class Current < ActiveSupport::CurrentAttributes
     global_session&.global_identity
   end
 
-  # In SaaS mode, user can be derived from workspace_membership
-  # In single-tenant mode, user is set directly from session
-  def user
-    if Sabha.saas? && workspace_membership.present?
-      @user ||= workspace_membership.user
-    else
-      super
-    end
-  end
-
-  # Current workspace (SaaS mode only)
-  # Returns the Workspace record for the current tenant
-  # Logs a warning if tenant is set but workspace record doesn't exist (data inconsistency)
+  # workspace and account are 1:1 derivations of ApplicationRecord.current_tenant,
+  # not independent inputs — see docs/multi-tenant/activerecord-tenanted-guide.md.
+  # The gem guarantees current_tenant is set in every tenant-aware context (HTTP,
+  # ActiveJob#perform_now, ActionCable around_command, with_tenant blocks), so
+  # lazy resolution from current_tenant is always correct. Modeling them as
+  # `attribute :…` would force assignment plumbing at every entrypoint with no
+  # added correctness — the gem already centralizes that.
   def workspace
     return nil unless Sabha.saas? && ApplicationRecord.current_tenant.present?
-
-    @workspace ||= begin
-      ws = Workspace.find_by(external_id: ApplicationRecord.current_tenant)
-      if ws.nil?
-        Rails.logger.warn "[Current.workspace] Tenant #{ApplicationRecord.current_tenant} has no Workspace record"
-      end
-      ws
-    end
+    @workspace ||= Workspace.find_by(external_id: ApplicationRecord.current_tenant)
   end
 
   def account
@@ -66,11 +57,9 @@ class Current < ActiveSupport::CurrentAttributes
     nil
   end
 
-  # Reset cached values when attributes change
   def reset
     super
     @workspace = nil
     @account = nil
-    @user = nil
   end
 end

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -105,6 +105,7 @@ class WorkspaceMembership < UntenantedRecord
       end
 
       cache_user_id!(user.id) unless user_id == user.id
+      Current.user = user if Current.workspace_membership == self
       user
     end
   end

--- a/saas/test/controllers/saas/authentication_test.rb
+++ b/saas/test/controllers/saas/authentication_test.rb
@@ -93,6 +93,32 @@ module Saas
       assert_equal "/workspaces", session[:return_to_after_authenticating]
     end
 
+    test "first-time visitor with blank membership user_id has User created and Current.user set" do
+      workspace = Workspace.create_with_database!(name: "First Visit Test", creator: global_identities(:alice))
+
+      # Bob is a member but has never visited — workspace_membership.user_id is blank
+      bob_membership = WorkspaceMembership.create!(
+        global_identity: global_identities(:bob),
+        tenant: workspace.external_id.to_s
+      )
+      assert_nil bob_membership.user_id
+
+      sign_in_global_identity(global_identities(:bob))
+      workspace_get "/", workspace: workspace
+
+      # Auth flow must populate Current.user after create_user!, otherwise
+      # require_workspace_membership bounces to /workspaces.
+      assert_not_equal "/workspaces", URI(response.location || "").path
+
+      bob_membership.reload
+      assert_not_nil bob_membership.user_id
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        assert User.exists?(id: bob_membership.user_id)
+      end
+    ensure
+      workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
+    end
+
     test "user whose tenant User was deleted gets it recreated on next visit" do
       workspace = Workspace.create_with_database!(name: "Orphan Test", creator: global_identities(:alice))
       sign_in_global_identity(global_identities(:alice))

--- a/saas/test/models/current_test.rb
+++ b/saas/test/models/current_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class SaasCurrentTest < ActiveSupport::TestCase
+  setup do
+    @workspace_a = workspaces(:acme)
+    @workspace_b = workspaces(:widgets)
+    @tenant_a = @workspace_a.external_id.to_s
+    @tenant_b = @workspace_b.external_id.to_s
+
+    [ @tenant_a, @tenant_b ].each do |tenant|
+      ApplicationRecord.create_tenant(tenant) unless ApplicationRecord.tenant_exist?(tenant)
+      ApplicationRecord.with_tenant(tenant) do
+        Account.find_or_create_by!(singleton_guard: 0) { |a| a.name = "Account-#{tenant}" }
+      end
+    end
+
+    Current.reset
+  end
+
+  test "workspace_membership= cascades into Current.user" do
+    membership = workspace_memberships(:alice_acme)
+    membership.create_user!
+
+    Current.workspace_membership = membership
+
+    assert_equal membership.user, Current.user
+  end
+
+  test "workspace_membership= nil clears Current.user" do
+    membership = workspace_memberships(:alice_acme)
+    membership.create_user!
+    Current.workspace_membership = membership
+    Current.workspace_membership = nil
+
+    assert_nil Current.user
+  end
+
+  test "Current.workspace recomputes after reset when tenant changes" do
+    workspace_a = ApplicationRecord.with_tenant(@tenant_a) { Current.workspace }
+    assert_equal @workspace_a, workspace_a
+
+    # Without reset, the memoized value would persist across tenants
+    leaked = ApplicationRecord.with_tenant(@tenant_b) { Current.workspace }
+    assert_equal @workspace_a, leaked, "guard: memoization should leak without reset"
+
+    Current.reset
+
+    fresh = ApplicationRecord.with_tenant(@tenant_b) { Current.workspace }
+    assert_equal @workspace_b, fresh
+  end
+
+  test "Current.account recomputes after reset when tenant changes" do
+    account_a = ApplicationRecord.with_tenant(@tenant_a) { Current.account }
+    assert_equal @tenant_a, account_a.tenant
+
+    # Without reset, the memoized account from tenant A leaks across tenant boundaries
+    leaked = ApplicationRecord.with_tenant(@tenant_b) { Current.account }
+    assert_equal @tenant_a, leaked.tenant, "guard: memoization should leak without reset"
+
+    Current.reset
+
+    fresh = ApplicationRecord.with_tenant(@tenant_b) { Current.account }
+    assert_equal @tenant_b, fresh.tenant
+  end
+end

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class CurrentTest < ActiveSupport::TestCase
+  setup { Current.reset }
+
+  test "session= cascades into Current.user" do
+    session = sessions(:david_safari)
+
+    Current.session = session
+
+    assert_equal session.user, Current.user
+  end
+
+  test "session= nil clears Current.user" do
+    Current.session = sessions(:david_safari)
+    Current.session = nil
+
+    assert_nil Current.user
+  end
+end


### PR DESCRIPTION
## Summary

Cleans up `Current` to follow the standard `CurrentAttributes` shape used in `once-campfire` and `fizzy`. The user resolution cascade now lives where Rails expects it — in setters, with framework-managed attribute storage — instead of in an overridden getter with hand-rolled memoization.

### Code changes

- **`Current#workspace_membership=` cascades into `self.user = value&.user`**, mirroring `session=`. Removes the `#user` override and its `if Sabha.saas?` mode branch — both modes now read from one `attribute :user` slot.
- **`WorkspaceMembership#create_user!` updates `Current.user` when this membership is the active one** (`if Current.workspace_membership == self`). Model owns the cascade end-to-end; the auth concern doesn't reach back into `Current` to re-derive a value the model just produced. The conditional is the scalpel — it no-ops in non-request callers (cable connect, join flow before assignment) and only fires for the active request membership.
- **`Current#session=` drops `unless Sabha.saas?`.** All callers of `start_new_session_for` are gated either explicitly (`SessionsController`, `auth_tokens/validations_controller` redirect to SaaS login; `UsersController` branches on `saas_authenticated?`) or by domain logic (`FirstRunsController` only fires when `Account` is empty). The guard defended against an unreachable code path.
- **`Current#workspace` drops the `Rails.logger.warn`** that fired when a tenant had no `Workspace` row. The getter is a pure projection of `current_tenant`; data-integrity policy belongs upstream.
- **Doc comment on `#workspace`/`#account`** explains why they stay lazy derivations rather than `attribute :…`: the activerecord-tenanted gem establishes `current_tenant` in tenant-aware contexts (HTTP, `ActiveJob#perform_now`, ActionCable `around_command`, `with_tenant` blocks), so they're projections of an already-established context, not independent inputs. Promoting them would duplicate plumbing the gem centralizes — and break the load-bearing pattern at `docs/multi-tenant/activerecord-tenanted-guide.md:664` where `Current.account` carries GlobalID into broadcast stream names.

### Test additions

- **Integration test for first-visit user creation** (`saas/test/controllers/saas/authentication_test.rb`). Pins the auth flow that motivated the cascade design: a `WorkspaceMembership` with blank `user_id` must produce a populated `Current.user` after `create_user!` so `require_workspace_membership` doesn't bounce the just-signed-in user to `/workspaces`. Verified to fail when the model's `Current.user = …` line is removed.
- **Unit tests for `Current` setter cascade and reset hygiene** (`test/models/current_test.rb`, `saas/test/models/current_test.rb`). Pin (a) `session=` and `workspace_membership=` immediately update `Current.user`, and (b) `Current.workspace`/`Current.account` recompute after `reset` rather than leaking memoized values across tenants. Reset-hygiene tests include a "guard" assertion demonstrating that without `reset`, the memoized value would leak — making the failure mode visible in the test.

## Test plan

- [x] `bin/rails test` — 1206 runs / 4183 assertions / 0 failures
- [x] `SAAS=true bin/rails test saas/test/` — 271 runs / 693 assertions / 0 failures
- [x] First-visit user creation pinned by integration test (no manual smoke needed)

## Reviewer follow-ups

- Doc comment on `#workspace`/`#account` could be trimmed further — currently 7 lines explaining why we *didn't* refactor. Shorter version: `# Lazy projections of ApplicationRecord.current_tenant; the tenanted gem owns assignment.` Left long for now since the rationale was contested in review.