### PR TITLE
Require Terms acceptance on SaaS signup, with stronger ToS

### DIFF
--- a/saas/app/controllers/saas/registrations_controller.rb
+++ b/saas/app/controllers/saas/registrations_controller.rb
@@ -34,7 +34,7 @@ module Saas
         auth_code.deliver_later
       else
         # New account - create and send verification code
-        global_identity = GlobalIdentity.create!(name: params[:name], email_address: params[:email_address])
+        global_identity = GlobalIdentity.create!(name: params[:name], email_address: params[:email_address], terms_of_service: params[:terms_of_service])
         auth_code = global_identity.auth_codes.create!(purpose: :sign_up)
         auth_code.deliver_later
       end

--- a/saas/app/models/global_identity.rb
+++ b/saas/app/models/global_identity.rb
@@ -17,14 +17,20 @@ class GlobalIdentity < UntenantedRecord
   has_many :auth_codes, dependent: :destroy
   has_many :workspace_memberships, dependent: :destroy
 
+  attribute :terms_of_service
+
   validates :email_address, presence: true,
                            uniqueness: { case_sensitive: false },
                            'valid_email_2/email': true
   validates :email_address, 'valid_email_2/email': { disposable: true, message: "looks like a temporary email address. We discourage use of disposable emails — please use a permanent one instead." }, if: -> { email_address.present? }
+  validates :terms_of_service, acceptance: true, on: :create
 
   normalizes :name, with: ->(name) { name&.strip.presence }
   normalizes :email_address, with: ->(email) { email.strip.downcase }
   normalizes :unconfirmed_email, with: ->(email) { email&.strip&.downcase }
+  normalizes :terms_of_service, with: ->(v) { ActiveRecord::Type::Boolean.new.deserialize(v) }
+
+  before_create :stamp_terms_acceptance, if: :terms_of_service
 
   validates :unconfirmed_email, 'valid_email_2/email': true, allow_blank: true
   validates :unconfirmed_email, 'valid_email_2/email': { disposable: true, message: "looks like a temporary email address. We discourage use of disposable emails — please use a permanent one instead." }, allow_blank: true
@@ -162,4 +168,10 @@ class GlobalIdentity < UntenantedRecord
     scope = excluding_id ? where.not(id: excluding_id) : all
     !scope.exists?(email_address: normalized)
   end
+
+  private
+
+    def stamp_terms_acceptance
+      self.accepted_terms_at ||= Time.current
+    end
 end

--- a/saas/app/views/saas/registrations/new.html.erb
+++ b/saas/app/views/saas/registrations/new.html.erb
@@ -35,13 +35,15 @@
         </div>
 
         <%= render "sessions/email_field", form: form, autofocus: false %>
-
-        <label class="flex align-start gap-half txt-medium txt-muted txt-align-left">
-          <%= form.check_box :terms_of_service, { required: true, class: "margin-block-start-quarter" }, "1", "0" %>
-          <span>I agree to the <%= link_to "Terms", "/terms", target: "_blank" %> and <%= link_to "Privacy Policy", "/privacy", target: "_blank" %>.</span>
-        </label>
-
         <div class="flex justify-center"><%= cloudflare_turnstile %></div>
+
+        <div class="flex justify-center">
+          <label class="flex align-center gap-half txt-medium txt-muted">
+            <%= form.check_box :terms_of_service, { required: true }, "1", "0" %>
+            <span>I agree to the <%= link_to "Terms", "/terms", target: "_blank" %> and <%= link_to "Privacy Policy", "/privacy", target: "_blank" %>.</span>
+          </label>
+        </div>
+
         <%= render "sessions/submit_button", form: form, label: "Create account" %>
       </fieldset>
     <% end %>

--- a/saas/app/views/saas/registrations/new.html.erb
+++ b/saas/app/views/saas/registrations/new.html.erb
@@ -35,6 +35,12 @@
         </div>
 
         <%= render "sessions/email_field", form: form, autofocus: false %>
+
+        <label class="flex align-start gap-half txt-medium txt-muted txt-align-left">
+          <%= form.check_box :terms_of_service, { required: true, class: "margin-block-start-quarter" }, "1", "0" %>
+          <span>I agree to the <%= link_to "Terms", "/terms", target: "_blank" %> and <%= link_to "Privacy Policy", "/privacy", target: "_blank" %>.</span>
+        </label>
+
         <div class="flex justify-center"><%= cloudflare_turnstile %></div>
         <%= render "sessions/submit_button", form: form, label: "Create account" %>
       </fieldset>

--- a/saas/app/views/saas/static/privacy.html.erb
+++ b/saas/app/views/saas/static/privacy.html.erb
@@ -76,7 +76,7 @@
       <p style="margin-top: 0.75rem;">We may update this policy from time to time. Material changes will be announced on the service or via email. The "Last updated" date at the top always reflects the current version.</p>
 
       <h2 style="margin-top: 2.5rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">Contact</h2>
-      <p style="margin-top: 0.75rem;">Questions, requests, or privacy concerns? Email <strong>ashwin[at]sabha.co</strong>.</p>
+      <p style="margin-top: 0.75rem;">Questions, requests, or privacy concerns? Email <strong>help[at]sabha.co</strong>.</p>
     </div>
   </div>
 </section>

--- a/saas/app/views/saas/static/terms.html.erb
+++ b/saas/app/views/saas/static/terms.html.erb
@@ -10,7 +10,7 @@
     <div class="landing-section-header">
       <span class="landing-label">LEGAL</span>
       <h1 class="landing-section-title">Terms of Service</h1>
-      <p class="landing-section-sub" style="margin-top: 0.5rem;">Last updated: April 18, 2026</p>
+      <p class="landing-section-sub" style="margin-top: 0.5rem;">Last updated: May 3, 2026</p>
     </div>
 
     <div style="font-size: 1.0625rem; line-height: 1.8; color: var(--color-text-secondary, #555);">
@@ -28,12 +28,17 @@
       <p style="margin-top: 0.75rem;">You agree not to use Sabha to:</p>
       <ul style="margin-top: 0.75rem; padding-left: 1.5rem;">
         <li style="margin-bottom: 0.5rem;">post unlawful, harassing, threatening, defamatory, or infringing content;</li>
+        <li style="margin-bottom: 0.5rem;">post hate speech or content that attacks people based on race, ethnicity, national origin, religion, gender identity, sexual orientation, or disability;</li>
+        <li style="margin-bottom: 0.5rem;">publish another person's private information without their consent (doxxing), or share non-consensual intimate imagery;</li>
+        <li style="margin-bottom: 0.5rem;">promote, coordinate, or glorify violence, terrorism, or extremist activity;</li>
+        <li style="margin-bottom: 0.5rem;">facilitate illegal commerce — drugs, weapons, fraud, or human trafficking of any kind;</li>
         <li style="margin-bottom: 0.5rem;">distribute malware, phishing links, or spam;</li>
         <li style="margin-bottom: 0.5rem;">impersonate others or misrepresent your affiliation;</li>
         <li style="margin-bottom: 0.5rem;">attempt to breach security, scrape at scale, or disrupt the service for others;</li>
-        <li style="margin-bottom: 0.5rem;">upload content involving the sexual exploitation of minors — this will be reported to authorities;</li>
+        <li style="margin-bottom: 0.5rem;">upload, store, or share child sexual abuse material (CSAM). Sabha is required by 18 U.S.C. §2258A to report apparent CSAM to the National Center for Missing &amp; Exploited Children (NCMEC), and we will preserve the relevant content and account data for law enforcement before removing it;</li>
         <li style="margin-bottom: 0.5rem;">use Sabha to violate any applicable law.</li>
       </ul>
+      <p style="margin-top: 1rem;">If you encounter content that violates these rules, report it to <strong>help[at]sabha.co</strong>.</p>
 
       <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">4. Your content</h2>
       <p style="margin-top: 0.75rem;">You retain ownership of everything you post — messages, files, avatars, workspace names. You grant Sabha a non-exclusive, worldwide, royalty-free license to host, store, display, and transmit your content solely to operate the service for you and the members of your workspace.</p>
@@ -47,27 +52,45 @@
 
       <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">7. Termination</h2>
       <p style="margin-top: 0.75rem;">You can delete your account or a workspace at any time. We may suspend or terminate accounts that violate these terms, that we believe pose a risk to other users, or that have been inactive for an extended period. Where practical, we will give notice before doing so.</p>
+      <p style="margin-top: 0.75rem;">For severe violations — CSAM, ongoing harassment campaigns, or attacks against the service — we may suspend or terminate immediately, without notice.</p>
 
       <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">8. Intellectual property</h2>
       <p style="margin-top: 0.75rem;">The Sabha name, logo, and branding are the property of Sabha LLC. The Sabha repository is dual-licensed: the core app is MIT, and the multi-tenant SaaS engine under <code>saas/</code> is proprietary under the Sabha SaaS License. See <a href="https://github.com/sabha-co/sabha/blob/main/LICENSE.md" target="_blank" style="color: inherit; text-decoration: underline; text-underline-offset: 4px;">LICENSE.md</a> and <a href="https://github.com/sabha-co/sabha/blob/main/saas/LICENSE" target="_blank" style="color: inherit; text-decoration: underline; text-underline-offset: 4px;">saas/LICENSE</a>. These terms grant you no other rights to Sabha's trademarks.</p>
 
-      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">9. Disclaimer</h2>
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">9. Copyright complaints (DMCA)</h2>
+      <p style="margin-top: 0.75rem;">If you believe content on sabha.co infringes your copyright, send a written notice that includes:</p>
+      <ul style="margin-top: 0.75rem; padding-left: 1.5rem;">
+        <li style="margin-bottom: 0.5rem;">your contact information;</li>
+        <li style="margin-bottom: 0.5rem;">a description of the copyrighted work you believe has been infringed;</li>
+        <li style="margin-bottom: 0.5rem;">a link to or description of the infringing content on sabha.co;</li>
+        <li style="margin-bottom: 0.5rem;">a statement that you have a good-faith belief the use is not authorized;</li>
+        <li style="margin-bottom: 0.5rem;">a statement, under penalty of perjury, that the information is accurate and that you are the rights holder or authorized to act on their behalf;</li>
+        <li style="margin-bottom: 0.5rem;">your physical or electronic signature.</li>
+      </ul>
+      <p style="margin-top: 0.75rem;">Send notices to our designated agent: <strong>Ashwin M., DMCA Agent, Sabha LLC</strong> — email <strong>help[at]sabha.co</strong>. We will respond as required by 17 U.S.C. §512.</p>
+      <p style="margin-top: 0.75rem;">If your content was removed and you believe the takedown was mistaken, you may send a counter-notice to the same address. We terminate the accounts of repeat infringers.</p>
+
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">10. Disclaimer</h2>
       <p style="margin-top: 0.75rem;">Sabha is provided "as is" without warranties of any kind, express or implied, including fitness for a particular purpose, merchantability, or non-infringement. We do not warrant that the service will be uninterrupted, error-free, or secure.</p>
 
-      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">10. Limitation of liability</h2>
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">11. Limitation of liability</h2>
       <p style="margin-top: 0.75rem;">To the fullest extent permitted by law, Sabha LLC and its affiliates are not liable for indirect, incidental, consequential, or punitive damages, or for any loss of data, revenue, or profits arising from your use of sabha.co. Our total liability for any claim related to the service is limited to one hundred US dollars ($100).</p>
 
-      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">11. Indemnification</h2>
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">12. Indemnification</h2>
       <p style="margin-top: 0.75rem;">You agree to indemnify Sabha LLC against any claim arising from content you post, your violation of these terms, or your violation of any law or third-party right.</p>
 
-      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">12. Governing law</h2>
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">13. Governing law</h2>
       <p style="margin-top: 0.75rem;">These terms are governed by the laws of the State of Delaware, United States, without regard to conflict-of-law principles. Any dispute will be resolved in the state or federal courts located in Delaware, and you consent to that jurisdiction.</p>
 
-      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">13. Changes</h2>
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">14. Changes</h2>
       <p style="margin-top: 0.75rem;">We may update these terms from time to time. Material changes will be announced on the service or via email. Continued use of sabha.co after a change means you accept the updated terms.</p>
 
-      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">14. Contact</h2>
-      <p style="margin-top: 0.75rem;">Questions about these terms? Email <strong>ashwin[at]sabha.co</strong>.</p>
+      <h2 style="margin-top: 2rem; font-size: 1.375rem; font-weight: 600; color: var(--color-text-primary, #111);">15. Contact</h2>
+      <ul style="margin-top: 0.75rem; padding-left: 1.5rem;">
+        <li style="margin-bottom: 0.5rem;">Questions about these terms: <strong>ashwin[at]sabha.co</strong></li>
+        <li style="margin-bottom: 0.5rem;">Reporting content that violates these terms: <strong>help[at]sabha.co</strong></li>
+        <li style="margin-bottom: 0.5rem;">Copyright (DMCA) notices: <strong>help[at]sabha.co</strong> (subject line: "DMCA notice")</li>
+      </ul>
     </div>
   </div>
 </section>

--- a/saas/db/untenanted_migrate/20260503000001_add_accepted_terms_at_to_global_identities.rb
+++ b/saas/db/untenanted_migrate/20260503000001_add_accepted_terms_at_to_global_identities.rb
@@ -1,0 +1,5 @@
+class AddAcceptedTermsAtToGlobalIdentities < ActiveRecord::Migration[8.2]
+  def change
+    add_column :global_identities, :accepted_terms_at, :datetime
+  end
+end

--- a/saas/db/untenanted_schema.rb
+++ b/saas/db/untenanted_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_02_000001) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_03_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_02_000001) do
   end
 
   create_table "global_identities", force: :cascade do |t|
+    t.datetime "accepted_terms_at"
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "name"

--- a/saas/test/controllers/saas/registrations_controller_test.rb
+++ b/saas/test/controllers/saas/registrations_controller_test.rb
@@ -19,12 +19,21 @@ module Saas
 
     test "create with blank name still succeeds (name is optional, fallback to email prefix)" do
       assert_difference "GlobalIdentity.count", 1 do
-        post registration_path, params: with_turnstile_response(name: "", email_address: "noname@example.com")
+        post registration_path, params: with_turnstile_response(name: "", email_address: "noname@example.com", terms_of_service: "1")
       end
 
       assert_redirected_to auth_code_path
       identity = GlobalIdentity.find_by(email_address: "noname@example.com")
       assert_nil identity.name
+    end
+
+    test "create rejects when terms checkbox is unchecked" do
+      assert_no_difference "GlobalIdentity.count" do
+        post registration_path, params: with_turnstile_response(name: "Test", email_address: "rejecttest@example.com", terms_of_service: "0")
+      end
+
+      assert_redirected_to new_registration_path
+      assert_match /Terms of service/, flash[:alert]
     end
 
     test "create with existing email sends sign_in auth code (same message as new)" do
@@ -52,7 +61,7 @@ module Saas
       assert_difference "GlobalIdentity.count", 1 do
         assert_difference "AuthCode.count", 1 do
           assert_enqueued_emails 1 do
-            post registration_path, params: with_turnstile_response(name: "New User", email_address: new_email)
+            post registration_path, params: with_turnstile_response(name: "New User", email_address: new_email, terms_of_service: "1")
           end
         end
       end
@@ -73,7 +82,7 @@ module Saas
     end
 
     test "create normalizes email to lowercase" do
-      post registration_path, params: with_turnstile_response(name: "New User", email_address: "  NewUser@Example.COM  ")
+      post registration_path, params: with_turnstile_response(name: "New User", email_address: "  NewUser@Example.COM  ", terms_of_service: "1")
       assert_redirected_to auth_code_path
 
       identity = GlobalIdentity.find_by(email_address: "newuser@example.com")

--- a/saas/test/models/global_identity_test.rb
+++ b/saas/test/models/global_identity_test.rb
@@ -154,4 +154,24 @@ class GlobalIdentityTest < ActiveSupport::TestCase
     # Excluding self works
     assert GlobalIdentity.email_available?(alice.email_address, excluding_id: alice.id)
   end
+
+  test "rejects signup when terms checkbox is unchecked" do
+    identity = GlobalIdentity.new(name: "Alice", email_address: "newalice@example.com", terms_of_service: "0")
+    assert_not identity.valid?(:create)
+    assert_includes identity.errors[:terms_of_service], "must be accepted"
+  end
+
+  test "stamps accepted_terms_at when terms checkbox is checked" do
+    identity = GlobalIdentity.create!(name: "Alice", email_address: "newalice@example.com", terms_of_service: "1")
+    assert_not_nil identity.accepted_terms_at
+  end
+
+  test "accepted_terms_at is preserved across subsequent updates" do
+    identity = GlobalIdentity.create!(name: "Alice", email_address: "newalice@example.com", terms_of_service: "1")
+    original_acceptance = identity.accepted_terms_at
+    travel 1.day do
+      identity.update!(name: "Renamed Alice")
+    end
+    assert_equal original_acceptance, identity.reload.accepted_terms_at
+  end
 end


### PR DESCRIPTION
## Summary

Two SaaS-only changes for the basics-before-launch pass:

1. **Terms of Service** strengthened — expanded acceptable-use list, CSAM clause cites 18 U.S.C. §2258A + NCMEC, new DMCA section with designated agent, immediate-termination clause, contacts consolidated to `help@sabha.co`.
2. **Signup gate** — `/registration/new` now requires checking *"I agree to the Terms and Privacy Policy."* New \`accepted_terms_at\` column on \`global_identities\`, stamped via \`before_create\` when the box is checked.

Self-hosted is unchanged — self-hosters operate under MIT.