### PR TITLE
Drop dead @shared_memberships assignment in DM inbox flow

### DIFF
--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -144,8 +144,5 @@ class InboxesController < ApplicationController
       # Load members for both inbox and sidebar lists
       room_ids = (@memberships.map(&:room_id) + @direct_memberships.map(&:room_id)).uniq
       @direct_room_members = Rooms::Direct.members_for_display_by_room(room_ids, excluding: Current.user)
-
-      # Shared rooms still loaded normally
-      @shared_memberships = sidebar.shared
     end
 end


### PR DESCRIPTION
## Summary

\`InboxesController#set_sidebar_memberships_for_dms\` was assigning \`@shared_memberships = sidebar.shared\` on every \`/inboxes/direct_messages\` page load, but no view in the DM flow reads it.

\`@shared_memberships\` is consumed in two places:
- \`app/views/users/sidebars/show.html.erb\` — rendered by \`Users::SidebarsController#show\`, which sets its own ivar via \`Sidebar#set_sidebar_memberships\` (a separate Turbo Frame)
- \`app/views/users/profiles/show.html.erb\` — fed by \`Users::ProfilesController\`, an unrelated source

Neither is in the DM inbox render path. The line and its \"# Shared rooms still loaded normally\" comment were vestiges of an earlier draft of the DM/Activity split (#62) that rendered the sidebar inline; got orphaned when the sidebar was extracted into its own Turbo Frame and never cleaned up.

## Impact

- One fewer \`Membership Eager Load\` query (~0.8ms) on every DM inbox page load
- More importantly: removes a misleading assignment that implied a contract the view layer doesn't honor

## Test plan

- [x] \`bin/rails test\` — 1184 runs / 4129 assertions / 0 failures
- [x] \`SAAS=true bin/rails test saas/test/\` — 271 runs / 693 assertions / 0 failures
- [x] Verified via grep that \`@shared_memberships\` is only read by \`users/sidebars/show.html.erb\` (different controller) and \`users/profiles/show.html.erb\` (different source)