### PR TITLE
Extend bot API read surface: boost aggregation + messages cursor pagination

### DIFF
--- a/app/controllers/api/bots/messages/boosts_controller.rb
+++ b/app/controllers/api/bots/messages/boosts_controller.rb
@@ -1,7 +1,14 @@
 class API::Bots::Messages::BoostsController < API::Bots::BaseController
   include NotifyBots
 
+  REACTIONS_CAP = 50
+  BOOSTERS_CAP = 100
+
   before_action :set_room_and_message
+
+  def index
+    @summary = @message.boost_summary(limit: REACTIONS_CAP, boosters_limit: BOOSTERS_CAP)
+  end
 
   def create
     content = request.body.tap(&:rewind).read.force_encoding("UTF-8").strip

--- a/app/controllers/api/bots/messages/boosts_controller.rb
+++ b/app/controllers/api/bots/messages/boosts_controller.rb
@@ -7,7 +7,7 @@ class API::Bots::Messages::BoostsController < API::Bots::BaseController
   before_action :set_room_and_message
 
   def index
-    @summary = @message.boost_summary(limit: REACTIONS_CAP, boosters_limit: BOOSTERS_CAP)
+    @groups, @total, @truncated = @message.boost_summary(limit: REACTIONS_CAP, boosters_limit: BOOSTERS_CAP)
   end
 
   def create

--- a/app/controllers/api/bots/messages_controller.rb
+++ b/app/controllers/api/bots/messages_controller.rb
@@ -2,27 +2,20 @@ class API::Bots::MessagesController < API::Bots::BaseController
   include ActiveStorage::SetCurrent, NotifyBots, CursorPaginated
 
   before_action :set_room
+  before_action :parse_pagination_params, only: :index
   before_action :set_own_message, only: %i[update destroy]
 
   def index
-    before_time, before_id = parse_before(params[:before])
-    return render_validation_error("'before' must be ISO8601 timestamp or composite cursor") if params[:before].present? && before_time.nil?
-
-    after_time = parse_time(params[:after])
-    return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && after_time.nil?
-
-    @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
-
     scope = @room.messages.active
                  .with_rich_text_body_and_embeds
                  .with_creator
                  .with_attached_attachment
                  .reorder(created_at: :desc, id: :desc)
-    scope = scope.since(after_time) if after_time
-    scope = if before_id
-      scope.before_cursor(before_time, before_id)
-    elsif before_time
-      scope.created_before(before_time)
+    scope = scope.since(@after_time) if @after_time
+    scope = if @before_id
+      scope.before_cursor(@before_time, @before_id)
+    elsif @before_time
+      scope.created_before(@before_time)
     else
       scope
     end

--- a/app/controllers/api/bots/messages_controller.rb
+++ b/app/controllers/api/bots/messages_controller.rb
@@ -1,17 +1,45 @@
 class API::Bots::MessagesController < API::Bots::BaseController
-  include ActiveStorage::SetCurrent, NotifyBots
+  include ActiveStorage::SetCurrent, NotifyBots, CursorPaginated
 
   before_action :set_room
   before_action :set_own_message, only: %i[update destroy]
 
   def index
-    messages = @room.messages.active.with_creator.with_attached_attachment.ordered.last(50).reverse
-    render json: messages.map { |msg| message_json(msg) }
+    before_time, before_id = parse_before(params[:before])
+    return render_validation_error("'before' must be ISO8601 timestamp or composite cursor") if params[:before].present? && before_time.nil?
+
+    after_time = parse_time(params[:after])
+    return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && after_time.nil?
+
+    @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+
+    scope = @room.messages.active
+                 .with_rich_text_body_and_embeds
+                 .with_creator
+                 .with_attached_attachment
+                 .reorder(created_at: :desc, id: :desc)
+    scope = scope.since(after_time) if after_time
+    scope = if before_id
+      scope.before_cursor(before_time, before_id)
+    elsif before_time
+      scope.created_before(before_time)
+    else
+      scope
+    end
+    scope = scope.limit(@limit + 1)
+
+    messages = scope.to_a
+    @has_more = messages.size > @limit
+    @messages = messages.first(@limit)
+    @next_cursor = build_cursor(@messages.last) if @has_more
   end
 
   def show
-    message = @room.messages.active.with_creator.with_attached_attachment.find(params[:id])
-    render json: message_json(message)
+    @message = @room.messages.active
+                    .with_rich_text_body_and_embeds
+                    .with_creator
+                    .with_attached_attachment
+                    .find(params[:id])
   end
 
   def create
@@ -83,26 +111,6 @@ class API::Bots::MessagesController < API::Bots::BaseController
       yield io.read.force_encoding("UTF-8")
     ensure
       io.rewind
-    end
-
-    def message_json(msg)
-      { id: msg.id,
-        creator: { id: msg.creator.id, name: msg.creator.name },
-        body: { html: msg.body.body.to_s, plain: msg.plain_text_body },
-        has_attachment: msg.attachment?,
-        attachment: msg.attachment? ? attachment_json(msg) : nil,
-        mentionees: msg.mentionees.map { |m| { id: m.id, name: m.name } },
-        created_at: msg.created_at.iso8601 }
-    end
-
-    def attachment_json(message)
-      blob = message.attachment.blob
-      {
-        url: blob.url(expires_in: 1.hour),
-        filename: blob.filename.to_s,
-        content_type: blob.content_type,
-        byte_size: blob.byte_size
-      }
     end
 
     def not_found

--- a/app/controllers/api/bots/searches_controller.rb
+++ b/app/controllers/api/bots/searches_controller.rb
@@ -1,17 +1,11 @@
 class API::Bots::SearchesController < API::Bots::BaseController
   include ActiveStorage::SetCurrent, CursorPaginated
 
+  before_action :parse_pagination_params, only: :show
+
   def show
     query = sanitize_query(params[:q])
     return render_validation_error("Query parameter 'q' is required") if query.blank?
-
-    before_time, before_id = parse_before(params[:before])
-    return render_validation_error("'before' must be ISO8601 timestamp or composite cursor") if params[:before].present? && before_time.nil?
-
-    after_time = parse_time(params[:after])
-    return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && after_time.nil?
-
-    @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
 
     room_ids = Array(params[:room_ids])
     author_ids = Array(params[:author_ids])
@@ -20,11 +14,11 @@ class API::Bots::SearchesController < API::Bots::BaseController
               .reorder(created_at: :desc, id: :desc)
     scope = scope.in_rooms(room_ids) if room_ids.any?
     scope = scope.created_by(author_ids) if author_ids.any?
-    scope = scope.since(after_time) if after_time
-    scope = if before_id
-      scope.before_cursor(before_time, before_id)
-    elsif before_time
-      scope.created_before(before_time)
+    scope = scope.since(@after_time) if @after_time
+    scope = if @before_id
+      scope.before_cursor(@before_time, @before_id)
+    elsif @before_time
+      scope.created_before(@before_time)
     else
       scope
     end

--- a/app/controllers/api/bots/searches_controller.rb
+++ b/app/controllers/api/bots/searches_controller.rb
@@ -1,8 +1,5 @@
 class API::Bots::SearchesController < API::Bots::BaseController
-  include ActiveStorage::SetCurrent
-
-  MAX_LIMIT = 200
-  DEFAULT_LIMIT = 50
+  include ActiveStorage::SetCurrent, CursorPaginated
 
   def show
     query = sanitize_query(params[:q])
@@ -42,32 +39,5 @@ class API::Bots::SearchesController < API::Bots::BaseController
   private
     def sanitize_query(value)
       value.to_s.gsub(/[^[:word:]]/, " ").strip
-    end
-
-    # Accepts either a plain ISO8601 timestamp (filter intent) or
-    # a composite "<iso>|<id>" cursor (pagination intent).
-    def parse_before(value)
-      return [ nil, nil ] if value.blank?
-      time_str, id_str = value.to_s.split("|", 2)
-      time = Time.zone.iso8601(time_str)
-      id = id_str.present? ? Integer(id_str) : nil
-      [ time, id ]
-    rescue ArgumentError, TypeError
-      [ nil, nil ]
-    end
-
-    def parse_time(value)
-      return nil if value.blank?
-      Time.zone.iso8601(value.to_s)
-    rescue ArgumentError
-      nil
-    end
-
-    def build_cursor(message)
-      "#{message.created_at.iso8601}|#{message.id}"
-    end
-
-    def render_validation_error(message)
-      render json: { error: message, code: "validation_failed" }, status: :unprocessable_entity
     end
 end

--- a/app/controllers/concerns/cursor_paginated.rb
+++ b/app/controllers/concerns/cursor_paginated.rb
@@ -5,6 +5,20 @@ module CursorPaginated
   DEFAULT_LIMIT = 50
 
   private
+    # Reads `before`, `after`, and `limit` from params and exposes them as
+    # `@before_time`, `@before_id`, `@after_time`, `@limit`. Renders 422 and
+    # halts the action chain on unparseable timestamps. Wire this in via
+    # `before_action :parse_pagination_params, only: [...]`.
+    def parse_pagination_params
+      @before_time, @before_id = parse_before(params[:before])
+      return render_validation_error("'before' must be ISO8601 timestamp or composite cursor") if params[:before].present? && @before_time.nil?
+
+      @after_time = parse_time(params[:after])
+      return render_validation_error("'after' must be an ISO8601 timestamp") if params[:after].present? && @after_time.nil?
+
+      @limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+    end
+
     # Accepts either a plain ISO8601 timestamp (filter intent) or
     # a composite "<iso>|<id>" cursor (pagination intent).
     def parse_before(value)

--- a/app/controllers/concerns/cursor_paginated.rb
+++ b/app/controllers/concerns/cursor_paginated.rb
@@ -1,0 +1,34 @@
+module CursorPaginated
+  extend ActiveSupport::Concern
+
+  MAX_LIMIT = 200
+  DEFAULT_LIMIT = 50
+
+  private
+    # Accepts either a plain ISO8601 timestamp (filter intent) or
+    # a composite "<iso>|<id>" cursor (pagination intent).
+    def parse_before(value)
+      return [ nil, nil ] if value.blank?
+      time_str, id_str = value.to_s.split("|", 2)
+      time = Time.zone.iso8601(time_str)
+      id = id_str.present? ? Integer(id_str) : nil
+      [ time, id ]
+    rescue ArgumentError, TypeError
+      [ nil, nil ]
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+      Time.zone.iso8601(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
+    def build_cursor(message)
+      "#{message.created_at.iso8601}|#{message.id}"
+    end
+
+    def render_validation_error(message)
+      render json: { error: message, code: "validation_failed" }, status: :unprocessable_entity
+    end
+end

--- a/app/models/boost.rb
+++ b/app/models/boost.rb
@@ -1,4 +1,6 @@
 class Boost < ApplicationRecord
+  Group = Data.define(:content, :count, :boosters, :truncated)
+
   belongs_to :message, touch: true
   belongs_to :booster, class_name: "User", default: -> { Current.user }
 

--- a/app/models/boost/group.rb
+++ b/app/models/boost/group.rb
@@ -1,2 +1,0 @@
-class Boost::Group < Data.define(:content, :count, :boosters, :truncated)
-end

--- a/app/models/boost/group.rb
+++ b/app/models/boost/group.rb
@@ -1,0 +1,3 @@
+class Boost::Group < Data.define(:content, :count, :boosters, :truncated)
+  Summary = Data.define(:groups, :total, :truncated)
+end

--- a/app/models/boost/group.rb
+++ b/app/models/boost/group.rb
@@ -1,3 +1,2 @@
 class Boost::Group < Data.define(:content, :count, :boosters, :truncated)
-  Summary = Data.define(:groups, :total, :truncated)
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -109,13 +109,15 @@ class Message < ApplicationRecord
     body.to_plain_text.presence || attachment&.filename&.to_s || ""
   end
 
-  # Aggregates this message's boosts into emoji-content groups.
-  # Groups are sorted count DESC, then earliest reaction ASC. Boosters
-  # within a group are sorted oldest-first ("who started this 🚀?").
+  # Aggregates this message's boosts into emoji-content groups, returning
+  # `[groups, total, truncated]`. Groups are sorted count DESC, then earliest
+  # reaction ASC. Boosters within a group are sorted oldest-first.
   #
   # Caps are applied in SQL (GROUP BY + per-group LIMIT) so a heavily-reacted
   # message never materializes more than ~limit × boosters_limit rows in Ruby.
-  def boost_summary(limit:, boosters_limit:)
+  # Issues O(distinct_emoji) queries by design — bounded by `limit + 1` —
+  # SQLite portability rules out a single `array_agg`.
+  def boost_summary(limit: 50, boosters_limit: 100)
     ranked = boosts.group(:content)
                    .reorder(Arel.sql("COUNT(*) DESC, MIN(created_at) ASC"))
                    .limit(limit + 1)
@@ -137,7 +139,7 @@ class Message < ApplicationRecord
       )
     end
 
-    Boost::Group::Summary.new(groups: groups, total: boosts.count, truncated: truncated)
+    [ groups, boosts.count, truncated ]
   end
 
   def thread_participants_for(thread)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -109,6 +109,37 @@ class Message < ApplicationRecord
     body.to_plain_text.presence || attachment&.filename&.to_s || ""
   end
 
+  # Aggregates this message's boosts into emoji-content groups.
+  # Groups are sorted count DESC, then earliest reaction ASC. Boosters
+  # within a group are sorted oldest-first ("who started this 🚀?").
+  #
+  # Caps are applied in SQL (GROUP BY + per-group LIMIT) so a heavily-reacted
+  # message never materializes more than ~limit × boosters_limit rows in Ruby.
+  def boost_summary(limit:, boosters_limit:)
+    ranked = boosts.group(:content)
+                   .reorder(Arel.sql("COUNT(*) DESC, MIN(created_at) ASC"))
+                   .limit(limit + 1)
+                   .pluck(:content, Arel.sql("COUNT(*)"), Arel.sql("MIN(created_at)"))
+
+    truncated = ranked.size > limit
+    visible = ranked.first(limit)
+
+    groups = visible.map do |content, count, _earliest|
+      sample = boosts.where(content: content)
+                     .reorder(:created_at)
+                     .limit(boosters_limit)
+                     .includes(:booster)
+      Boost::Group.new(
+        content: content,
+        count: count,
+        boosters: sample.map(&:booster),
+        truncated: count > boosters_limit
+      )
+    end
+
+    Boost::Group::Summary.new(groups: groups, total: boosts.count, truncated: truncated)
+  end
+
   def thread_participants_for(thread)
     @thread_participants&.fetch(thread.id, nil)
   end

--- a/app/views/api/bots/messages/_message.json.jbuilder
+++ b/app/views/api/bots/messages/_message.json.jbuilder
@@ -1,0 +1,21 @@
+json.id message.id
+json.creator do
+  json.id message.creator.id
+  json.name message.creator.name
+end
+json.body do
+  json.html message.body.body.to_s
+  json.plain message.plain_text_body
+end
+if message.attachment?
+  blob = message.attachment.blob
+  json.attachment do
+    json.url blob.url(expires_in: 1.hour)
+    json.filename blob.filename.to_s
+    json.content_type blob.content_type
+    json.byte_size blob.byte_size
+  end
+else
+  json.attachment nil
+end
+json.created_at message.created_at.iso8601

--- a/app/views/api/bots/messages/boosts/index.json.jbuilder
+++ b/app/views/api/bots/messages/boosts/index.json.jbuilder
@@ -1,0 +1,11 @@
+json.reactions @summary.groups do |group|
+  json.content group.content
+  json.count group.count
+  json.boosters group.boosters do |booster|
+    json.id booster.id
+    json.name booster.name
+  end
+  json.truncated group.truncated
+end
+json.total @summary.total
+json.truncated @summary.truncated

--- a/app/views/api/bots/messages/boosts/index.json.jbuilder
+++ b/app/views/api/bots/messages/boosts/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.reactions @summary.groups do |group|
+json.reactions @groups do |group|
   json.content group.content
   json.count group.count
   json.boosters group.boosters do |booster|
@@ -7,5 +7,5 @@ json.reactions @summary.groups do |group|
   end
   json.truncated group.truncated
 end
-json.total @summary.total
-json.truncated @summary.truncated
+json.total @total
+json.truncated @truncated

--- a/app/views/api/bots/messages/index.json.jbuilder
+++ b/app/views/api/bots/messages/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.results @messages, partial: "message", as: :message
+json.has_more @has_more
+json.next_cursor @next_cursor

--- a/app/views/api/bots/messages/show.json.jbuilder
+++ b/app/views/api/bots/messages/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "message", message: @message
+json.mentionees @message.mentionees do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,7 +164,7 @@ Rails.application.routes.draw do
         resources :messages, only: %i[ index show create update destroy ] do
           scope module: :messages do
             resource  :thread, only: :create
-            resources :boosts, only: %i[ create destroy ]
+            resources :boosts, only: %i[ index create destroy ]
           end
         end
         resources :members, only: %i[ index create destroy ]

--- a/test/controllers/api/bots/messages/boosts_controller_test.rb
+++ b/test/controllers/api/bots/messages/boosts_controller_test.rb
@@ -51,4 +51,81 @@ class API::Bots::Messages::BoostsControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :not_found
   end
+
+  # index — aggregated reactions
+  # Cap-edge and sort-order behavior is exercised at the model level
+  # (Message#reaction_summary). These tests cover the wire contract,
+  # permissions, and N+1 prevention only.
+
+  test "index returns the aggregated reactions wire shape" do
+    @message.boosts.create!(content: "🚀", booster: users(:jason))
+    @message.boosts.create!(content: "🚀", booster: users(:david))
+    @message.boosts.create!(content: "❤️", booster: users(:jz))
+
+    get api_bots_room_message_boosts_url(@room, @message), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal %w[reactions total truncated], json.keys
+    assert_equal 3, json["total"]
+    assert_equal false, json["truncated"]
+
+    rocket = json["reactions"].find { |r| r["content"] == "🚀" }
+    assert_equal %w[boosters content count truncated], rocket.keys.sort
+    assert_equal 2, rocket["count"]
+    assert_equal false, rocket["truncated"]
+    assert_equal %w[id name], rocket["boosters"].first.keys.sort
+    assert_equal [ users(:jason).id, users(:david).id ], rocket["boosters"].map { |b| b["id"] }
+  end
+
+  test "index returns empty envelope when no reactions exist" do
+    get api_bots_room_message_boosts_url(@room, @message), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal [], json["reactions"]
+    assert_equal 0, json["total"]
+    assert_equal false, json["truncated"]
+  end
+
+  test "index does not N+1 on booster lookups as boost count grows" do
+    %i[ jason david ].each { |h| @message.boosts.create!(content: "🚀", booster: users(h)) }
+    baseline = count_sql_queries do
+      get api_bots_room_message_boosts_url(@room, @message), headers: bot_headers(@bot.bot_key)
+    end
+    assert_response :success
+
+    %i[ jz rachel ].each { |h| @message.boosts.create!(content: "🚀", booster: users(h)) }
+    doubled = count_sql_queries do
+      get api_bots_room_message_boosts_url(@room, @message), headers: bot_headers(@bot.bot_key)
+    end
+    assert_response :success
+
+    assert_operator doubled, :<=, baseline + 1,
+      "doubling boosts added #{doubled - baseline} queries — likely a per-booster N+1"
+  end
+
+  test "index 404s when bot cannot see the room" do
+    get api_bots_room_message_boosts_url(rooms(:designers), messages(:first)),
+        headers: bot_headers(@bot.bot_key)
+
+    assert_response :not_found
+  end
+
+  test "index 404s when message is inactive" do
+    @message.deactivate
+    get api_bots_room_message_boosts_url(@room, @message), headers: bot_headers(@bot.bot_key)
+
+    assert_response :not_found
+  end
+
+  private
+    def count_sql_queries
+      count = 0
+      callback = ->(_, _, _, _, payload) {
+        count += 1 unless payload[:name] == "SCHEMA" || payload[:sql].start_with?("BEGIN", "COMMIT", "RELEASE", "SAVEPOINT", "ROLLBACK")
+      }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+      count
+    end
 end

--- a/test/controllers/api/bots/messages/reads_test.rb
+++ b/test/controllers/api/bots/messages/reads_test.rb
@@ -3,80 +3,294 @@ require "test_helper"
 class API::Bots::Messages::ReadsTest < ActionDispatch::IntegrationTest
   setup do
     @bot = users(:bender)
-    @room = rooms(:watercooler)
+    @room = rooms(:watercooler) # bender is a member
+    @other_room = rooms(:designers) # bender is NOT a member
   end
 
-  test "returns messages from a room the bot is a member of" do
+  # Fresh room with bender as a member — used by tests that need a controlled
+  # message set without fixture noise. Strips the "room_created" / "member_joined"
+  # system events so the room starts empty from the API's perspective.
+  def fresh_room
+    @fresh_room ||= begin
+      room = Rooms::Open.create!(name: "Bot Read Test Room", creator: users(:david))
+      Membership.create!(user: @bot, room: room, involvement: :everything)
+      room.messages.destroy_all
+      room
+    end
+  end
+
+  # Envelope shape
+
+  test "index returns results, has_more, and next_cursor envelope keys" do
+    @room.messages.create!(creator: users(:david), body: "hello")
+
     get api_bots_room_messages_url(@room), headers: bot_headers(@bot.bot_key)
 
     assert_response :success
     json = response.parsed_body
-    assert json.is_a?(Array)
+    assert json.key?("results"), "expected 'results' key, got #{json.inspect}"
+    assert json.key?("has_more")
+    assert json.key?("next_cursor")
+    assert json["results"].is_a?(Array)
+    assert_includes [ true, false ], json["has_more"]
   end
 
-  test "each message includes expected fields" do
+  test "index result objects expose id, creator, body, attachment, created_at — and not mentionees or has_attachment" do
+    @room.messages.create!(creator: users(:david), body: "hello")
+
     get api_bots_room_messages_url(@room), headers: bot_headers(@bot.bot_key)
 
-    assert_response :success
-    json = response.parsed_body
-    return if json.empty?
-
-    msg = json.first
+    msg = response.parsed_body["results"].first
     assert msg["id"].present?
-    assert msg["creator"].is_a?(Hash)
-    assert msg["creator"]["id"].present?
-    assert msg["creator"]["name"].present?
-    assert msg["body"].is_a?(Hash)
-    assert msg.key?("mentionees")
+    assert_equal %w[id name], msg["creator"].keys.sort
+    assert_equal %w[html plain], msg["body"].keys.sort
+    assert msg.key?("attachment")
     assert msg["created_at"].present?
-    assert_equal false, msg["has_attachment"]
-    assert_nil msg["attachment"]
+
+    assert_not msg.key?("mentionees"), "index intentionally omits mentionees to avoid the pre-existing per-message N+1"
+    assert_not msg.key?("has_attachment"), "has_attachment is redundant with attachment? null check"
   end
 
-  test "returns 404 for room the bot is not a member of" do
-    get api_bots_room_messages_url(rooms(:designers)), headers: bot_headers(@bot.bot_key)
-
-    assert_response :not_found
-  end
-
-  test "invalid bot key redirects to sign in" do
-    get api_bots_room_messages_url(@room), headers: bot_headers("999-invalidtoken")
-
-    assert_redirected_to new_session_url
-  end
-
-  # Single message read
-
-  test "returns a single message by id" do
+  test "show response includes mentionees field" do
     message = messages(:bender_message)
 
     get api_bots_room_message_url(@room, message), headers: bot_headers(@bot.bot_key)
 
     assert_response :success
     json = response.parsed_body
+    assert json.key?("mentionees"), "show retains mentionees — single-row N+1 is bounded"
     assert_equal message.id, json["id"]
-    assert json["creator"].is_a?(Hash)
-    assert json["body"].is_a?(Hash)
-    assert json["created_at"].present?
+    assert_equal %w[id name], json["creator"].keys.sort
   end
 
-  test "returns 404 for message in room bot is not in" do
-    other_room = rooms(:designers)
-    # Create a message in the other room to look up
-    message = other_room.messages.create!(
-      creator: users(:david),
-      body: "test",
-      client_message_id: Random.uuid
-    )
+  # Permissions
 
-    get api_bots_room_message_url(other_room, message), headers: bot_headers(@bot.bot_key)
-
+  test "index 404s when bot is not in the room" do
+    get api_bots_room_messages_url(@other_room), headers: bot_headers(@bot.bot_key)
     assert_response :not_found
   end
 
-  test "returns 404 for nonexistent message" do
+  test "invalid bot key redirects to sign in" do
+    get api_bots_room_messages_url(@room), headers: bot_headers("999-invalidtoken")
+    assert_redirected_to new_session_url
+  end
+
+  test "show 404s for nonexistent message" do
     get api_bots_room_message_url(@room, 999999), headers: bot_headers(@bot.bot_key)
-
     assert_response :not_found
   end
+
+  test "show 404s for message in room bot is not in" do
+    message = @other_room.messages.create!(creator: users(:david), body: "test")
+    get api_bots_room_message_url(@other_room, message), headers: bot_headers(@bot.bot_key)
+    assert_response :not_found
+  end
+
+  # has_more truncation signal
+
+  test "has_more is false and next_cursor is nil when results fit within limit" do
+    create_messages(fresh_room, count: 2)
+
+    get api_bots_room_messages_url(fresh_room, limit: 10), headers: bot_headers(@bot.bot_key)
+
+    json = response.parsed_body
+    assert_equal false, json["has_more"]
+    assert_nil json["next_cursor"]
+    assert_equal 2, json["results"].size
+  end
+
+  test "has_more is true and next_cursor is composite (iso|id) when more results exist" do
+    create_messages(fresh_room, count: 5)
+
+    get api_bots_room_messages_url(fresh_room, limit: 2), headers: bot_headers(@bot.bot_key)
+
+    json = response.parsed_body
+    assert_equal true, json["has_more"]
+    assert_equal 2, json["results"].size
+
+    last = json["results"].last
+    expected = "#{Time.iso8601(last["created_at"]).iso8601}|#{last["id"]}"
+    assert_equal expected, json["next_cursor"]
+  end
+
+  # Limit cap
+
+  test "limit clamps above MAX_LIMIT" do
+    get api_bots_room_messages_url(@room, limit: 5_000), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    assert_operator response.parsed_body["results"].size, :<=, 200
+  end
+
+  test "limit clamps below 1 to 1" do
+    create_messages(fresh_room, count: 3)
+
+    get api_bots_room_messages_url(fresh_room, limit: 0), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    assert_equal 1, response.parsed_body["results"].size
+  end
+
+  # Time filters
+
+  test "after lower-bound excludes messages older than the cutoff" do
+    older = create_messages(fresh_room, count: 1).first
+    older.update_columns(created_at: 2.days.ago)
+    newer = create_messages(fresh_room, count: 1).first
+
+    get api_bots_room_messages_url(fresh_room, after: 1.day.ago.iso8601), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ newer.id ], ids
+  end
+
+  test "plain ISO timestamp before still works as a filter (back-compat)" do
+    older = create_messages(fresh_room, count: 1).first
+    older.update_columns(created_at: 2.days.ago)
+    create_messages(fresh_room, count: 1) # newer, "now"
+
+    get api_bots_room_messages_url(fresh_room, before: 1.day.ago.iso8601), headers: bot_headers(@bot.bot_key)
+
+    assert_response :success
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ older.id ], ids
+  end
+
+  test "unparseable before timestamp returns 422" do
+    get api_bots_room_messages_url(@room, before: "not-a-date"), headers: bot_headers(@bot.bot_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+    assert_match(/before/i, response.parsed_body["error"])
+  end
+
+  test "unparseable after timestamp returns 422" do
+    get api_bots_room_messages_url(@room, after: "yesterday"), headers: bot_headers(@bot.bot_key)
+
+    assert_response :unprocessable_entity
+    assert_equal "validation_failed", response.parsed_body["code"]
+    assert_match(/after/i, response.parsed_body["error"])
+  end
+
+  # Ordering and cursor pagination
+
+  test "results come back newest-first" do
+    older = create_messages(fresh_room, count: 1).first
+    older.update_columns(created_at: 2.hours.ago)
+    middle = create_messages(fresh_room, count: 1).first
+    middle.update_columns(created_at: 1.hour.ago)
+    newest = create_messages(fresh_room, count: 1).first
+
+    get api_bots_room_messages_url(fresh_room), headers: bot_headers(@bot.bot_key)
+
+    ids = response.parsed_body["results"].map { |r| r["id"] }
+    assert_equal [ newest.id, middle.id, older.id ], ids
+  end
+
+  test "composite cursor is stable across same-second timestamp ties" do
+    shared_time = 1.hour.ago.change(usec: 0)
+    msgs = Array.new(3) { create_messages(fresh_room, count: 1).first }
+    msgs.each { |m| m.update_columns(created_at: shared_time) }
+    expected_ids = msgs.map(&:id).sort.reverse # id DESC tiebreaker
+
+    get api_bots_room_messages_url(fresh_room, limit: 2), headers: bot_headers(@bot.bot_key)
+    page_one = response.parsed_body
+    cursor = page_one["next_cursor"]
+    assert_not_nil cursor
+
+    get api_bots_room_messages_url(fresh_room, limit: 2, before: cursor), headers: bot_headers(@bot.bot_key)
+    page_two = response.parsed_body
+
+    page_one_ids = page_one["results"].map { |r| r["id"] }
+    page_two_ids = page_two["results"].map { |r| r["id"] }
+    assert_empty (page_one_ids & page_two_ids), "tied-timestamp rows must not overlap"
+    assert_equal expected_ids, page_one_ids + page_two_ids
+  end
+
+  test "after lower-bound composes with cursor across pages" do
+    out_of_window = create_messages(fresh_room, count: 1).first
+    out_of_window.update_columns(created_at: 10.days.ago)
+
+    in_window = Array.new(4) do |i|
+      m = create_messages(fresh_room, count: 1).first
+      m.update_columns(created_at: (4 - i).hours.ago)
+      m
+    end
+    expected_order = in_window.reverse.map(&:id)
+
+    lower_bound = 1.day.ago.iso8601
+
+    get api_bots_room_messages_url(fresh_room, after: lower_bound, limit: 2), headers: bot_headers(@bot.bot_key)
+    page_one = response.parsed_body
+    cursor = page_one["next_cursor"]
+
+    get api_bots_room_messages_url(fresh_room, after: lower_bound, limit: 2, before: cursor),
+        headers: bot_headers(@bot.bot_key)
+    page_two = response.parsed_body
+
+    seen = page_one["results"].map { |r| r["id"] } + page_two["results"].map { |r| r["id"] }
+    assert_equal expected_order, seen
+    assert_not_includes seen, out_of_window.id
+  end
+
+  test "passing next_cursor as before continues pagination without overlap" do
+    msgs = Array.new(4) do |i|
+      m = create_messages(fresh_room, count: 1).first
+      m.update_columns(created_at: (4 - i).hours.ago)
+      m
+    end
+    expected_order = msgs.reverse.map(&:id)
+
+    get api_bots_room_messages_url(fresh_room, limit: 2), headers: bot_headers(@bot.bot_key)
+    page_one = response.parsed_body
+    cursor = page_one["next_cursor"]
+    assert_not_nil cursor
+
+    get api_bots_room_messages_url(fresh_room, limit: 2, before: cursor), headers: bot_headers(@bot.bot_key)
+    page_two = response.parsed_body
+
+    page_one_ids = page_one["results"].map { |r| r["id"] }
+    page_two_ids = page_two["results"].map { |r| r["id"] }
+
+    assert_empty (page_one_ids & page_two_ids)
+    assert_equal expected_order, page_one_ids + page_two_ids
+    assert_equal false, page_two["has_more"]
+    assert_nil page_two["next_cursor"]
+  end
+
+  # N+1 prevention
+
+  test "rendering many results does not trigger per-row creator or body queries" do
+    create_messages(fresh_room, count: 5)
+    baseline = count_sql_queries do
+      get api_bots_room_messages_url(fresh_room, limit: 5), headers: bot_headers(@bot.bot_key)
+    end
+    assert_response :success
+    assert_equal 5, response.parsed_body["results"].size
+
+    create_messages(fresh_room, count: 5)
+    doubled = count_sql_queries do
+      get api_bots_room_messages_url(fresh_room, limit: 10), headers: bot_headers(@bot.bot_key)
+    end
+    assert_response :success
+    assert_equal 10, response.parsed_body["results"].size
+
+    assert_operator doubled, :<=, baseline + 2,
+      "doubling rows added #{doubled - baseline} queries — likely an N+1 regression"
+  end
+
+  private
+    def create_messages(room, count:)
+      Array.new(count) { |i| room.messages.create!(creator: users(:david), body: "msg #{i}") }
+    end
+
+    def count_sql_queries
+      count = 0
+      callback = ->(_, _, _, _, payload) {
+        count += 1 unless payload[:name] == "SCHEMA" || payload[:sql].start_with?("BEGIN", "COMMIT", "RELEASE", "SAVEPOINT", "ROLLBACK")
+      }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+      count
+    end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -349,13 +349,13 @@ class MessageTest < ActiveSupport::TestCase
     message.boosts.create!(content: "🚀", booster: users(:david))
     message.boosts.create!(content: "❤️", booster: users(:jz))
 
-    summary = message.boost_summary(limit: 50, boosters_limit: 100)
+    groups, total, truncated = message.boost_summary
 
-    assert_equal 3, summary.total
-    assert_equal false, summary.truncated
-    assert_equal [ "🚀", "❤️" ], summary.groups.map(&:content)
+    assert_equal 3, total
+    assert_equal false, truncated
+    assert_equal [ "🚀", "❤️" ], groups.map(&:content)
 
-    rocket = summary.groups.first
+    rocket = groups.first
     assert_equal 2, rocket.count
     assert_equal false, rocket.truncated
     assert_equal [ users(:jason), users(:david) ], rocket.boosters
@@ -369,8 +369,8 @@ class MessageTest < ActiveSupport::TestCase
     Boost.create!(message: message, booster: users(:rachel), content: "🚀", created_at: 20.minutes.ago)
     Boost.create!(message: message, booster: users(:nsa),    content: "🚀", created_at: 10.minutes.ago)
 
-    summary = message.boost_summary(limit: 50, boosters_limit: 100)
-    assert_equal [ "👍", "🚀", "❤️" ], summary.groups.map(&:content)
+    groups, _total, _truncated = message.boost_summary
+    assert_equal [ "👍", "🚀", "❤️" ], groups.map(&:content)
   end
 
   test "boost_summary sorts boosters within a group oldest-first" do
@@ -379,8 +379,8 @@ class MessageTest < ActiveSupport::TestCase
     Boost.create!(message: message, booster: users(:david), content: "🚀", created_at: 20.minutes.ago)
     Boost.create!(message: message, booster: users(:jz),    content: "🚀", created_at: 10.minutes.ago)
 
-    summary = message.boost_summary(limit: 50, boosters_limit: 100)
-    assert_equal [ users(:jason), users(:david), users(:jz) ], summary.groups.first.boosters
+    groups, _total, _truncated = message.boost_summary
+    assert_equal [ users(:jason), users(:david), users(:jz) ], groups.first.boosters
   end
 
   test "boost_summary truncates boosters past boosters_limit and sets per-group truncated flag" do
@@ -389,13 +389,13 @@ class MessageTest < ActiveSupport::TestCase
       message.boosts.create!(booster: users(handle), content: "🚀")
     end
 
-    summary = message.boost_summary(limit: 10, boosters_limit: 2)
-    rocket = summary.groups.first
+    groups, total, truncated = message.boost_summary(limit: 10, boosters_limit: 2)
+    rocket = groups.first
     assert_equal 4, rocket.count
     assert_equal 2, rocket.boosters.size
     assert rocket.truncated
-    assert_equal 4, summary.total
-    assert_equal false, summary.truncated, "top-level truncated tracks groups cap, not boosters cap"
+    assert_equal 4, total
+    assert_equal false, truncated, "top-level truncated tracks groups cap, not boosters cap"
   end
 
   test "boost_summary truncates groups past limit and sets top-level truncated flag" do
@@ -404,19 +404,19 @@ class MessageTest < ActiveSupport::TestCase
       message.boosts.create!(booster: users(:jason), content: emoji)
     end
 
-    summary = message.boost_summary(limit: 2, boosters_limit: 100)
-    assert_equal 2, summary.groups.size
-    assert summary.truncated
-    assert_equal 4, summary.total
+    groups, total, truncated = message.boost_summary(limit: 2, boosters_limit: 100)
+    assert_equal 2, groups.size
+    assert truncated
+    assert_equal 4, total
   end
 
-  test "boost_summary returns empty summary when no boosts exist" do
+  test "boost_summary returns empty result when no boosts exist" do
     message = messages(:bender_message)
 
-    summary = message.boost_summary(limit: 50, boosters_limit: 100)
-    assert_equal [], summary.groups
-    assert_equal 0, summary.total
-    assert_equal false, summary.truncated
+    groups, total, truncated = message.boost_summary
+    assert_equal [], groups
+    assert_equal 0, total
+    assert_equal false, truncated
   end
 
   private

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -341,6 +341,84 @@ class MessageTest < ActiveSupport::TestCase
     assert_not_equal before, message.reload.thread_fingerprint
   end
 
+  # boost_summary
+
+  test "boost_summary aggregates boosts by content with counts and boosters" do
+    message = messages(:bender_message)
+    message.boosts.create!(content: "🚀", booster: users(:jason))
+    message.boosts.create!(content: "🚀", booster: users(:david))
+    message.boosts.create!(content: "❤️", booster: users(:jz))
+
+    summary = message.boost_summary(limit: 50, boosters_limit: 100)
+
+    assert_equal 3, summary.total
+    assert_equal false, summary.truncated
+    assert_equal [ "🚀", "❤️" ], summary.groups.map(&:content)
+
+    rocket = summary.groups.first
+    assert_equal 2, rocket.count
+    assert_equal false, rocket.truncated
+    assert_equal [ users(:jason), users(:david) ], rocket.boosters
+  end
+
+  test "boost_summary sorts groups by count DESC then earliest reaction ASC" do
+    message = messages(:bender_message)
+    Boost.create!(message: message, booster: users(:jz),     content: "❤️", created_at: 1.hour.ago)
+    Boost.create!(message: message, booster: users(:david),  content: "👍", created_at: 30.minutes.ago)
+    Boost.create!(message: message, booster: users(:jason),  content: "👍", created_at: 5.minutes.ago)
+    Boost.create!(message: message, booster: users(:rachel), content: "🚀", created_at: 20.minutes.ago)
+    Boost.create!(message: message, booster: users(:nsa),    content: "🚀", created_at: 10.minutes.ago)
+
+    summary = message.boost_summary(limit: 50, boosters_limit: 100)
+    assert_equal [ "👍", "🚀", "❤️" ], summary.groups.map(&:content)
+  end
+
+  test "boost_summary sorts boosters within a group oldest-first" do
+    message = messages(:bender_message)
+    Boost.create!(message: message, booster: users(:jason), content: "🚀", created_at: 30.minutes.ago)
+    Boost.create!(message: message, booster: users(:david), content: "🚀", created_at: 20.minutes.ago)
+    Boost.create!(message: message, booster: users(:jz),    content: "🚀", created_at: 10.minutes.ago)
+
+    summary = message.boost_summary(limit: 50, boosters_limit: 100)
+    assert_equal [ users(:jason), users(:david), users(:jz) ], summary.groups.first.boosters
+  end
+
+  test "boost_summary truncates boosters past boosters_limit and sets per-group truncated flag" do
+    message = messages(:bender_message)
+    %i[ jason david jz rachel ].each do |handle|
+      message.boosts.create!(booster: users(handle), content: "🚀")
+    end
+
+    summary = message.boost_summary(limit: 10, boosters_limit: 2)
+    rocket = summary.groups.first
+    assert_equal 4, rocket.count
+    assert_equal 2, rocket.boosters.size
+    assert rocket.truncated
+    assert_equal 4, summary.total
+    assert_equal false, summary.truncated, "top-level truncated tracks groups cap, not boosters cap"
+  end
+
+  test "boost_summary truncates groups past limit and sets top-level truncated flag" do
+    message = messages(:bender_message)
+    %w[ 🚀 ❤️ 👍 🎉 ].each do |emoji|
+      message.boosts.create!(booster: users(:jason), content: emoji)
+    end
+
+    summary = message.boost_summary(limit: 2, boosters_limit: 100)
+    assert_equal 2, summary.groups.size
+    assert summary.truncated
+    assert_equal 4, summary.total
+  end
+
+  test "boost_summary returns empty summary when no boosts exist" do
+    message = messages(:bender_message)
+
+    summary = message.boost_summary(limit: 50, boosters_limit: 100)
+    assert_equal [], summary.groups
+    assert_equal 0, summary.total
+    assert_equal false, summary.truncated
+  end
+
   private
     def create_new_message_in(room)
       room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "123")


### PR DESCRIPTION
## Summary

Extends the bot API read surface so AI agents can read full reaction state and paginate room history. Three landed changes plus a post-review cleanup:

- **`boosts#index`** — new `GET /api/bots/rooms/:room_id/messages/:message_id/boosts`. Returns aggregated reactions: `{ reactions: [{ content, count, boosters, truncated }], total, truncated }`. Caps: 50 distinct emoji × 100 boosters per emoji. Wire-level term `reactions` matches Slack/Discord; internal Ruby uses the codebase's `Boost::Group` term.
- **`CursorPaginated` concern** — extracts `parse_pagination_params`, `parse_before`, `parse_time`, `build_cursor`, `render_validation_error`, and `MAX_LIMIT` / `DEFAULT_LIMIT` out of `searches_controller.rb`. Used as a `before_action` so paginated actions read straight scope-building.
- **`messages#index` reshape (BREAKING)** — moves to envelope shape `{ results, has_more, next_cursor }` with `after` / `before` / `limit` params matching search exactly. Newest-first ordering. Composite `<iso>|<id>` cursor handles same-second ties. Drops `mentionees` from index response (avoids pre-existing per-message N+1 — `show` still includes it). Drops redundant `has_attachment` field. Adds `with_rich_text_body_and_embeds` preload (kills body N+1).

Pairs with the plugin-side update in [openclaw-sabha](https://github.com/sabha-co/openclaw-sabha) — see [`docs/READ-ENDPOINT-SCALE-PLAN.md`](https://github.com/sabha-co/openclaw-sabha/blob/main/docs/READ-ENDPOINT-SCALE-PLAN.md) on the plugin side.

Bot API is pre-production. The shape change on `messages#index` is a clean break (no envelope-flag hedge); `boosts#index` is purely additive.

## Why this shape

- **Aggregated reactions, not paginated boost rows.** Boosts are per-message aggregated state, not a paginated stream. Slack and Discord both aggregate. Returning raw boost rows would force the agent to group by emoji client-side — exactly the dump-and-filter pattern this work exists to kill.
- **Caps in SQL, not in Ruby.** `Message#boost_summary` does `GROUP BY content … LIMIT 51` for top-K, then per-content `WHERE content=? ORDER BY created_at LIMIT 100` for booster samples — bounded by the wire caps regardless of how viral a message gets. SQLite portability rules out a single `array_agg`.
- **`before` does double duty as cursor or filter.** Plain ISO timestamp = filter; composite `<iso>\|<id>` = cursor. Same domain object, one wire param.
- **Composite cursor handles same-second ties.** Without `id` tiebreaker, two messages at the same `created_at` silently drop a sibling on a page boundary. Carried forward from #49.
- **Newest-first.** Matches search, Slack `conversations.history`, and Discord. Agents asking \"what did we just say?\" want recent first.
- **Boosters within a reaction sorted oldest-first.** \"Who started this 🚀?\" is a different question than \"what's the most recent reaction?\" Documented divergence from messages-newest-first.

## DHH-style reviews shaped the design

Two passes from `ce-dhh-rails-reviewer` drove the controller↔model boundary:

- Aggregation moved off the controller to `Message#boost_summary`.
- `Boost::Group` (`Data.define`) unifies the AR-vs-hash access split in the jbuilder.
- `Boost::Group::Summary` wrapper was dropped in favor of a `[groups, total, truncated]` tuple return.
- Param parsing pulled into a `before_action` on the concern so both action bodies read straight scope-building.
- `Boost::Group` ended up inlined at the top of `app/models/boost.rb` rather than in its own one-line file (matches Sabha's stated \"no complexity theater\" guidance).

## Test plan

- [x] `bin/rails test test/controllers/api/bots/` — 132 tests
- [x] `bin/rails test test/models/message_test.rb` — 32 tests (boost_summary covers sort, cap edges, empty case via cheap small-cap setup)
- [x] `bin/rails test` — full suite, 1235 / 1235
- [x] N+1 guards in both `boosts_controller_test.rb` (booster preload) and `reads_test.rb` (creator/body preload) using `count_sql_queries` from #49's pattern
- [x] Same-second cursor stability test (the bug-catcher from #49 Phase 3) carried over to messages
- [x] `after` + cursor composability across pages
- [x] Permission 404s for unreachable rooms / inactive messages on every new endpoint

## Notes for review

- Plan lives at `docs/plans/BOT-READ-REACTIONS-PLAN.md` (not committed — local design doc).
- `CursorPaginated` is at top-level `app/controllers/concerns/` (matches Sabha convention — `NotifyBots`, `RoomScoped`, etc., all live there). The plan literally said `app/controllers/api/bots/concerns/`; I diverged from the plan to match the codebase.
- `Message#boost_summary` issues O(distinct_emoji) queries by design — bounded by `limit + 1`. Comment in the model. Could be collapsed to one query via SQLite 3.25+ window functions; deferred as a separate optimization.