### PR TITLE
Reshape /api/bots read surface for scale

### DIFF
--- a/app/controllers/api/bots/rooms_controller.rb
+++ b/app/controllers/api/bots/rooms_controller.rb
@@ -3,11 +3,10 @@ class API::Bots::RoomsController < API::Bots::BaseController
   before_action :require_creator, only: %i[update destroy]
 
   def index
-    @rooms = if params[:joinable].present?
-      Rooms::Open.browsable_by(Current.user)
-    else
-      Current.user.rooms.without_threads
-    end
+    per_page = (params[:per_page].presence || 50).to_i.clamp(1, 100)
+    page = [ (params[:page].presence || 1).to_i, 1 ].max
+
+    @rooms = base_rooms.matching(params[:query]).ordered.offset((page - 1) * per_page).limit(per_page)
   end
 
   def create
@@ -50,6 +49,10 @@ class API::Bots::RoomsController < API::Bots::BaseController
   end
 
   private
+    def base_rooms
+      params[:joinable].present? ? Rooms::Open.browsable_by(Current.user) : Current.user.rooms.without_threads
+    end
+
     def set_room
       @room = Current.user.rooms.find(params[:id])
     end

--- a/app/controllers/api/bots/searches_controller.rb
+++ b/app/controllers/api/bots/searches_controller.rb
@@ -1,25 +1,53 @@
 class API::Bots::SearchesController < API::Bots::BaseController
   include ActiveStorage::SetCurrent
 
+  MAX_LIMIT = 200
+  DEFAULT_LIMIT = 50
+  MAX_PAGE = 50
+
   def show
-    query = params[:q].to_s.gsub(/[^[:word:]]/, " ").strip
-    return render(json: { error: "Query parameter 'q' is required", code: "validation_failed" }, status: :unprocessable_entity) if query.blank?
+    query = sanitize_query(params[:q])
+    return render_validation_error("Query parameter 'q' is required") if query.blank?
 
-    messages = Current.user.reachable_messages
-                           .active
-                           .search(query)
-                           .with_creator
-                           .includes(:room)
-                           .limit(50)
+    before_time = parse_time!(params[:before])
+    return render_validation_error("'before' must be an ISO8601 timestamp") if params[:before].present? && before_time.nil?
 
-    render json: messages.map { |msg|
-      {
-        id: msg.id,
-        creator: { id: msg.creator.id, name: msg.creator.name },
-        body: { html: msg.body.body.to_s, plain: msg.plain_text_body },
-        room: { id: msg.room.id, name: msg.room.name },
-        created_at: msg.created_at.iso8601
-      }
-    }
+    after_time = parse_time!(params[:after])
+    return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && after_time.nil?
+
+    @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+    page = (params[:page].presence || 1).to_i.clamp(1, MAX_PAGE)
+
+    room_ids = Array(params[:room_ids])
+    author_ids = Array(params[:author_ids])
+
+    scope = Current.user.reachable_messages.active.search(query)
+    scope = scope.in_rooms(room_ids) if room_ids.any?
+    scope = scope.created_by(author_ids) if author_ids.any?
+    scope = scope.since(after_time) if after_time
+    scope = scope.created_before(before_time) if before_time
+    scope = scope.with_rich_text_body_and_embeds.with_creator.includes(:room)
+                 .offset((page - 1) * @limit)
+                 .limit(@limit + 1)
+
+    messages = scope.to_a
+    @has_more = messages.size > @limit
+    @messages = messages.first(@limit)
   end
+
+  private
+    def sanitize_query(value)
+      value.to_s.gsub(/[^[:word:]]/, " ").strip
+    end
+
+    def parse_time!(value)
+      return nil if value.blank?
+      Time.zone.iso8601(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
+    def render_validation_error(message)
+      render json: { error: message, code: "validation_failed" }, status: :unprocessable_entity
+    end
 end

--- a/app/controllers/api/bots/searches_controller.rb
+++ b/app/controllers/api/bots/searches_controller.rb
@@ -8,10 +8,10 @@ class API::Bots::SearchesController < API::Bots::BaseController
     query = sanitize_query(params[:q])
     return render_validation_error("Query parameter 'q' is required") if query.blank?
 
-    before_time = parse_time!(params[:before])
-    return render_validation_error("'before' must be an ISO8601 timestamp") if params[:before].present? && before_time.nil?
+    before_time, before_id = parse_before(params[:before])
+    return render_validation_error("'before' must be ISO8601 timestamp or composite cursor") if params[:before].present? && before_time.nil?
 
-    after_time = parse_time!(params[:after])
+    after_time = parse_time(params[:after])
     return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && after_time.nil?
 
     @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
@@ -24,13 +24,19 @@ class API::Bots::SearchesController < API::Bots::BaseController
     scope = scope.in_rooms(room_ids) if room_ids.any?
     scope = scope.created_by(author_ids) if author_ids.any?
     scope = scope.since(after_time) if after_time
-    scope = scope.created_before(before_time) if before_time
+    scope = if before_id
+      scope.before_cursor(before_time, before_id)
+    elsif before_time
+      scope.created_before(before_time)
+    else
+      scope
+    end
     scope = scope.with_rich_text_body_and_embeds.with_creator.includes(:room).limit(@limit + 1)
 
     messages = scope.to_a
     @has_more = messages.size > @limit
     @messages = messages.first(@limit)
-    @next_cursor = @has_more ? @messages.last.created_at.iso8601 : nil
+    @next_cursor = build_cursor(@messages.last) if @has_more
   end
 
   private
@@ -38,11 +44,27 @@ class API::Bots::SearchesController < API::Bots::BaseController
       value.to_s.gsub(/[^[:word:]]/, " ").strip
     end
 
-    def parse_time!(value)
+    # Accepts either a plain ISO8601 timestamp (filter intent) or
+    # a composite "<iso>|<id>" cursor (pagination intent).
+    def parse_before(value)
+      return [ nil, nil ] if value.blank?
+      time_str, id_str = value.to_s.split("|", 2)
+      time = Time.zone.iso8601(time_str)
+      id = id_str.present? ? Integer(id_str) : nil
+      [ time, id ]
+    rescue ArgumentError, TypeError
+      [ nil, nil ]
+    end
+
+    def parse_time(value)
       return nil if value.blank?
       Time.zone.iso8601(value.to_s)
     rescue ArgumentError
       nil
+    end
+
+    def build_cursor(message)
+      "#{message.created_at.iso8601}|#{message.id}"
     end
 
     def render_validation_error(message)

--- a/app/controllers/api/bots/searches_controller.rb
+++ b/app/controllers/api/bots/searches_controller.rb
@@ -3,7 +3,6 @@ class API::Bots::SearchesController < API::Bots::BaseController
 
   MAX_LIMIT = 200
   DEFAULT_LIMIT = 50
-  MAX_PAGE = 50
 
   def show
     query = sanitize_query(params[:q])
@@ -16,23 +15,22 @@ class API::Bots::SearchesController < API::Bots::BaseController
     return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && after_time.nil?
 
     @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
-    page = (params[:page].presence || 1).to_i.clamp(1, MAX_PAGE)
 
     room_ids = Array(params[:room_ids])
     author_ids = Array(params[:author_ids])
 
     scope = Current.user.reachable_messages.active.search(query)
+              .reorder(created_at: :desc, id: :desc)
     scope = scope.in_rooms(room_ids) if room_ids.any?
     scope = scope.created_by(author_ids) if author_ids.any?
     scope = scope.since(after_time) if after_time
     scope = scope.created_before(before_time) if before_time
-    scope = scope.with_rich_text_body_and_embeds.with_creator.includes(:room)
-                 .offset((page - 1) * @limit)
-                 .limit(@limit + 1)
+    scope = scope.with_rich_text_body_and_embeds.with_creator.includes(:room).limit(@limit + 1)
 
     messages = scope.to_a
     @has_more = messages.size > @limit
     @messages = messages.first(@limit)
+    @next_cursor = @has_more ? @messages.last.created_at.iso8601 : nil
   end
 
   private

--- a/app/controllers/rooms/browse_controller.rb
+++ b/app/controllers/rooms/browse_controller.rb
@@ -1,6 +1,6 @@
 class Rooms::BrowseController < ApplicationController
   def index
-    rooms = Rooms::Open.browsable_by(Current.user)
+    rooms = Rooms::Open.browsable_by(Current.user).ordered
     set_page_and_extract_portion_from rooms, per_page: 20
     @rooms = @page.records
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -46,10 +46,12 @@ class Message < ApplicationRecord
       .includes(boosts: { booster: { avatar_attachment: { blob: :variant_records } } })
       .with_thread_summary
   }
-  scope :created_by, ->(user) { where(creator_id: user.id) }
+  scope :created_by, ->(users) { where(creator_id: Array.wrap(users).map { |u| u.is_a?(User) ? u.id : u }) }
   scope :without_created_by, ->(user) { where.not(creator_id: user.id) }
   scope :between, ->(from, to) { where(created_at: from..to) }
   scope :since, ->(time) { where(created_at: time..) }
+  scope :created_before, ->(time) { where(created_at: ..time) }
+  scope :in_rooms, ->(ids) { where(room_id: ids) }
   scope :with_bookmark_status_for, ->(user) {
     joins(sanitize_sql_array([ <<~SQL.squish, user.id ])).select("messages.*, (bookmarks.id IS NOT NULL) AS is_bookmarked")
       LEFT JOIN bookmarks

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -52,6 +52,15 @@ class Message < ApplicationRecord
   scope :since, ->(time) { where(created_at: time..) }
   scope :created_before, ->(time) { where(created_at: ..time) }
   scope :in_rooms, ->(ids) { where(room_id: ids) }
+
+  # Composite cursor for stable pagination across timestamp ties.
+  # Pairs with an ORDER BY (created_at DESC, id DESC) — emit cursor from the
+  # last row of a page, pass it back to skip past that exact (time, id) point.
+  scope :before_cursor, ->(time, id) {
+    table = arel_table
+    where(table[:created_at].lt(time))
+      .or(where(table[:created_at].eq(time)).where(table[:id].lt(id)))
+  }
   scope :with_bookmark_status_for, ->(user) {
     joins(sanitize_sql_array([ <<~SQL.squish, user.id ])).select("messages.*, (bookmarks.id IS NOT NULL) AS is_bookmarked")
       LEFT JOIN bookmarks

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -58,6 +58,9 @@ class Room < ApplicationRecord
   scope :without_threads, -> { where.not(type: "Rooms::Thread") }
 
   scope :ordered, -> { order(:sortable_name) }
+  scope :matching, ->(query) {
+    query.present? ? where("name LIKE ?", "%#{sanitize_sql_like(query)}%") : all
+  }
 
   after_update_commit :broadcast_reactivation_if_restored
   after_create_commit :announce_creation

--- a/app/models/rooms/open.rb
+++ b/app/models/rooms/open.rb
@@ -3,7 +3,6 @@
 class Rooms::Open < Room
   scope :browsable_by, ->(user) {
     active.where.not(id: user.memberships.visible.select(:room_id))
-          .order(:sortable_name)
   }
 
   after_save_commit :grant_access_to_all_users, if: :auto_join?

--- a/app/views/api/bots/searches/show.json.jbuilder
+++ b/app/views/api/bots/searches/show.json.jbuilder
@@ -15,3 +15,4 @@ json.results @messages do |message|
   json.created_at message.created_at.iso8601
 end
 json.has_more @has_more
+json.next_cursor @next_cursor

--- a/app/views/api/bots/searches/show.json.jbuilder
+++ b/app/views/api/bots/searches/show.json.jbuilder
@@ -1,0 +1,17 @@
+json.results @messages do |message|
+  json.id message.id
+  json.creator do
+    json.id message.creator.id
+    json.name message.creator.name
+  end
+  json.body do
+    json.html message.body.body.to_s
+    json.plain message.plain_text_body
+  end
+  json.room do
+    json.id message.room.id
+    json.name message.room.name
+  end
+  json.created_at message.created_at.iso8601
+end
+json.has_more @has_more

--- a/test/controllers/api/bots/rooms_controller_test.rb
+++ b/test/controllers/api/bots/rooms_controller_test.rb
@@ -68,6 +68,97 @@ class API::Bots::RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes room_ids, rooms(:hq).id
   end
 
+  test "joinable filter only returns open rooms the bot has not joined" do
+    rooms(:hq).accept_join!(@bot)
+
+    get api_bots_rooms_url, params: { joinable: true }, headers: bot_headers(@bot.bot_key)
+
+    room_ids = response.parsed_body.map { |r| r["id"] }
+    joined_room_ids = @bot.memberships.visible.pluck(:room_id)
+    assert_empty (room_ids & joined_room_ids), "joinable list must not contain rooms the bot is in"
+  end
+
+  # Query and pagination
+
+  test "index filters by query against room name" do
+    get api_bots_rooms_url, params: { query: "Talk" }, headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    names = response.parsed_body.map { |r| r["name"] }
+    assert_includes names, rooms(:watercooler).name # "All Talk"
+    assert names.all? { |n| n.downcase.include?("talk") }, "expected only Talk-matching rooms, got #{names.inspect}"
+  end
+
+  test "index returns no rooms for non-matching query" do
+    get api_bots_rooms_url, params: { query: "ZzzNoSuchRoom" }, headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    assert_empty response.parsed_body
+  end
+
+  test "blank query returns the full set" do
+    get api_bots_rooms_url, headers: bot_headers(@bot.bot_key)
+    unfiltered = response.parsed_body.map { |r| r["id"] }
+
+    get api_bots_rooms_url, params: { query: "" }, headers: bot_headers(@bot.bot_key)
+    assert_equal unfiltered, response.parsed_body.map { |r| r["id"] }
+  end
+
+  test "non-positive page values clamp to first page" do
+    get api_bots_rooms_url, params: { per_page: 1, page: 1 }, headers: bot_headers(@bot.bot_key)
+    first_page = response.parsed_body
+
+    get api_bots_rooms_url, params: { per_page: 1, page: 0 }, headers: bot_headers(@bot.bot_key)
+    assert_equal first_page, response.parsed_body
+
+    get api_bots_rooms_url, params: { per_page: 1, page: -5 }, headers: bot_headers(@bot.bot_key)
+    assert_equal first_page, response.parsed_body
+  end
+
+  test "joinable filter combines with query" do
+    get api_bots_rooms_url, params: { joinable: true, query: "HQ" }, headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    room_ids = response.parsed_body.map { |r| r["id"] }
+    assert_includes room_ids, rooms(:hq).id
+    assert_not_includes room_ids, rooms(:pets).id
+  end
+
+  test "index paginates and caps per_page" do
+    Current.user = @bot
+    5.times { |i| Rooms::Open.create_for({ name: "Page Room #{i}" }, users: @bot) }
+    Current.reset
+
+    get api_bots_rooms_url, params: { query: "Page Room", per_page: 2, page: 1 }, headers: bot_headers(@bot.bot_key)
+    assert_response :success
+    first_page = response.parsed_body
+    assert_equal 2, first_page.size
+
+    get api_bots_rooms_url, params: { query: "Page Room", per_page: 2, page: 2 }, headers: bot_headers(@bot.bot_key)
+    assert_response :success
+    second_page = response.parsed_body
+    assert_equal 2, second_page.size
+
+    assert_empty (first_page.map { |r| r["id"] } & second_page.map { |r| r["id"] })
+
+    get api_bots_rooms_url, params: { per_page: 500 }, headers: bot_headers(@bot.bot_key)
+    assert_operator response.parsed_body.size, :<=, 100
+  end
+
+  test "query is sanitized against LIKE wildcards" do
+    Current.user = @bot
+    Rooms::Open.create_for({ name: "Project Alpha" }, users: @bot)
+    Rooms::Open.create_for({ name: "Project Beta" }, users: @bot)
+    Current.reset
+
+    # A bare % would otherwise match everything; sanitize_sql_like escapes it
+    get api_bots_rooms_url, params: { query: "%Alpha" }, headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    names = response.parsed_body.map { |r| r["name"] }
+    assert_empty names, "literal % should not act as a wildcard, got #{names.inspect}"
+  end
+
   # Room creation
 
   test "create an open room" do

--- a/test/controllers/api/bots/searches_controller_test.rb
+++ b/test/controllers/api/bots/searches_controller_test.rb
@@ -9,15 +9,16 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
 
   # Envelope shape
 
-  test "search returns results array and has_more flag" do
+  test "search returns results, has_more, and next_cursor envelope keys" do
     create_searchable_messages(@room, count: 1)
 
     get api_bots_search_url(q: "findme"), headers: bot_headers(@bot.bot_key)
 
     assert_response :success
     json = response.parsed_body
-    assert json.key?("results"), "expected envelope with 'results' key, got #{json.inspect}"
-    assert json.key?("has_more"), "expected envelope with 'has_more' key, got #{json.inspect}"
+    assert json.key?("results"), "expected 'results' key, got #{json.inspect}"
+    assert json.key?("has_more"), "expected 'has_more' key, got #{json.inspect}"
+    assert json.key?("next_cursor"), "expected 'next_cursor' key, got #{json.inspect}"
     assert json["results"].is_a?(Array)
     assert_includes [ true, false ], json["has_more"]
   end
@@ -57,7 +58,7 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
 
   # has_more truncation signal
 
-  test "has_more is false when results fit within limit" do
+  test "has_more is false and next_cursor is nil when results fit within limit" do
     create_searchable_messages(@room, count: 2)
 
     get api_bots_search_url(q: "findme", limit: 10), headers: bot_headers(@bot.bot_key)
@@ -65,10 +66,11 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = response.parsed_body
     assert_equal false, json["has_more"]
+    assert_nil json["next_cursor"]
     assert_equal 2, json["results"].size
   end
 
-  test "has_more is true and exactly limit results returned when more exist" do
+  test "has_more is true and next_cursor is set when more results exist" do
     create_searchable_messages(@room, count: 5)
 
     get api_bots_search_url(q: "findme", limit: 2), headers: bot_headers(@bot.bot_key)
@@ -77,6 +79,10 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
     json = response.parsed_body
     assert_equal true, json["has_more"]
     assert_equal 2, json["results"].size
+
+    # next_cursor is the created_at of the oldest (last) result in newest-first ordering
+    expected_cursor = Time.iso8601(json["results"].last["created_at"]).iso8601
+    assert_equal expected_cursor, json["next_cursor"]
   end
 
   # Limit cap
@@ -198,47 +204,46 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_match(/after/i, response.parsed_body["error"])
   end
 
-  # Pagination
+  # Ordering and cursor pagination
 
-  test "page advances past previously seen results" do
-    create_searchable_messages(@room, count: 4)
+  test "results come back newest-first" do
+    older = create_searchable_messages(@room, count: 1).first
+    older.update_columns(created_at: 2.hours.ago)
+    middle = create_searchable_messages(@room, count: 1).first
+    middle.update_columns(created_at: 1.hour.ago)
+    newest = create_searchable_messages(@room, count: 1).first
 
-    get api_bots_search_url(q: "findme", limit: 2, page: 1), headers: bot_headers(@bot.bot_key)
-    first_page_ids = response.parsed_body["results"].map { |r| r["id"] }
+    get api_bots_search_url(q: "findme"), headers: bot_headers(@bot.bot_key)
 
-    get api_bots_search_url(q: "findme", limit: 2, page: 2), headers: bot_headers(@bot.bot_key)
-    second_page_ids = response.parsed_body["results"].map { |r| r["id"] }
-
-    assert_equal 2, first_page_ids.size
-    assert_equal 2, second_page_ids.size
-    assert_empty (first_page_ids & second_page_ids)
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ newest.id, middle.id, older.id ], ids
   end
 
-  test "non-positive page values clamp to first page" do
-    create_searchable_messages(@room, count: 3)
+  test "passing next_cursor as before continues pagination without overlap" do
+    # Create 4 messages with distinct timestamps so cursor is unambiguous
+    msgs = Array.new(4) do |i|
+      m = create_searchable_messages(@room, count: 1).first
+      m.update_columns(created_at: (4 - i).hours.ago)
+      m
+    end
+    expected_order_newest_first = msgs.reverse.map(&:id)
 
-    get api_bots_search_url(q: "findme", limit: 1, page: 1), headers: bot_headers(@bot.bot_key)
-    expected = response.parsed_body["results"]
+    get api_bots_search_url(q: "findme", limit: 2), headers: bot_headers(@bot.bot_key)
+    page_one = response.parsed_body
+    cursor = page_one["next_cursor"]
+    assert_not_nil cursor
 
-    get api_bots_search_url(q: "findme", limit: 1, page: 0), headers: bot_headers(@bot.bot_key)
-    assert_equal expected, response.parsed_body["results"]
-
-    get api_bots_search_url(q: "findme", limit: 1, page: -3), headers: bot_headers(@bot.bot_key)
-    assert_equal expected, response.parsed_body["results"]
-  end
-
-  test "page clamps to MAX_PAGE to bound deep-offset work" do
-    create_searchable_messages(@room, count: 1)
-
-    over_max = API::Bots::SearchesController::MAX_PAGE + 100
-    get api_bots_search_url(q: "findme", limit: 1, page: over_max), headers: bot_headers(@bot.bot_key)
-    over_response = response.parsed_body
-
-    get api_bots_search_url(q: "findme", limit: 1, page: API::Bots::SearchesController::MAX_PAGE),
+    get api_bots_search_url(q: "findme", limit: 2, before: cursor),
         headers: bot_headers(@bot.bot_key)
-    capped_response = response.parsed_body
+    page_two = response.parsed_body
 
-    assert_equal capped_response, over_response
+    page_one_ids = page_one["results"].map { |r| r["id"] }
+    page_two_ids = page_two["results"].map { |r| r["id"] }
+
+    assert_empty (page_one_ids & page_two_ids), "pages must not overlap"
+    assert_equal expected_order_newest_first, page_one_ids + page_two_ids
+    assert_equal false, page_two["has_more"]
+    assert_nil page_two["next_cursor"]
   end
 
   # N+1 prevention

--- a/test/controllers/api/bots/searches_controller_test.rb
+++ b/test/controllers/api/bots/searches_controller_test.rb
@@ -70,7 +70,7 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, json["results"].size
   end
 
-  test "has_more is true and next_cursor is set when more results exist" do
+  test "has_more is true and next_cursor is composite (iso|id) when more results exist" do
     create_searchable_messages(@room, count: 5)
 
     get api_bots_search_url(q: "findme", limit: 2), headers: bot_headers(@bot.bot_key)
@@ -80,9 +80,9 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, json["has_more"]
     assert_equal 2, json["results"].size
 
-    # next_cursor is the created_at of the oldest (last) result in newest-first ordering
-    expected_cursor = Time.iso8601(json["results"].last["created_at"]).iso8601
-    assert_equal expected_cursor, json["next_cursor"]
+    last = json["results"].last
+    expected = "#{Time.iso8601(last["created_at"]).iso8601}|#{last["id"]}"
+    assert_equal expected, json["next_cursor"]
   end
 
   # Limit cap
@@ -217,6 +217,71 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
 
     ids = response.parsed_body["results"].map { |r| r["id"] }
     assert_equal [ newest.id, middle.id, older.id ], ids
+  end
+
+  test "composite cursor is stable across same-second timestamp ties" do
+    # Three messages share the exact same created_at — without a composite
+    # cursor, the page-2 query (`created_at < cursor_time`) drops the siblings.
+    shared_time = 1.hour.ago.change(usec: 0)
+    msgs = Array.new(3) { create_searchable_messages(@room, count: 1).first }
+    msgs.each { |m| m.update_columns(created_at: shared_time) }
+    expected_ids = msgs.map(&:id).sort.reverse # id DESC tiebreaker
+
+    get api_bots_search_url(q: "findme", limit: 2), headers: bot_headers(@bot.bot_key)
+    page_one = response.parsed_body
+    cursor = page_one["next_cursor"]
+    assert_not_nil cursor
+
+    get api_bots_search_url(q: "findme", limit: 2, before: cursor),
+        headers: bot_headers(@bot.bot_key)
+    page_two = response.parsed_body
+
+    page_one_ids = page_one["results"].map { |r| r["id"] }
+    page_two_ids = page_two["results"].map { |r| r["id"] }
+    assert_empty (page_one_ids & page_two_ids), "tied-timestamp rows must not overlap"
+    assert_equal expected_ids, page_one_ids + page_two_ids,
+      "every tied-timestamp row must appear exactly once across pages"
+  end
+
+  test "plain ISO timestamp before still works as a filter (back-compat)" do
+    older = create_searchable_messages(@room, count: 1).first
+    older.update_columns(created_at: 2.days.ago)
+    create_searchable_messages(@room, count: 1) # newer
+
+    get api_bots_search_url(q: "findme", before: 1.day.ago.iso8601),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ older.id ], ids
+  end
+
+  test "after lower-bound composes with cursor across pages" do
+    # Out-of-window message (older than the lower bound) — must never appear.
+    out_of_window = create_searchable_messages(@room, count: 1).first
+    out_of_window.update_columns(created_at: 10.days.ago)
+
+    in_window = Array.new(4) do |i|
+      m = create_searchable_messages(@room, count: 1).first
+      m.update_columns(created_at: (4 - i).hours.ago)
+      m
+    end
+    expected_order = in_window.reverse.map(&:id)
+
+    lower_bound = 1.day.ago.iso8601
+
+    get api_bots_search_url(q: "findme", after: lower_bound, limit: 2),
+        headers: bot_headers(@bot.bot_key)
+    page_one = response.parsed_body
+    cursor = page_one["next_cursor"]
+
+    get api_bots_search_url(q: "findme", after: lower_bound, limit: 2, before: cursor),
+        headers: bot_headers(@bot.bot_key)
+    page_two = response.parsed_body
+
+    seen = page_one["results"].map { |r| r["id"] } + page_two["results"].map { |r| r["id"] }
+    assert_equal expected_order, seen
+    assert_not_includes seen, out_of_window.id, "after must clamp the page-2 query too"
   end
 
   test "passing next_cursor as before continues pagination without overlap" do

--- a/test/controllers/api/bots/searches_controller_test.rb
+++ b/test/controllers/api/bots/searches_controller_test.rb
@@ -3,24 +3,39 @@ require "test_helper"
 class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @bot = users(:bender)
+    @room = rooms(:watercooler) # bender is a member
+    @other_room = rooms(:designers) # bender is NOT a member
   end
 
-  test "search returns matching messages" do
-    get api_bots_search_url(q: "post"), headers: bot_headers(@bot.bot_key)
+  # Envelope shape
+
+  test "search returns results array and has_more flag" do
+    create_searchable_messages(@room, count: 1)
+
+    get api_bots_search_url(q: "findme"), headers: bot_headers(@bot.bot_key)
 
     assert_response :success
     json = response.parsed_body
-    assert json.is_a?(Array)
-
-    if json.any?
-      msg = json.first
-      assert msg["id"].present?
-      assert msg["creator"].is_a?(Hash)
-      assert msg["body"].is_a?(Hash)
-      assert msg["room"].is_a?(Hash)
-      assert msg["created_at"].present?
-    end
+    assert json.key?("results"), "expected envelope with 'results' key, got #{json.inspect}"
+    assert json.key?("has_more"), "expected envelope with 'has_more' key, got #{json.inspect}"
+    assert json["results"].is_a?(Array)
+    assert_includes [ true, false ], json["has_more"]
   end
+
+  test "result objects expose id, creator, body, room, created_at" do
+    create_searchable_messages(@room, count: 1)
+
+    get api_bots_search_url(q: "findme"), headers: bot_headers(@bot.bot_key)
+
+    msg = response.parsed_body["results"].first
+    assert msg["id"].present?
+    assert_equal %w[id name], msg["creator"].keys.sort
+    assert_equal %w[html plain], msg["body"].keys.sort
+    assert_equal %w[id name], msg["room"].keys.sort
+    assert msg["created_at"].present?
+  end
+
+  # Validation
 
   test "search requires q param" do
     get api_bots_search_url(), headers: bot_headers(@bot.bot_key)
@@ -39,4 +54,227 @@ class API::Bots::SearchesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_url
   end
+
+  # has_more truncation signal
+
+  test "has_more is false when results fit within limit" do
+    create_searchable_messages(@room, count: 2)
+
+    get api_bots_search_url(q: "findme", limit: 10), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal false, json["has_more"]
+    assert_equal 2, json["results"].size
+  end
+
+  test "has_more is true and exactly limit results returned when more exist" do
+    create_searchable_messages(@room, count: 5)
+
+    get api_bots_search_url(q: "findme", limit: 2), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal true, json["has_more"]
+    assert_equal 2, json["results"].size
+  end
+
+  # Limit cap
+
+  test "limit clamps above MAX_LIMIT" do
+    create_searchable_messages(@room, count: 1)
+
+    get api_bots_search_url(q: "findme", limit: 5_000), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    # Cap is silent — caller asked for 5000, server enforces 200.
+    # Verify by checking has_more remains false (1 result ≤ 200) without erroring.
+    assert_equal false, response.parsed_body["has_more"]
+  end
+
+  test "limit clamps below 1 to 1" do
+    create_searchable_messages(@room, count: 3)
+
+    get api_bots_search_url(q: "findme", limit: 0), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    assert_equal 1, response.parsed_body["results"].size
+  end
+
+  # Scoping by room
+
+  test "results filter by room_ids" do
+    create_searchable_messages(@room, count: 2)
+    other_room = Rooms::Open.create!(name: "Bot Side Room", creator: users(:david))
+    Membership.create!(user: @bot, room: other_room, involvement: :everything)
+    create_searchable_messages(other_room, count: 3)
+
+    get api_bots_search_url(q: "findme", room_ids: [ other_room.id ]),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    room_ids = response.parsed_body["results"].map { |r| r["room"]["id"] }
+    assert_equal [ other_room.id ], room_ids.uniq
+  end
+
+  test "results never include messages from rooms bot cannot reach" do
+    # Create a message in designers (bender is not a member)
+    @other_room.messages.create!(creator: users(:david), body: "findme stranger")
+
+    get api_bots_search_url(q: "findme"), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    room_ids = response.parsed_body["results"].map { |r| r["room"]["id"] }
+    assert_not_includes room_ids, @other_room.id
+  end
+
+  test "passing an unreachable room_id returns no results, not 403" do
+    create_searchable_messages(@room, count: 1)
+
+    get api_bots_search_url(q: "findme", room_ids: [ @other_room.id ]),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    assert_empty response.parsed_body["results"]
+  end
+
+  # Scoping by author
+
+  test "results filter by author_ids" do
+    create_searchable_messages(@room, count: 2, creator: users(:david))
+    create_searchable_messages(@room, count: 2, creator: users(:jason))
+
+    get api_bots_search_url(q: "findme", author_ids: [ users(:david).id ]),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    creator_ids = response.parsed_body["results"].map { |r| r["creator"]["id"] }
+    assert_equal [ users(:david).id ], creator_ids.uniq
+  end
+
+  # Time filters
+
+  test "created_before excludes messages newer than the cutoff" do
+    older = create_searchable_messages(@room, count: 1).first
+    older.update_columns(created_at: 2.days.ago)
+    create_searchable_messages(@room, count: 1) # newer, "now"
+
+    cutoff = 1.day.ago.iso8601
+    get api_bots_search_url(q: "findme", before: cutoff), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ older.id ], ids
+  end
+
+  test "created_after excludes messages older than the cutoff" do
+    older = create_searchable_messages(@room, count: 1).first
+    older.update_columns(created_at: 2.days.ago)
+    newer = create_searchable_messages(@room, count: 1).first
+
+    cutoff = 1.day.ago.iso8601
+    get api_bots_search_url(q: "findme", after: cutoff), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ newer.id ], ids
+  end
+
+  test "unparseable before timestamp returns 422" do
+    get api_bots_search_url(q: "findme", before: "not-a-date"),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+    assert_match(/before/i, response.parsed_body["error"])
+  end
+
+  test "unparseable after timestamp returns 422" do
+    get api_bots_search_url(q: "findme", after: "yesterday"),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+    assert_match(/after/i, response.parsed_body["error"])
+  end
+
+  # Pagination
+
+  test "page advances past previously seen results" do
+    create_searchable_messages(@room, count: 4)
+
+    get api_bots_search_url(q: "findme", limit: 2, page: 1), headers: bot_headers(@bot.bot_key)
+    first_page_ids = response.parsed_body["results"].map { |r| r["id"] }
+
+    get api_bots_search_url(q: "findme", limit: 2, page: 2), headers: bot_headers(@bot.bot_key)
+    second_page_ids = response.parsed_body["results"].map { |r| r["id"] }
+
+    assert_equal 2, first_page_ids.size
+    assert_equal 2, second_page_ids.size
+    assert_empty (first_page_ids & second_page_ids)
+  end
+
+  test "non-positive page values clamp to first page" do
+    create_searchable_messages(@room, count: 3)
+
+    get api_bots_search_url(q: "findme", limit: 1, page: 1), headers: bot_headers(@bot.bot_key)
+    expected = response.parsed_body["results"]
+
+    get api_bots_search_url(q: "findme", limit: 1, page: 0), headers: bot_headers(@bot.bot_key)
+    assert_equal expected, response.parsed_body["results"]
+
+    get api_bots_search_url(q: "findme", limit: 1, page: -3), headers: bot_headers(@bot.bot_key)
+    assert_equal expected, response.parsed_body["results"]
+  end
+
+  test "page clamps to MAX_PAGE to bound deep-offset work" do
+    create_searchable_messages(@room, count: 1)
+
+    over_max = API::Bots::SearchesController::MAX_PAGE + 100
+    get api_bots_search_url(q: "findme", limit: 1, page: over_max), headers: bot_headers(@bot.bot_key)
+    over_response = response.parsed_body
+
+    get api_bots_search_url(q: "findme", limit: 1, page: API::Bots::SearchesController::MAX_PAGE),
+        headers: bot_headers(@bot.bot_key)
+    capped_response = response.parsed_body
+
+    assert_equal capped_response, over_response
+  end
+
+  # N+1 prevention
+
+  test "rendering many results does not trigger per-row creator or room queries" do
+    create_searchable_messages(@room, count: 5)
+    baseline_count = count_sql_queries do
+      get api_bots_search_url(q: "findme", limit: 5), headers: bot_headers(@bot.bot_key)
+    end
+    assert_response :success
+    assert_equal 5, response.parsed_body["results"].size
+
+    create_searchable_messages(@room, count: 5)
+    doubled_count = count_sql_queries do
+      get api_bots_search_url(q: "findme", limit: 10), headers: bot_headers(@bot.bot_key)
+    end
+    assert_response :success
+    assert_equal 10, response.parsed_body["results"].size
+
+    # Rendering 2x rows must not 2x the queries — that would mean a per-row fetch.
+    assert_operator doubled_count, :<=, baseline_count + 2,
+      "rendering 2x rows added #{doubled_count - baseline_count} queries — likely an N+1 regression"
+  end
+
+  private
+    def create_searchable_messages(room, count:, creator: nil)
+      creator ||= room.users.where.not(id: @bot.id).first || users(:david)
+      Array.new(count) { |i| room.messages.create!(creator: creator, body: "findme token #{i}") }
+    end
+
+    def count_sql_queries
+      count = 0
+      callback = ->(_, _, _, _, payload) {
+        count += 1 unless payload[:name] == "SCHEMA" || payload[:sql].start_with?("BEGIN", "COMMIT", "RELEASE", "SAVEPOINT", "ROLLBACK")
+      }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+      count
+    end
 end


### PR DESCRIPTION
## Summary

Brings the bot read surface (`/api/bots/rooms`, `/api/bots/search`) up to the shape predicted by the openclaw-sabha plugin's [READ-ENDPOINT-SCALE-PLAN](../openclaw-sabha/blob/main/docs/READ-ENDPOINT-SCALE-PLAN.md) — uniform server-side filtering, hard caps, and an explicit truncation signal so agents can refine queries instead of dumping-and-filtering. Companion plugin update will follow.

## What changed

**`/api/bots/rooms`**
- Accepts `?query=`, `?page=`, `?per_page=` alongside the existing `?joinable=`. `joinable` is a filter now, not a mode switch.
- `Room.matching` scope, sanitized via `sanitize_sql_like`.
- Mirrors `UsersController`'s pagination pattern (default 50, max 100). Empty page is the end signal — bare-array response unchanged.

**`/api/bots/search`** (breaking — coordinate with plugin Phase 3)
- Accepts `?room_ids=`, `?author_ids=`, `?before=`, `?after=`, `?limit=` (default 50, hard cap 200).
- Response is now `{ results: [...], has_more: bool, next_cursor: "<iso>|<id>" | null }`.
- **Cursor pagination**, no `page` param. Newest-first ordering for the bot endpoint only — `Message::Searchable.search` ASC behavior is preserved for the human search UI.
- Composite cursor (`<iso>|<id>`) survives same-second timestamp collisions; plain ISO `before=<iso>` still works as a back-compat filter.
- Loud 422 on unparseable timestamps so agents see their malformed input.

## Non-bot side effects (both backwards-compatible)

- `Rooms::Open.browsable_by` — duplicate `ORDER BY` removed from the scope. `rooms/browse_controller.rb` now adds `.ordered` explicitly. Human Browse UI unchanged.
- `Message.created_by(users)` — signature widened to accept User / id / array of either via `Array.wrap`. Three existing callers (profile recent messages, user search, user message list) all pass a single User and continue to work.

## Test plan

- [x] `bin/rails test test/controllers/api/bots/` — 105 runs, 0 failures
- [x] `bin/rails test test/controllers/api/bots/ test/controllers/users_controller_test.rb test/models/message/` — 169 runs, 0 failures
- [x] Rubocop and Brakeman clean
- [ ] Spot-check `/rooms/browse` (Browse Rooms UI) — should still show rooms alphabetized
- [ ] Spot-check `/users/:id` profile recent-messages and `/users/:id/messages` search — `created_by` signature change is transparent to these
- [ ] Coordinate plugin Phase 3 update (`client.search()` drops `page`, loops on `next_cursor`)

## Notes for reviewers

- Cursor format is intentionally transparent — agent can read `next_cursor`, parse it, debug it. Opaque tokens deferred until there's a tamper-resistance need.
- `before` URL param does double duty: plain ISO = filter ("messages older than X"), composite = cursor ("continue from this position"). Same domain object, one mechanism.
- `MAX_LIMIT=200` for search vs `max per_page=100` for rooms/users — search legitimately allows more because agents narrowing on one workspace's history is the typical case.
- Three rounds of DHH-style review (one per phase) shaped this. Notable catches: `Room.matching` ternary stays composable, polymorphic `created_by` over a separate `by_authors`, loud failure on unparseable timestamps over silent fallback, composite cursor over timestamp-only.