### PR TITLE
Lock banned and deactivated SaaS workspace users out, and email on ban/unban

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -124,7 +124,7 @@ module Authentication
     def deny_inactive_workspace_user
       return unless Current.user&.banned? || Current.user&.deactivated?
 
-      redirect_to "/workspaces"
+      redirect_to "/workspaces", alert: "You no longer have access to this workspace."
     end
 
     # In SaaS mode, create the workspace User on first visit.

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -131,7 +131,7 @@ module Authentication
       return unless Sabha.saas? && Current.user
       return unless Current.user.banned? || Current.user.deactivated?
 
-      redirect_to "/settings?denied=workspace"
+      redirect_to settings_path(script_name: "", denied: "workspace")
     end
 
     # In SaaS mode, create the workspace User on first visit.

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -123,25 +123,15 @@ module Authentication
       end
     end
 
-    # Banned/deactivated workspace users get bounced to their next available
-    # workspace (or the new-workspace page) with an alert. Picks the destination
-    # itself so callers don't have to launder the flash through a transit redirect.
+    # Banned/deactivated workspace users get bounced to /settings, which lists
+    # their other workspaces. The ?denied=workspace query param tells the page
+    # to render a persistent banner — flash gets clobbered by Turbo refetches
+    # and auto-fades after 3s, so it's unreliable for this kind of message.
     def deny_inactive_workspace_user
       return unless Sabha.saas? && Current.user
       return unless Current.user.banned? || Current.user.deactivated?
 
-      redirect_to next_workspace_path_for_inactive_user,
-        alert: "You no longer have access to this workspace."
-    end
-
-    def next_workspace_path_for_inactive_user
-      current_external_id = ApplicationRecord.current_tenant
-      next_workspace = Current.global_session
-        &.global_identity
-        &.active_workspaces_recent_first
-        &.reject { |workspace| workspace.external_id.to_s == current_external_id }
-        &.first
-      next_workspace ? "/#{next_workspace.external_id}" : "/workspaces/new"
+      redirect_to "/settings?denied=workspace"
     end
 
     # In SaaS mode, create the workspace User on first visit.

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -113,11 +113,18 @@ module Authentication
         session.resume(user_agent: request.user_agent, ip_address: request.remote_ip)
         Current.global_session = session
         ensure_workspace_user_exists if ApplicationRecord.current_tenant.present?
+        deny_inactive_workspace_user
         set_authenticated_by(:session)
       else
         session.resume user_agent: request.user_agent, ip_address: request.remote_ip
         authenticated_as session
       end
+    end
+
+    def deny_inactive_workspace_user
+      return unless Current.user&.banned? || Current.user&.deactivated?
+
+      redirect_to "/workspaces"
     end
 
     # In SaaS mode, create the workspace User on first visit.

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -21,7 +21,7 @@ module Authentication
 
     def require_unauthenticated_access(**options)
       skip_before_action :require_authentication, **options
-      before_action :restore_authentication, :redirect_signed_in_user_to_root, **options
+      before_action :restore_authentication, :deny_inactive_workspace_user, :redirect_signed_in_user_to_root, **options
     end
   end
 
@@ -32,6 +32,9 @@ module Authentication
 
     def require_authentication
       restore_authentication || bot_authentication || request_authentication
+      return if performed?
+
+      deny_inactive_workspace_user
       require_workspace_membership unless performed?
     end
 
@@ -113,7 +116,6 @@ module Authentication
         session.resume(user_agent: request.user_agent, ip_address: request.remote_ip)
         Current.global_session = session
         ensure_workspace_user_exists if ApplicationRecord.current_tenant.present?
-        deny_inactive_workspace_user
         set_authenticated_by(:session)
       else
         session.resume user_agent: request.user_agent, ip_address: request.remote_ip
@@ -121,10 +123,25 @@ module Authentication
       end
     end
 
+    # Banned/deactivated workspace users get bounced to their next available
+    # workspace (or the new-workspace page) with an alert. Picks the destination
+    # itself so callers don't have to launder the flash through a transit redirect.
     def deny_inactive_workspace_user
-      return unless Current.user&.banned? || Current.user&.deactivated?
+      return unless Sabha.saas? && Current.user
+      return unless Current.user.banned? || Current.user.deactivated?
 
-      redirect_to "/workspaces", alert: "You no longer have access to this workspace."
+      redirect_to next_workspace_path_for_inactive_user,
+        alert: "You no longer have access to this workspace."
+    end
+
+    def next_workspace_path_for_inactive_user
+      current_external_id = ApplicationRecord.current_tenant
+      next_workspace = Current.global_session
+        &.global_identity
+        &.active_workspaces_recent_first
+        &.reject { |workspace| workspace.external_id.to_s == current_external_id }
+        &.first
+      next_workspace ? "/#{next_workspace.external_id}" : "/workspaces/new"
     end
 
     # In SaaS mode, create the workspace User on first visit.

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,6 +1,9 @@
 class WelcomeController < ApplicationController
   def show
     if Current.user.rooms.any?
+      # Workspace root is a transit redirect to the landing room — preserve any
+      # alert/notice the caller set so it reaches the rendered destination.
+      flash.keep
       room = landing_room
       target = room_url(room)
       target = target + "?" + request.query_string if request.query_string.present?

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,9 +1,6 @@
 class WelcomeController < ApplicationController
   def show
     if Current.user.rooms.any?
-      # Workspace root is a transit redirect to the landing room — preserve any
-      # alert/notice the caller set so it reaches the rendered destination.
-      flash.keep
       room = landing_room
       target = room_url(room)
       target = target + "?" + request.query_string if request.query_string.present?

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -26,4 +26,18 @@ class UserMailer < ApplicationMailer
 
     mail(to: [ old_email, user.email_address ].compact.uniq, subject: "Your email address has been changed for #{Branding.contextual_app_name}")
   end
+
+  def banned(user)
+    @user = user
+    @account_name = Account.sole&.name || Branding.contextual_app_name
+
+    mail(to: user.email_address, subject: "Your access to #{@account_name} has been suspended")
+  end
+
+  def unbanned(user)
+    @user = user
+    @account_name = Account.sole&.name || Branding.contextual_app_name
+
+    mail(to: user.email_address, subject: "Your access to #{@account_name} has been restored")
+  end
 end

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -2,7 +2,7 @@ class Ban < ApplicationRecord
   belongs_to :user
 
   validates :ip_address, presence: true
-  validate :ip_address_is_public, if: -> { ip_address.present? }
+  validate :ip_address_is_public, if: -> { ip_address.present? && !Rails.env.development? }
 
   after_save_commit    :bust_cache
   after_destroy_commit :bust_cache

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -2,7 +2,7 @@ class Ban < ApplicationRecord
   belongs_to :user
 
   validates :ip_address, presence: true
-  validate :ip_address_is_public, if: -> { ip_address.present? && !Rails.env.development? }
+  validate :ip_address_is_public, if: :ip_address?, unless: -> { Rails.env.development? }
 
   after_save_commit    :bust_cache
   after_destroy_commit :bust_cache

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,6 +199,7 @@ class User < ApplicationRecord
       update! status: :active
       reset_remote_connections
     end
+    sync_workspace_membership_active(true)
   end
 
   def deactivate
@@ -216,6 +217,7 @@ class User < ApplicationRecord
     push_subscriptions.delete_all
     sessions.delete_all
     auth_tokens.delete_all
+    sync_workspace_membership_active(false)
   end
 
   def reset_remote_connections
@@ -359,6 +361,24 @@ class User < ApplicationRecord
 
   def pending_email_change?
     unconfirmed_email.present?
+  end
+
+  # Mirror the per-tenant User#active? onto the untenanted WorkspaceMembership row
+  # so the workspace selector can filter without cross-tenant queries. No-op in
+  # self-hosted mode where WorkspaceMembership isn't loaded. The two writes
+  # (User.status + WorkspaceMembership.user_active) live in different databases
+  # and aren't transactional — log and continue on failure rather than rolling
+  # back the calling lifecycle method, since the auth-time guard in Authentication
+  # reads the tenanted User row and keeps access blocked even if the mirror is
+  # stale. The mirror is a hint for the selector, not a security control.
+  def sync_workspace_membership_active(value)
+    return unless Sabha.saas?
+    return unless workspace_membership
+
+    workspace_membership.update(user_active: value) ||
+      Rails.logger.error("[User#sync_workspace_membership_active] failed to mirror user_active=#{value} for membership=#{workspace_membership.id}: #{workspace_membership.errors.full_messages.to_sentence}")
+  rescue ActiveRecord::ActiveRecordError => e
+    Rails.logger.error("[User#sync_workspace_membership_active] error mirroring user_active=#{value} for user=#{id}: #{e.class}: #{e.message}")
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,6 +132,7 @@ class User < ApplicationRecord
 
   after_update :send_email_change_notification, if: :saved_change_to_email_address?
   after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
+  after_update_commit :sync_workspace_membership_active, if: -> { Sabha.saas? && saved_change_to_status? }
 
   before_validation :set_default_name
   before_validation :normalize_social_urls
@@ -199,7 +200,6 @@ class User < ApplicationRecord
       update! status: :active
       reset_remote_connections
     end
-    sync_workspace_membership_active(true)
   end
 
   def deactivate
@@ -217,7 +217,6 @@ class User < ApplicationRecord
     push_subscriptions.delete_all
     sessions.delete_all
     auth_tokens.delete_all
-    sync_workspace_membership_active(false)
   end
 
   def reset_remote_connections
@@ -363,25 +362,22 @@ class User < ApplicationRecord
     unconfirmed_email.present?
   end
 
-  # Mirror the per-tenant User#active? onto the untenanted WorkspaceMembership row
-  # so the workspace selector can filter without cross-tenant queries. No-op in
-  # self-hosted mode where WorkspaceMembership isn't loaded. The two writes
-  # (User.status + WorkspaceMembership.user_active) live in different databases
-  # and aren't transactional — log and continue on failure rather than rolling
-  # back the calling lifecycle method, since the auth-time guard in Authentication
-  # reads the tenanted User row and keeps access blocked even if the mirror is
-  # stale. The mirror is a hint for the selector, not a security control.
-  def sync_workspace_membership_active(value)
-    return unless Sabha.saas?
-    return unless workspace_membership
-
-    workspace_membership.update(user_active: value) ||
-      Rails.logger.error("[User#sync_workspace_membership_active] failed to mirror user_active=#{value} for membership=#{workspace_membership.id}: #{workspace_membership.errors.full_messages.to_sentence}")
-  rescue ActiveRecord::ActiveRecordError => e
-    Rails.logger.error("[User#sync_workspace_membership_active] error mirroring user_active=#{value} for user=#{id}: #{e.class}: #{e.message}")
-  end
-
   private
+    # Mirror User#active? onto the untenanted WorkspaceMembership row so the
+    # workspace selector can filter without cross-tenant queries. Runs after
+    # the tenanted transaction commits, so a Postgres failure here cannot roll
+    # back the SQLite write. The auth-time guard reads the tenanted User row,
+    # so a stale mirror cannot let a banned user through — it can only hide a
+    # workspace the user should still see, and the rake backfill repairs that.
+    def sync_workspace_membership_active
+      return unless workspace_membership
+
+      workspace_membership.update(user_active: active?) ||
+        Rails.logger.error("[User#sync_workspace_membership_active] failed to mirror user_active=#{active?} for membership=#{workspace_membership.id}: #{workspace_membership.errors.full_messages.to_sentence}")
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.error("[User#sync_workspace_membership_active] error mirroring user_active=#{active?} for user=#{id}: #{e.class}: #{e.message}")
+    end
+
     def deactivate_direct_rooms
       Membership.where(user_id: id).direct_rooms.each do |membership|
         membership.room.deactivate
@@ -445,10 +441,13 @@ class User < ApplicationRecord
     # `dependent: :destroy` only finds active records. We need to delete all
     # records regardless, hence the explicit queries.
     def destroy_all_associated_records
-      # Clear cached user_id on WorkspaceMembership (SaaS mode)
+      # Clear cached user_id and flip user_active on WorkspaceMembership (SaaS mode).
+      # user_active mirrors User#active? but the after_*_commit callback only fires on
+      # status changes — a hard destroy must explicitly drop the mirror or the
+      # workspace selector keeps surfacing an orphaned membership row.
       if Sabha.saas? && workspace_membership_id.present?
         WorkspaceMembership.where(id: workspace_membership_id, user_id: id)
-                           .update_all(user_id: nil)
+                           .update_all(user_id: nil, user_active: false)
       end
 
       # Delete messages first (they have FKs to boosts, bookmarks, notifications)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -364,18 +364,15 @@ class User < ApplicationRecord
 
   private
     # Mirror User#active? onto the untenanted WorkspaceMembership row so the
-    # workspace selector can filter without cross-tenant queries. Runs after
-    # the tenanted transaction commits, so a Postgres failure here cannot roll
-    # back the SQLite write. The auth-time guard reads the tenanted User row,
-    # so a stale mirror cannot let a banned user through — it can only hide a
-    # workspace the user should still see, and the rake backfill repairs that.
+    # workspace selector can filter without cross-tenant queries. Runs post-
+    # commit, so a Postgres failure here cannot roll back the SQLite write.
+    # The auth-time guard reads the tenanted User row, so a stale mirror can
+    # only hide a workspace the user should still see — repaired by the
+    # workspace_membership:backfill_user_active rake task.
     def sync_workspace_membership_active
-      return unless workspace_membership
-
-      workspace_membership.update(user_active: active?) ||
-        Rails.logger.error("[User#sync_workspace_membership_active] failed to mirror user_active=#{active?} for membership=#{workspace_membership.id}: #{workspace_membership.errors.full_messages.to_sentence}")
+      workspace_membership&.update_column(:user_active, active?)
     rescue ActiveRecord::ActiveRecordError => e
-      Rails.logger.error("[User#sync_workspace_membership_active] error mirroring user_active=#{active?} for user=#{id}: #{e.class}: #{e.message}")
+      Rails.logger.error("Failed to mirror user_active for workspace_membership=#{workspace_membership_id}: #{e.message}")
     end
 
     def deactivate_direct_rooms

--- a/app/models/user/bannable.rb
+++ b/app/models/user/bannable.rb
@@ -14,6 +14,7 @@ module User::Bannable
       bans.delete_all
       active!
     end
+    sync_workspace_membership_active(true)
   end
 
   def remove_banned_content_later

--- a/app/models/user/bannable.rb
+++ b/app/models/user/bannable.rb
@@ -14,7 +14,6 @@ module User::Bannable
       bans.delete_all
       active!
     end
-    sync_workspace_membership_active(true)
   end
 
   def remove_banned_content_later

--- a/app/models/user/bannable.rb
+++ b/app/models/user/bannable.rb
@@ -1,6 +1,10 @@
 module User::Bannable
   extend ActiveSupport::Concern
 
+  included do
+    after_update_commit :notify_of_ban_or_unban, if: :saved_change_to_status?
+  end
+
   def ban
     transaction do
       create_bans_from_sessions
@@ -41,5 +45,16 @@ module User::Bannable
     def apply_ban
       revoke_access
       remove_banned_content_later
+    end
+
+    def notify_of_ban_or_unban
+      return if bot? || email_address.blank?
+
+      from, to = saved_change_to_status
+      if to == "banned"
+        UserMailer.banned(self).deliver_later
+      elsif from == "banned" && to == "active"
+        UserMailer.unbanned(self).deliver_later
+      end
     end
 end

--- a/app/models/user/bannable.rb
+++ b/app/models/user/bannable.rb
@@ -2,7 +2,8 @@ module User::Bannable
   extend ActiveSupport::Concern
 
   included do
-    after_update_commit :notify_of_ban_or_unban, if: :saved_change_to_status?
+    after_update_commit :send_ban_email,   if: :ban_just_happened?
+    after_update_commit :send_unban_email, if: :unban_just_happened?
   end
 
   def ban
@@ -47,14 +48,24 @@ module User::Bannable
       remove_banned_content_later
     end
 
-    def notify_of_ban_or_unban
-      return if bot? || email_address.blank?
+    def send_ban_email
+      UserMailer.banned(self).deliver_later
+    end
 
-      from, to = saved_change_to_status
-      if to == "banned"
-        UserMailer.banned(self).deliver_later
-      elsif from == "banned" && to == "active"
-        UserMailer.unbanned(self).deliver_later
-      end
+    def send_unban_email
+      UserMailer.unbanned(self).deliver_later
+    end
+
+    def ban_just_happened?
+      saved_change_to_status? && banned? && notifiable_about_status?
+    end
+
+    def unban_just_happened?
+      return false unless saved_change_to_status? && notifiable_about_status?
+      saved_change_to_status.first == "banned" && active?
+    end
+
+    def notifiable_about_status?
+      !bot? && email_address.present?
     end
 end

--- a/app/views/user_mailer/banned.html.erb
+++ b/app/views/user_mailer/banned.html.erb
@@ -1,0 +1,5 @@
+<p>Hi <%= @user.name %>,</p>
+
+<p>Your access to <strong><%= @account_name %></strong> has been suspended by an administrator.</p>
+
+<p>If you believe this was a mistake, please reach out to the workspace administrator.</p>

--- a/app/views/user_mailer/banned.text.erb
+++ b/app/views/user_mailer/banned.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @user.name %>,
+
+Your access to <%= @account_name %> has been suspended by an administrator.
+
+If you believe this was a mistake, please reach out to the workspace administrator.

--- a/app/views/user_mailer/unbanned.html.erb
+++ b/app/views/user_mailer/unbanned.html.erb
@@ -1,0 +1,3 @@
+<p>Hi <%= @user.name %>,</p>
+
+<p>Your access to <strong><%= @account_name %></strong> has been restored. You can sign in again.</p>

--- a/app/views/user_mailer/unbanned.text.erb
+++ b/app/views/user_mailer/unbanned.text.erb
@@ -1,0 +1,3 @@
+Hi <%= @user.name %>,
+
+Your access to <%= @account_name %> has been restored. You can sign in again.

--- a/app/views/users/_ban_button.html.erb
+++ b/app/views/users/_ban_button.html.erb
@@ -1,14 +1,14 @@
 <% if user.active? %>
   <%= button_to user_ban_path(user), method: :post,
         class: "btn",
-        data: { turbo_confirm: "Are you sure you want to ban this user? This will log them out, delete their messages, and block their IP addresses." } do %>
+        data: { turbo_confirm: "Ban #{user.name}? This logs them out, permanently deletes their messages, removes them from rooms, and blocks their IP addresses." } do %>
     <%= icon_tag "cancel" %>
     <span>Ban</span>
   <% end %>
 <% else %>
   <%= button_to user_ban_path(user), method: :delete,
         class: "btn btn--negative",
-        data: { turbo_confirm: "Are you sure you want to remove the ban on this user?" } do %>
+        data: { turbo_confirm: "Remove the ban on #{user.name}? They can sign in again. Deleted messages and room memberships are not restored — they'll need to rejoin rooms." } do %>
     <%= icon_tag "cancel" %>
     <span>Remove ban</span>
   <% end %>

--- a/docs/testing/deny-banned-users.md
+++ b/docs/testing/deny-banned-users.md
@@ -3,17 +3,18 @@
 Branch: `deny-banned-workspace-users`
 
 This branch:
-- Mirrors `User#active?` onto `workspace_memberships.user_active` (SaaS) so the workspace selector can filter without crossing tenants.
-- Denies banned/deactivated users at session resume in SaaS, redirecting to the next available workspace (or `/workspaces/new`).
-- Drops the orphan `user_active` row when a User is hard-destroyed; restores it on rejoin.
+- **SaaS:** mirrors `User#active?` onto `workspace_memberships.user_active` so the workspace selector and `/settings` can filter without crossing tenants.
+- **SaaS:** denies banned/deactivated users at session resume and bounces them to `/settings?denied=workspace`, where a persistent banner explains the redirect. The settings list shows "Inactive" for any membership where the user lost access.
+- **Both modes:** sends an email notification when a user is banned and another when unbanned.
+- **SaaS:** drops the `user_active` mirror to `false` when a workspace User is hard-destroyed; restores to `true` on rejoin.
 
-Verify both modes — most behavior is SaaS-only, but self-hosted gets an audit pass to confirm no regressions.
+Verify both modes — most behavior is SaaS-only, but self-hosted gets a regression sweep plus the new mailer.
 
 ---
 
 ## Self-hosted
 
-The mirror callback is gated on `Sabha.saas?`, so all User lifecycle changes should behave exactly as before. This section is a regression sweep.
+The mirror is gated on `Sabha.saas?`. The mailer is not — ban/unban emails fire in both modes.
 
 ### Setup
 
@@ -33,23 +34,37 @@ Visit http://localhost:3000 and create the first admin via the welcome flow.
 2. As admin, visit the second user's profile and click **Ban**.
 3. Sign back in as the banned user (or refresh their tab).
 
-   *Expected:* banned user is logged out / cannot post / sees the banned state. ActionCable disconnects.
+   *Expected:*
+   - Banned user is logged out / cannot post / sees the banned state. ActionCable disconnects.
+   - **One ban-notification email is enqueued** to the banned user (subject: "Your access to … has been suspended"). Confirm in `letter_opener` or by tailing logs for `UserMailer#banned`.
 
 **SH-2. Admin unbans the member**
 
 1. Continuing from SH-1, as admin click **Unban** on the banned user's profile.
 2. Banned user signs in again.
 
-   *Expected:* full access restored.
+   *Expected:*
+   - Full access restored.
+   - **One unban-notification email is enqueued** (subject: "Your access to … has been restored").
 
 **SH-3. User leaves the workspace (deactivate)**
 
 1. Sign in as a non-admin member.
 2. Settings → leave workspace.
 
-   *Expected:* user is signed out, status becomes `deactivated`, direct rooms still appear for other members but the user can't post.
+   *Expected:*
+   - User is signed out, status becomes `deactivated`, direct rooms still appear for other members but the user can't post.
+   - **No email is sent** (only ban/unban transitions email; deactivate/reactivate do not).
 
-**SH-4. User hard-destroy via console**
+**SH-4. Reactivate a deactivated user (admin)**
+
+1. As admin, find the deactivated user and reactivate via the user profile.
+
+   *Expected:*
+   - User can sign in again.
+   - **No email** — only `banned → active` triggers the unban mailer; `deactivated → active` is silent.
+
+**SH-5. User hard-destroy via console**
 
 In a separate terminal:
 ```bash
@@ -58,11 +73,11 @@ bin/rails console
 > u.destroy!
 ```
 
-   *Expected:* no errors. Messages from this user are deleted, memberships cleaned, no FK violations.
+   *Expected:* no errors. Messages from this user are deleted, memberships cleaned, no FK violations. No email sent.
 
-**SH-5. Sanity: no `workspace_memberships` writes**
+**SH-6. Sanity: no `workspace_memberships` writes**
 
-Self-hosted has no `WorkspaceMembership` table. Confirm no errors mentioning `workspace_memberships` in the dev log during any of SH-1 through SH-4.
+Self-hosted has no `WorkspaceMembership` table. Confirm no errors mentioning `workspace_memberships` in the dev log during any of SH-1 through SH-5.
 
 ```bash
 grep -i workspace_membership log/development.log
@@ -74,7 +89,7 @@ grep -i workspace_membership log/development.log
 
 ## SaaS
 
-This is where the real behavior lives. You'll need at least 2 GlobalIdentities and 2 workspaces.
+This is where the new redirect, banner, and selector-filtering behavior lives. You'll need at least 2 GlobalIdentities and 2 workspaces.
 
 ### Setup
 
@@ -86,6 +101,28 @@ bin/dev
 Visit http://localhost:3000. Sign up via `/registration/new` for the first identity, create a workspace ("Acme"). Open a second browser (or incognito) and register a second identity, create a second workspace ("Beta") OR have it join Acme via an invite.
 
 OTP codes for sign-in: tail `log/development.log` for the magic link / code, or check `letter_opener` if enabled.
+
+### Backfill the mirror (one-time, post-migration)
+
+The new `workspace_memberships.user_active` column defaults to `true`, so memberships created **before** the migration ran will all be `true` — even when the per-tenant User is already banned/deactivated. Run the backfill once to repair existing data:
+
+```bash
+unset UNTENANTED_DATABASE_URL    # only if it's pointing at the test DB
+SAAS=true bin/rails workspace_membership:backfill_user_active
+```
+
+The task reads each tenant's `User.status` and flips `user_active=false` for any membership where the User is banned/deactivated. Output looks like:
+
+```
+Marked inactive: tenant=1000007 user_id=259 status=deactivated
+Marked inactive: tenant=1000006 user_id=511 status=deactivated
+...
+Done. Flipped 81 membership(s) to inactive. Skipped 0.
+```
+
+The same step is required in **production** after deploying this branch — without it, the workspace selector and `/settings` will keep surfacing inactive memberships until each User has a fresh status change. Add to the deploy runbook.
+
+The task writes only to `workspace_memberships` (via `update_column`) and **does not trigger the ban/unban mailer** — no emails are sent during backfill, even if it flips state for thousands of memberships.
 
 ### Helpful console snippets
 
@@ -117,28 +154,28 @@ WorkspaceMembership.find(N).update_column(:user_active, true)
    WorkspaceMembership.find_by(global_identity: GlobalIdentity.find_by(email_address: "bob@..."), tenant: "1000001").user_active
    ```
 
-   *Expected:* `false`.
+   *Expected:* `false`. **One ban email enqueued** to Bob.
 
 **SaaS-2. Unban restores `user_active` to true**
 
 1. Continuing: admin unbans Bob.
-2. Re-check the same SQL/console query.
+2. Re-check the same query.
 
-   *Expected:* `true`.
+   *Expected:* `true`. **One unban email enqueued** to Bob.
 
 **SaaS-3. Leave workspace flips `user_active` to false**
 
 1. Bob (signed in) navigates to the Acme workspace settings and leaves the workspace.
 2. Re-check `user_active` for Bob's Acme membership.
 
-   *Expected:* `false`. The membership row is preserved (so staff admin can still see the user).
+   *Expected:* `false`. The membership row is preserved (so staff admin can still see the user). **No email** (deactivate doesn't email).
 
 **SaaS-4. Rejoin restores `user_active` to true**
 
 1. Bob revisits a fresh invite link for Acme and joins.
 2. Re-check.
 
-   *Expected:* `true`.
+   *Expected:* `true`. No email.
 
 **SaaS-5. Hard-destroy flips `user_active` to false AND clears `user_id`**
 
@@ -152,7 +189,7 @@ WorkspaceMembership.find(N).update_column(:user_active, true)
 
 2. Inspect the membership.
 
-   *Expected:* `user_id: nil`, `user_active: false`.
+   *Expected:* `user_id: nil`, `user_active: false`. No email.
 
 **SaaS-6. Re-sign-in after destroy restores both**
 
@@ -163,62 +200,30 @@ WorkspaceMembership.find(N).update_column(:user_active, true)
 
 ---
 
-### B. Auth-time redirect
+### B. Auth-time redirect to `/settings`
 
-**SaaS-7. Banned user with one workspace lands on `/workspaces/new`**
+The deny guard always redirects to `/settings?denied=workspace` regardless of how many other workspaces the user has. The destination is intentional: it shows the user their full workspace list (with "Inactive" labels) and avoids redirect-chain flash issues.
 
-1. Admin bans Bob in Acme. Bob has no other workspaces.
+**SaaS-7. Banned user is bounced to /settings**
+
+1. Admin bans Bob in Acme. (Bob may have other workspaces or not — doesn't matter.)
 2. Bob refreshes any Acme URL (e.g. `/1000001/`).
 
-   *Expected:* redirected directly to `/workspaces/new`. Page shows "You're not part of any workspace yet" and an alert: "You no longer have access to this workspace." No transit through `/workspaces`.
+   *Expected:*
+   - Redirect to `/settings?denied=workspace`.
+   - **Persistent red banner** at the top of the page: "You no longer have access to that workspace."
+   - The banner does NOT auto-fade. Refresh keeps it (the query param is in the URL). It clears when the user clicks any link to `/settings` without the param.
 
-**SaaS-8. Banned user with another workspace lands on the next workspace**
+**SaaS-8. Deactivated user (left workspace) is also bounced to /settings**
 
-1. Bob is a member of both Acme and Beta. Admin bans Bob in Acme.
-2. Bob refreshes an Acme URL.
+1. Bob leaves Acme.
+2. Bob refreshes any Acme URL.
 
-   *Expected:* redirected directly to `/{Beta_external_id}` (Beta's root). Alert: "You no longer have access to this workspace."
+   *Expected:* same as SaaS-7 — `/settings?denied=workspace` with the banner.
 
-**SaaS-9. Deactivated user (left workspace) is treated like banned**
+**SaaS-9. Drift case fail-closes**
 
-1. Bob leaves Acme. He still has access to Beta.
-2. Bob refreshes an Acme URL.
-
-   *Expected:* redirected to Beta. Same alert.
-
-**SaaS-10. Deactivated user with no other workspaces lands on `/workspaces/new`**
-
-1. Bob leaves his only workspace.
-2. Bob refreshes the Acme URL (or the URL he had open).
-
-   *Expected:* `/workspaces/new`.
-
----
-
-### C. Workspace selector / sidebar
-
-**SaaS-11. Banned workspace is hidden from the sidebar**
-
-1. Bob is a member of Acme + Beta. Bob is signed in and on Beta's root page.
-2. Admin bans Bob in Acme.
-3. Bob reloads Beta.
-
-   *Expected:* the sidebar workspace selector shows Beta only — no link to Acme.
-
-**SaaS-12. Banned workspace is hidden from `/workspaces`**
-
-1. Same as SaaS-11.
-2. Bob navigates to `/workspaces` directly.
-
-   *Expected:* redirects to Beta (the only active workspace), not Acme.
-
----
-
-### D. Drift / defense-in-depth
-
-**SaaS-13. Stale `user_active=true` doesn't bypass the auth guard**
-
-The mirror is a hint for the selector, not a security control. The auth guard reads the tenanted `User` row.
+The mirror is a hint, not a security control. The auth guard reads the tenanted `User` row.
 
 1. Admin bans Bob in Acme.
 2. In console, manually corrupt the mirror:
@@ -229,43 +234,107 @@ The mirror is a hint for the selector, not a security control. The auth guard re
 
 3. Bob reloads an Acme URL.
 
-   *Expected:* still gets bounced — auth guard reads `User#banned?` from SQLite and redirects. Alert shows.
+   *Expected:* still bounced to `/settings?denied=workspace`. The auth guard reads `User#banned?` from SQLite and ignores the stale mirror.
 
-**SaaS-14. Mirror write failure doesn't roll back the ban**
+---
 
-This is harder to reproduce manually — it's covered by `WorkspaceMembershipTest#test_mirror_write_failure_logs_and_does_not_roll_back_the_User#deactivate_transaction`. Skip unless you're specifically suspicious.
+### C. Workspace selector & settings list
+
+**SaaS-10. Banned workspace is hidden from the sidebar**
+
+1. Bob is a member of Acme + Beta. Bob is signed in on Beta.
+2. Admin bans Bob in Acme.
+3. Bob reloads Beta.
+
+   *Expected:* sidebar shows Beta only — no Acme.
+
+**SaaS-11. Banned workspace shows on `/settings` with "Inactive" label**
+
+1. Continuing: Bob navigates to `/settings`.
+
+   *Expected:*
+   - All workspaces Bob has memberships in are listed.
+   - For Acme (banned), the role label reads **"Inactive"** (where active workspaces show "Member" or "Administrator").
+   - Clicking the Acme row attempts to navigate to its tenanted settings → bounces back to `/settings?denied=workspace` (the deny guard catches it).
+
+**SaaS-12. `/workspaces` redirect skips banned workspaces**
+
+1. Same setup as SaaS-10.
+2. Bob navigates to `/workspaces` directly.
+
+   *Expected:* redirects to Beta (the only active workspace). Acme is not picked.
+
+---
+
+### D. Drift / defense-in-depth
+
+**SaaS-13. Mirror write failure doesn't roll back the ban**
+
+Hard to reproduce manually — covered by `WorkspaceMembershipTest#test_mirror_write_failure_logs_and_does_not_roll_back_the_User#deactivate_transaction`. Skip unless you're specifically suspicious.
 
 ---
 
 ### E. Join flow
 
-**SaaS-15. Banned member visiting a join URL is redirected away**
+**SaaS-14. Banned member visiting a join URL is redirected away**
 
 1. Bob is banned from Acme. Acme has an active invite link (e.g. `/1000001/join/ABC123`).
 2. Bob visits the join URL while signed in.
 
-   *Expected:* Bob is redirected — NOT into Acme. Lands on Beta (if he's a member) or `/workspaces/new`. Alert: "You no longer have access to this workspace."
+   *Expected:* redirected to `/settings?denied=workspace` — NOT into Acme.
 
 ---
 
 ### F. Cross-session / multi-tab
 
-**SaaS-16. Active session gets kicked on next request after ban**
+**SaaS-15. Active session gets kicked on next request after ban**
 
 1. Bob is signed in and active on Acme in browser tab 1.
 2. Admin bans Bob in browser tab 2.
 3. Bob clicks any link in tab 1 (no full reload).
 
-   *Expected:* Bob is redirected to next workspace or `/workspaces/new`. ActionCable disconnects (existing behavior — see `app/channels/application_cable/connection.rb`).
+   *Expected:*
+   - Bob is redirected to `/settings?denied=workspace`.
+   - ActionCable disconnects (existing behavior — see `app/channels/application_cable/connection.rb`).
+   - **Ban-notification email** also enqueued (from step 2's admin action).
+
+---
+
+### G. Email notifications
+
+**SaaS-16. Ban triggers exactly one email per ban transition**
+
+1. Admin bans Bob in Acme.
+
+   *Expected:* exactly one email enqueued via `UserMailer#banned`. Subject: "Your access to {Acme account name} has been suspended".
+
+2. Admin unbans Bob.
+
+   *Expected:* exactly one email enqueued via `UserMailer#unbanned`. Subject: "Your access to {Acme account name} has been restored".
+
+**SaaS-17. Other lifecycle transitions do NOT email**
+
+1. Bob leaves a workspace (deactivate).
+2. Bob rejoins via invite (deactivated → active).
+3. A user gets hard-destroyed.
+
+   *Expected:* no `UserMailer#banned` or `UserMailer#unbanned` mail enqueued for any of these.
+
+**SaaS-18. Bots and emailless users don't trigger mail**
+
+1. Ban a bot user (if you have one set up).
+
+   *Expected:* no email enqueued (the callback short-circuits on `bot?`).
 
 ---
 
 ## Sign-off checklist
 
-- [ ] Self-hosted: SH-1 through SH-5 pass; no `workspace_memberships` writes in log
+- [ ] Self-hosted: SH-1 through SH-6 pass; ban/unban emails arrive; no `workspace_memberships` writes in log
 - [ ] SaaS Mirror (A): SaaS-1 through SaaS-6 pass; column matches User state in every case
-- [ ] SaaS Redirect (B): SaaS-7 through SaaS-10 pass; no double-redirect through `/workspaces`
-- [ ] SaaS Sidebar (C): SaaS-11, SaaS-12 pass; banned workspace never linked
-- [ ] SaaS Drift (D): SaaS-13 still denies access despite stale mirror
-- [ ] SaaS Join (E): SaaS-15 redirects away from banned workspace
-- [ ] SaaS Multi-tab (F): SaaS-16 kicks active session on next request
+- [ ] SaaS Redirect (B): SaaS-7 through SaaS-9 pass; banner is persistent and doesn't auto-fade
+- [ ] SaaS Selector & Settings list (C): SaaS-10 through SaaS-12; banned workspace hidden from sidebar, "Inactive" label on /settings
+- [ ] SaaS Drift (D): SaaS-13 covered by automated test
+- [ ] SaaS Join (E): SaaS-14 redirects to `/settings?denied=workspace`
+- [ ] SaaS Multi-tab (F): SaaS-15 kicks active session on next request, ban email arrives
+- [ ] SaaS Mailer (G): SaaS-16 sends exactly one email per ban/unban; SaaS-17 confirms other transitions are silent; SaaS-18 confirms bot/emailless users are skipped

--- a/docs/testing/deny-banned-users.md
+++ b/docs/testing/deny-banned-users.md
@@ -1,0 +1,271 @@
+# Manual testing: deny banned/deactivated workspace users
+
+Branch: `deny-banned-workspace-users`
+
+This branch:
+- Mirrors `User#active?` onto `workspace_memberships.user_active` (SaaS) so the workspace selector can filter without crossing tenants.
+- Denies banned/deactivated users at session resume in SaaS, redirecting to the next available workspace (or `/workspaces/new`).
+- Drops the orphan `user_active` row when a User is hard-destroyed; restores it on rejoin.
+
+Verify both modes — most behavior is SaaS-only, but self-hosted gets an audit pass to confirm no regressions.
+
+---
+
+## Self-hosted
+
+The mirror callback is gated on `Sabha.saas?`, so all User lifecycle changes should behave exactly as before. This section is a regression sweep.
+
+### Setup
+
+```bash
+bin/rails saas:disable && bundle install   # only if SAAS was previously enabled
+bin/setup
+bin/dev
+```
+
+Visit http://localhost:3000 and create the first admin via the welcome flow.
+
+### Scenarios
+
+**SH-1. Admin bans a member**
+
+1. Sign in as admin. Invite a second user, sign them in (separate browser).
+2. As admin, visit the second user's profile and click **Ban**.
+3. Sign back in as the banned user (or refresh their tab).
+
+   *Expected:* banned user is logged out / cannot post / sees the banned state. ActionCable disconnects.
+
+**SH-2. Admin unbans the member**
+
+1. Continuing from SH-1, as admin click **Unban** on the banned user's profile.
+2. Banned user signs in again.
+
+   *Expected:* full access restored.
+
+**SH-3. User leaves the workspace (deactivate)**
+
+1. Sign in as a non-admin member.
+2. Settings → leave workspace.
+
+   *Expected:* user is signed out, status becomes `deactivated`, direct rooms still appear for other members but the user can't post.
+
+**SH-4. User hard-destroy via console**
+
+In a separate terminal:
+```bash
+bin/rails console
+> u = User.find_by(email_address: "test@example.com")
+> u.destroy!
+```
+
+   *Expected:* no errors. Messages from this user are deleted, memberships cleaned, no FK violations.
+
+**SH-5. Sanity: no `workspace_memberships` writes**
+
+Self-hosted has no `WorkspaceMembership` table. Confirm no errors mentioning `workspace_memberships` in the dev log during any of SH-1 through SH-4.
+
+```bash
+grep -i workspace_membership log/development.log
+```
+
+   *Expected:* no output.
+
+---
+
+## SaaS
+
+This is where the real behavior lives. You'll need at least 2 GlobalIdentities and 2 workspaces.
+
+### Setup
+
+```bash
+bin/rails saas:enable && bundle install && bin/rails saas:setup
+bin/dev
+```
+
+Visit http://localhost:3000. Sign up via `/registration/new` for the first identity, create a workspace ("Acme"). Open a second browser (or incognito) and register a second identity, create a second workspace ("Beta") OR have it join Acme via an invite.
+
+OTP codes for sign-in: tail `log/development.log` for the magic link / code, or check `letter_opener` if enabled.
+
+### Helpful console snippets
+
+```ruby
+# Inspect the mirror state
+WorkspaceMembership.all.pluck(:tenant, :global_identity_id, :user_id, :user_active)
+
+# Ban a user inside a tenant
+ApplicationRecord.with_tenant("1000001") { User.find(1).ban }
+
+# Force a stale mirror (drift case)
+WorkspaceMembership.find(N).update_column(:user_active, true)
+```
+
+`unset UNTENANTED_DATABASE_URL` before running console if it complains about Postgres.
+
+---
+
+### A. Mirror updates (untenanted Postgres ← tenanted SQLite)
+
+**SaaS-1. Ban flips `user_active` to false**
+
+1. Sign in as Acme admin.
+2. From a separate session, sign in a member ("Bob"). Confirm Bob can read messages.
+3. As admin, ban Bob from his profile page.
+4. In console:
+
+   ```ruby
+   WorkspaceMembership.find_by(global_identity: GlobalIdentity.find_by(email_address: "bob@..."), tenant: "1000001").user_active
+   ```
+
+   *Expected:* `false`.
+
+**SaaS-2. Unban restores `user_active` to true**
+
+1. Continuing: admin unbans Bob.
+2. Re-check the same SQL/console query.
+
+   *Expected:* `true`.
+
+**SaaS-3. Leave workspace flips `user_active` to false**
+
+1. Bob (signed in) navigates to the Acme workspace settings and leaves the workspace.
+2. Re-check `user_active` for Bob's Acme membership.
+
+   *Expected:* `false`. The membership row is preserved (so staff admin can still see the user).
+
+**SaaS-4. Rejoin restores `user_active` to true**
+
+1. Bob revisits a fresh invite link for Acme and joins.
+2. Re-check.
+
+   *Expected:* `true`.
+
+**SaaS-5. Hard-destroy flips `user_active` to false AND clears `user_id`**
+
+1. In console:
+
+   ```ruby
+   ApplicationRecord.with_tenant("1000001") do
+     User.find_by(email_address: "bob@...").destroy!
+   end
+   ```
+
+2. Inspect the membership.
+
+   *Expected:* `user_id: nil`, `user_active: false`.
+
+**SaaS-6. Re-sign-in after destroy restores both**
+
+1. Bob signs back into Acme via a join link or the workspace selector (existing membership row).
+2. Inspect the membership.
+
+   *Expected:* `user_id` is set to a new value, `user_active: true`. Bob has access.
+
+---
+
+### B. Auth-time redirect
+
+**SaaS-7. Banned user with one workspace lands on `/workspaces/new`**
+
+1. Admin bans Bob in Acme. Bob has no other workspaces.
+2. Bob refreshes any Acme URL (e.g. `/1000001/`).
+
+   *Expected:* redirected directly to `/workspaces/new`. Page shows "You're not part of any workspace yet" and an alert: "You no longer have access to this workspace." No transit through `/workspaces`.
+
+**SaaS-8. Banned user with another workspace lands on the next workspace**
+
+1. Bob is a member of both Acme and Beta. Admin bans Bob in Acme.
+2. Bob refreshes an Acme URL.
+
+   *Expected:* redirected directly to `/{Beta_external_id}` (Beta's root). Alert: "You no longer have access to this workspace."
+
+**SaaS-9. Deactivated user (left workspace) is treated like banned**
+
+1. Bob leaves Acme. He still has access to Beta.
+2. Bob refreshes an Acme URL.
+
+   *Expected:* redirected to Beta. Same alert.
+
+**SaaS-10. Deactivated user with no other workspaces lands on `/workspaces/new`**
+
+1. Bob leaves his only workspace.
+2. Bob refreshes the Acme URL (or the URL he had open).
+
+   *Expected:* `/workspaces/new`.
+
+---
+
+### C. Workspace selector / sidebar
+
+**SaaS-11. Banned workspace is hidden from the sidebar**
+
+1. Bob is a member of Acme + Beta. Bob is signed in and on Beta's root page.
+2. Admin bans Bob in Acme.
+3. Bob reloads Beta.
+
+   *Expected:* the sidebar workspace selector shows Beta only — no link to Acme.
+
+**SaaS-12. Banned workspace is hidden from `/workspaces`**
+
+1. Same as SaaS-11.
+2. Bob navigates to `/workspaces` directly.
+
+   *Expected:* redirects to Beta (the only active workspace), not Acme.
+
+---
+
+### D. Drift / defense-in-depth
+
+**SaaS-13. Stale `user_active=true` doesn't bypass the auth guard**
+
+The mirror is a hint for the selector, not a security control. The auth guard reads the tenanted `User` row.
+
+1. Admin bans Bob in Acme.
+2. In console, manually corrupt the mirror:
+
+   ```ruby
+   WorkspaceMembership.find_by(global_identity: GlobalIdentity.find_by(email_address: "bob@..."), tenant: "1000001").update_column(:user_active, true)
+   ```
+
+3. Bob reloads an Acme URL.
+
+   *Expected:* still gets bounced — auth guard reads `User#banned?` from SQLite and redirects. Alert shows.
+
+**SaaS-14. Mirror write failure doesn't roll back the ban**
+
+This is harder to reproduce manually — it's covered by `WorkspaceMembershipTest#test_mirror_write_failure_logs_and_does_not_roll_back_the_User#deactivate_transaction`. Skip unless you're specifically suspicious.
+
+---
+
+### E. Join flow
+
+**SaaS-15. Banned member visiting a join URL is redirected away**
+
+1. Bob is banned from Acme. Acme has an active invite link (e.g. `/1000001/join/ABC123`).
+2. Bob visits the join URL while signed in.
+
+   *Expected:* Bob is redirected — NOT into Acme. Lands on Beta (if he's a member) or `/workspaces/new`. Alert: "You no longer have access to this workspace."
+
+---
+
+### F. Cross-session / multi-tab
+
+**SaaS-16. Active session gets kicked on next request after ban**
+
+1. Bob is signed in and active on Acme in browser tab 1.
+2. Admin bans Bob in browser tab 2.
+3. Bob clicks any link in tab 1 (no full reload).
+
+   *Expected:* Bob is redirected to next workspace or `/workspaces/new`. ActionCable disconnects (existing behavior — see `app/channels/application_cable/connection.rb`).
+
+---
+
+## Sign-off checklist
+
+- [ ] Self-hosted: SH-1 through SH-5 pass; no `workspace_memberships` writes in log
+- [ ] SaaS Mirror (A): SaaS-1 through SaaS-6 pass; column matches User state in every case
+- [ ] SaaS Redirect (B): SaaS-7 through SaaS-10 pass; no double-redirect through `/workspaces`
+- [ ] SaaS Sidebar (C): SaaS-11, SaaS-12 pass; banned workspace never linked
+- [ ] SaaS Drift (D): SaaS-13 still denies access despite stale mirror
+- [ ] SaaS Join (E): SaaS-15 redirects away from banned workspace
+- [ ] SaaS Multi-tab (F): SaaS-16 kicks active session on next request

--- a/lib/tasks/workspace_membership_backfill.rake
+++ b/lib/tasks/workspace_membership_backfill.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :workspace_membership do
+  desc "Backfill workspace_memberships.user_active by reading each workspace's User.status"
+  task backfill_user_active: :environment do
+    unless Sabha.saas?
+      puts "SaaS mode is not enabled. Run with SAAS=true or bin/rails saas:enable"
+      exit 1
+    end
+
+    flipped = 0
+    skipped = 0
+
+    WorkspaceMembership.where(user_active: true).find_each do |m|
+      next skipped += 1 if m.user_id.blank?
+
+      ApplicationRecord.with_tenant(m.tenant) do
+        user = User.find_by(id: m.user_id)
+        if user && !user.active?
+          m.update_column(:user_active, false)
+          flipped += 1
+          puts "  Marked inactive: tenant=#{m.tenant} user_id=#{m.user_id} status=#{user.status}"
+        end
+      rescue ActiveRecord::Tenanted::TenantDoesNotExistError
+        skipped += 1
+      end
+    end
+
+    puts "Done. Flipped #{flipped} membership(s) to inactive. Skipped #{skipped}."
+  end
+end

--- a/saas/app/assets/stylesheets/saas_settings.css
+++ b/saas/app/assets/stylesheets/saas_settings.css
@@ -69,3 +69,19 @@
     }
   }
 }
+
+/* Persistent alert above the settings grid. Used when the deny guard bounces
+   a banned/deactivated user here — flash auto-fades after 3s and Turbo
+   refetches eat it, so this is rendered as page content from a query param. */
+.settings-banner {
+  margin: var(--block-space) auto 0;
+  max-inline-size: 100ch;
+  padding: 0 var(--block-space);
+}
+
+.settings-banner__inner {
+  background: var(--color-negative);
+  border-radius: 0.5rem;
+  color: white;
+  padding: 0.875rem 1.25rem;
+}

--- a/saas/app/controllers/saas/settings_controller.rb
+++ b/saas/app/controllers/saas/settings_controller.rb
@@ -13,6 +13,7 @@ module Saas
     def show
       @global_identity = current_global_identity
       @workspace_memberships = current_global_identity.workspace_memberships_with_workspaces
+      @workspace_access_denied = params[:denied] == "workspace"
     end
 
     def update

--- a/saas/app/controllers/saas/workspaces_controller.rb
+++ b/saas/app/controllers/saas/workspaces_controller.rb
@@ -5,7 +5,10 @@ module Saas
     # Workspace management (outside workspace context)
 
     def index
-      # Always redirect - workspace selection happens via sidebar, not this page
+      # Always redirect — workspace selection happens via sidebar, not this page.
+      # flash.keep so flashes set by callers (e.g. the deny-inactive-user guard
+      # in Authentication) survive this transit hop and reach the rendered destination.
+      flash.keep
       workspaces = current_global_identity.active_workspaces_recent_first
 
       if workspaces.any?

--- a/saas/app/controllers/saas/workspaces_controller.rb
+++ b/saas/app/controllers/saas/workspaces_controller.rb
@@ -6,9 +6,6 @@ module Saas
 
     def index
       # Always redirect — workspace selection happens via sidebar, not this page.
-      # flash.keep so flashes set by callers (e.g. the deny-inactive-user guard
-      # in Authentication) survive this transit hop and reach the rendered destination.
-      flash.keep
       workspaces = current_global_identity.active_workspaces_recent_first
 
       if workspaces.any?

--- a/saas/app/controllers/saas/workspaces_controller.rb
+++ b/saas/app/controllers/saas/workspaces_controller.rb
@@ -5,7 +5,7 @@ module Saas
     # Workspace management (outside workspace context)
 
     def index
-      # Always redirect — workspace selection happens via sidebar, not this page.
+      # Always redirect - workspace selection happens via sidebar, not this page
       workspaces = current_global_identity.active_workspaces_recent_first
 
       if workspaces.any?

--- a/saas/app/helpers/workspace_selector_helper.rb
+++ b/saas/app/helpers/workspace_selector_helper.rb
@@ -34,7 +34,8 @@ module WorkspaceSelectorHelper
   def workspace_selector_workspaces
     return [] unless Current.global_identity
 
-    Current.global_identity.workspace_memberships_ordered.filter_map(&:workspace).select(&:active?)
+    Current.global_identity.workspace_memberships_ordered.user_active
+      .filter_map { |m| m.workspace if m.workspace&.active? }
   end
 
   def workspace_url(workspace)

--- a/saas/app/helpers/workspace_selector_helper.rb
+++ b/saas/app/helpers/workspace_selector_helper.rb
@@ -45,4 +45,12 @@ module WorkspaceSelectorHelper
   def workspace_logo_url(workspace)
     account_logo_path(script_name: workspace.slug, size: "small")
   end
+
+  # "Inactive" hides the specific reason (banned vs. deactivated) from the
+  # member's own settings list. Falls back to "Member" when the User row
+  # exists but has no role (legacy/edge case).
+  def workspace_role_label(membership)
+    return "Inactive" if membership.inactive?
+    membership.user&.role&.capitalize || "Member"
+  end
 end

--- a/saas/app/models/global_identity.rb
+++ b/saas/app/models/global_identity.rb
@@ -65,10 +65,10 @@ class GlobalIdentity < UntenantedRecord
   end
 
   def active_workspaces_recent_first
-    workspace_memberships
+    workspace_memberships.user_active
       .includes(:workspace)
       .order(updated_at: :desc)
-      .filter_map { |m| m.workspace if m.workspace&.active? && m.user_active? }
+      .filter_map { |m| m.workspace if m.workspace&.active? }
   end
 
   # Get workspace memberships in user-defined order (for workspace selector)

--- a/saas/app/models/global_identity.rb
+++ b/saas/app/models/global_identity.rb
@@ -68,8 +68,7 @@ class GlobalIdentity < UntenantedRecord
     workspace_memberships
       .includes(:workspace)
       .order(updated_at: :desc)
-      .filter_map(&:workspace)
-      .select(&:active?)
+      .filter_map { |m| m.workspace if m.workspace&.active? && m.user_active? }
   end
 
   # Get workspace memberships in user-defined order (for workspace selector)

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -86,8 +86,8 @@ class WorkspaceMembership < UntenantedRecord
   # Update the cached user_id and reset the user_active mirror. Linking a new
   # User to a membership implies the user is active — necessary for the rejoin
   # path after a hard destroy, which left user_active=false on the orphan row.
-  def cache_user_id!(user_id)
-    update_columns(user_id: user_id, user_active: true)
+  def cache_user_id!(id)
+    update_columns(user_id: id, user_active: true)
   end
 
   # True when the per-workspace User has been banned or deactivated. Mirrors

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -90,12 +90,10 @@ class WorkspaceMembership < UntenantedRecord
     update_columns(user_id: user_id, user_active: true)
   end
 
-  # Display label for the workspace selector / settings list. Reads "Inactive"
-  # for banned/deactivated users so the row reflects the reason it's there
-  # without leaking the specific reason.
-  def role_label
-    return "Inactive" unless user_active
-    user&.role&.capitalize || "Member"
+  # True when the per-workspace User has been banned or deactivated. Mirrors
+  # User#active?'s inverse via the user_active cache column — see scope above.
+  def inactive?
+    !user_active
   end
 
   # Create or find the User record in the workspace database

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -90,6 +90,14 @@ class WorkspaceMembership < UntenantedRecord
     update_columns(user_id: user_id, user_active: true)
   end
 
+  # Display label for the workspace selector / settings list. Reads "Inactive"
+  # for banned/deactivated users so the row reflects the reason it's there
+  # without leaking the specific reason.
+  def role_label
+    return "Inactive" unless user_active
+    user&.role&.capitalize || "Member"
+  end
+
   # Create or find the User record in the workspace database
   # Uses find_or_create pattern to be idempotent
   # Reactivates deactivated users on rejoin

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -83,9 +83,11 @@ class WorkspaceMembership < UntenantedRecord
     nil
   end
 
-  # Update the cached user_id
+  # Update the cached user_id and reset the user_active mirror. Linking a new
+  # User to a membership implies the user is active — necessary for the rejoin
+  # path after a hard destroy, which left user_active=false on the orphan row.
   def cache_user_id!(user_id)
-    update_column(:user_id, user_id)
+    update_columns(user_id: user_id, user_active: true)
   end
 
   # Create or find the User record in the workspace database

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -64,6 +64,20 @@ class WorkspaceMembership < UntenantedRecord
     nil
   end
 
+  # Whether the workspace user is in :active status. Used to filter the workspace
+  # selector so banned/deactivated members don't get bounced back into a workspace
+  # they can't access. Returns true for first-time visitors (user_id blank) and
+  # when the tenant DB is unreachable, to avoid hiding workspaces on infra hiccups.
+  def user_active?
+    return true if user_id.blank?
+
+    ApplicationRecord.with_tenant(tenant) do
+      User.active.where(id: user_id).exists?
+    end
+  rescue ActiveRecord::Tenanted::TenantDoesNotExistError
+    true
+  end
+
   # Get the Account name for this workspace
   def account_name
     ApplicationRecord.with_tenant(tenant) do

--- a/saas/app/models/workspace_membership.rb
+++ b/saas/app/models/workspace_membership.rb
@@ -64,19 +64,15 @@ class WorkspaceMembership < UntenantedRecord
     nil
   end
 
-  # Whether the workspace user is in :active status. Used to filter the workspace
-  # selector so banned/deactivated members don't get bounced back into a workspace
-  # they can't access. Returns true for first-time visitors (user_id blank) and
-  # when the tenant DB is unreachable, to avoid hiding workspaces on infra hiccups.
-  def user_active?
-    return true if user_id.blank?
-
-    ApplicationRecord.with_tenant(tenant) do
-      User.active.where(id: user_id).exists?
-    end
-  rescue ActiveRecord::Tenanted::TenantDoesNotExistError
-    true
-  end
+  # Mirror of the per-workspace User's :active status. Source of truth lives on
+  # the tenanted User row; the `user_active` column is a denormalized cache
+  # updated by User#revoke_access / User#unban / User#reactivate so the workspace
+  # selector can filter without cross-tenant queries (activerecord-tenanted
+  # prohibits shard swapping inside an active tenant context). NOTE: this is
+  # NOT the Deactivatable soft-delete pattern — the membership row is preserved
+  # for staff visibility (Admin::WorkspaceMembersController etc.) regardless of
+  # this flag.
+  scope :user_active, -> { where(user_active: true) }
 
   # Get the Account name for this workspace
   def account_name

--- a/saas/app/views/saas/settings/show.html.erb
+++ b/saas/app/views/saas/settings/show.html.erb
@@ -33,7 +33,7 @@
                 </div>
                 <div class="flex flex-column">
                   <strong><%= workspace.name %></strong>
-                  <span class="txt-small txt-muted"><%= membership.role_label %></span>
+                  <span class="txt-small txt-muted"><%= workspace_role_label(membership) %></span>
                 </div>
               </div>
               <%= icon_tag "arrow-right", class: "txt-muted" %>

--- a/saas/app/views/saas/settings/show.html.erb
+++ b/saas/app/views/saas/settings/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "Settings" %>
 
 <% if @workspace_access_denied %>
-  <div role="alert" style="max-inline-size: 100ch; margin: var(--block-space) auto 0; padding: 0 var(--block-space);">
-    <div style="background: var(--color-negative); color: white; padding: 0.875rem 1.25rem; border-radius: 0.5rem;">
+  <div role="alert" class="settings-banner">
+    <div class="settings-banner__inner">
       You no longer have access to that workspace.
     </div>
   </div>
@@ -20,7 +20,6 @@
         <div class="flex flex-column gap-half">
           <% @workspace_memberships.each do |membership| %>
             <% workspace = membership.workspace %>
-            <% user = membership.user %>
 
             <%= link_to settings_path(script_name: workspace.slug),
                   class: "flex align-center justify-space-between pad-block-half pad-inline gap txt-undecorated" do %>
@@ -34,9 +33,7 @@
                 </div>
                 <div class="flex flex-column">
                   <strong><%= workspace.name %></strong>
-                  <span class="txt-small txt-muted">
-                    <%= membership.user_active ? (user&.role&.capitalize || "Member") : "Inactive" %>
-                  </span>
+                  <span class="txt-small txt-muted"><%= membership.role_label %></span>
                 </div>
               </div>
               <%= icon_tag "arrow-right", class: "txt-muted" %>

--- a/saas/app/views/saas/settings/show.html.erb
+++ b/saas/app/views/saas/settings/show.html.erb
@@ -34,7 +34,9 @@
                 </div>
                 <div class="flex flex-column">
                   <strong><%= workspace.name %></strong>
-                  <span class="txt-small txt-muted"><%= user&.role&.capitalize || "Member" %></span>
+                  <span class="txt-small txt-muted">
+                    <%= membership.user_active ? (user&.role&.capitalize || "Member") : "Inactive" %>
+                  </span>
                 </div>
               </div>
               <%= icon_tag "arrow-right", class: "txt-muted" %>

--- a/saas/app/views/saas/settings/show.html.erb
+++ b/saas/app/views/saas/settings/show.html.erb
@@ -1,5 +1,13 @@
 <% content_for :title, "Settings" %>
 
+<% if @workspace_access_denied %>
+  <div role="alert" style="max-inline-size: 100ch; margin: var(--block-space) auto 0; padding: 0 var(--block-space);">
+    <div style="background: var(--color-negative); color: white; padding: 0.875rem 1.25rem; border-radius: 0.5rem;">
+      You no longer have access to that workspace.
+    </div>
+  </div>
+<% end %>
+
 <div class="saas-settings settings-layout">
   <%# Workspaces Section %>
   <div class="panel">

--- a/saas/db/untenanted_migrate/20260507000001_add_user_active_to_workspace_memberships.rb
+++ b/saas/db/untenanted_migrate/20260507000001_add_user_active_to_workspace_memberships.rb
@@ -1,0 +1,12 @@
+class AddUserActiveToWorkspaceMemberships < ActiveRecord::Migration[8.2]
+  disable_ddl_transaction!
+
+  def change
+    # Denormalized mirror of the per-tenant User#active? — updated by the User
+    # lifecycle methods (revoke_access, unban, reactivate) so the workspace
+    # selector can filter without cross-tenant queries (activerecord-tenanted
+    # forbids shard swapping inside an active tenant context).
+    add_column :workspace_memberships, :user_active, :boolean, default: true, null: false
+    add_index :workspace_memberships, [ :global_identity_id, :user_active ], algorithm: :concurrently
+  end
+end

--- a/saas/db/untenanted_schema.rb
+++ b/saas/db/untenanted_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_03_000001) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_07_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -75,9 +75,11 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_03_000001) do
     t.integer "position"
     t.string "tenant", null: false
     t.datetime "updated_at", null: false
+    t.boolean "user_active", default: true, null: false
     t.bigint "user_id"
     t.index ["global_identity_id", "position"], name: "index_workspace_memberships_on_global_identity_id_and_position"
     t.index ["global_identity_id", "tenant"], name: "index_workspace_memberships_on_global_identity_id_and_tenant", unique: true
+    t.index ["global_identity_id", "user_active"], name: "idx_on_global_identity_id_user_active_ea0fe19527"
     t.index ["tenant"], name: "index_workspace_memberships_on_tenant"
   end
 

--- a/saas/test/controllers/saas/authentication_test.rb
+++ b/saas/test/controllers/saas/authentication_test.rb
@@ -145,7 +145,7 @@ module Saas
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
     end
 
-    test "banned workspace user with no other workspaces lands on workspace selector without sidebar link to the banned workspace" do
+    test "banned workspace user with no other workspaces lands on new-workspace page without sidebar link to the banned workspace" do
       identity = GlobalIdentity.create!(email_address: "ban-tester@example.com", name: "Ban Tester")
       workspace = Workspace.create_with_database!(name: "Ban Test", creator: identity)
       sign_in_global_identity(identity)
@@ -157,12 +157,10 @@ module Saas
 
       workspace_get "/", workspace: workspace
 
-      assert_redirected_to "/workspaces"
+      assert_redirected_to "/workspaces/new"
       assert_equal "You no longer have access to this workspace.", flash[:alert]
-      follow_redirect! while response.redirect?
+      follow_redirect!
       assert_response :success
-      assert_match "You no longer have access to this workspace.", response.body,
-        "flash must survive the redirect chain and be rendered to the user"
       assert_no_match %r{href=["']/#{workspace.external_id}(/|["'])},
         response.body,
         "rendered page must not link back to the banned workspace (sidebar would bounce the user)"
@@ -173,7 +171,7 @@ module Saas
       identity&.destroy
     end
 
-    test "banned user with multiple workspaces sees no link to the banned workspace from the destination workspace's sidebar" do
+    test "banned user with multiple workspaces is redirected directly to the next available workspace" do
       identity = GlobalIdentity.create!(email_address: "multi-ban@example.com", name: "Multi Ban")
       banned_workspace = Workspace.create_with_database!(name: "Banned WS", creator: identity)
       other_workspace = Workspace.create_with_database!(name: "Other WS", creator: identity)
@@ -186,7 +184,7 @@ module Saas
 
       workspace_get "/", workspace: banned_workspace
 
-      assert_redirected_to "/workspaces"
+      assert_redirected_to "/#{other_workspace.external_id}"
       follow_redirect! while response.redirect?
       assert_response :success
       assert_no_match %r{href=["']/#{banned_workspace.external_id}(/|["'])},
@@ -214,14 +212,14 @@ module Saas
 
       workspace_get "/", workspace: workspace
 
-      assert_redirected_to "/workspaces"
+      assert_redirected_to "/workspaces/new"
       assert_equal "You no longer have access to this workspace.", flash[:alert]
     ensure
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
       identity&.destroy
     end
 
-    test "deactivated workspace user with no other workspaces lands on workspace selector without sidebar link" do
+    test "deactivated workspace user with no other workspaces lands on new-workspace page without sidebar link" do
       identity = GlobalIdentity.create!(email_address: "deactivate-tester@example.com", name: "Deactivate Tester")
       workspace = Workspace.create_with_database!(name: "Deactivate Test", creator: identity)
       sign_in_global_identity(identity)
@@ -233,12 +231,10 @@ module Saas
 
       workspace_get "/", workspace: workspace
 
-      assert_redirected_to "/workspaces"
+      assert_redirected_to "/workspaces/new"
       assert_equal "You no longer have access to this workspace.", flash[:alert]
-      follow_redirect! while response.redirect?
+      follow_redirect!
       assert_response :success
-      assert_match "You no longer have access to this workspace.", response.body,
-        "flash must survive the redirect chain and be rendered to the user"
       assert_no_match %r{href=["']/#{workspace.external_id}(/|["'])},
         response.body,
         "rendered page must not link back to the deactivated workspace (sidebar would bounce the user)"

--- a/saas/test/controllers/saas/authentication_test.rb
+++ b/saas/test/controllers/saas/authentication_test.rb
@@ -145,10 +145,11 @@ module Saas
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
     end
 
-    test "banned workspace user is redirected and selector does not loop back into the banned workspace" do
-      workspace = Workspace.create_with_database!(name: "Ban Test", creator: global_identities(:alice))
-      sign_in_global_identity(global_identities(:alice))
-      membership = global_identities(:alice).workspace_memberships.find_by(tenant: workspace.external_id.to_s)
+    test "banned workspace user with no other workspaces lands on workspace selector without sidebar link to the banned workspace" do
+      identity = GlobalIdentity.create!(email_address: "ban-tester@example.com", name: "Ban Tester")
+      workspace = Workspace.create_with_database!(name: "Ban Test", creator: identity)
+      sign_in_global_identity(identity)
+      membership = identity.workspace_memberships.find_by(tenant: workspace.external_id.to_s)
 
       ApplicationRecord.with_tenant(workspace.external_id.to_s) do
         User.find(membership.user_id).ban
@@ -157,19 +158,74 @@ module Saas
       workspace_get "/", workspace: workspace
 
       assert_redirected_to "/workspaces"
-      follow_redirect!
-      assert_no_match %r{/#{workspace.external_id}(/|$)}, response.location.to_s,
-        "selector must not bounce a banned user back into their banned workspace"
+      assert_equal "You no longer have access to this workspace.", flash[:alert]
+      follow_redirect! while response.redirect?
+      assert_response :success
+      assert_match "You no longer have access to this workspace.", response.body,
+        "flash must survive the redirect chain and be rendered to the user"
+      assert_no_match %r{href=["']/#{workspace.external_id}(/|["'])},
+        response.body,
+        "rendered page must not link back to the banned workspace (sidebar would bounce the user)"
       assert WorkspaceMembership.exists?(membership.id),
         "membership must be preserved for staff admin visibility"
     ensure
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
+      identity&.destroy
     end
 
-    test "deactivated workspace user is redirected and selector does not loop back" do
-      workspace = Workspace.create_with_database!(name: "Deactivate Test", creator: global_identities(:alice))
-      sign_in_global_identity(global_identities(:alice))
-      membership = global_identities(:alice).workspace_memberships.find_by(tenant: workspace.external_id.to_s)
+    test "banned user with multiple workspaces sees no link to the banned workspace from the destination workspace's sidebar" do
+      identity = GlobalIdentity.create!(email_address: "multi-ban@example.com", name: "Multi Ban")
+      banned_workspace = Workspace.create_with_database!(name: "Banned WS", creator: identity)
+      other_workspace = Workspace.create_with_database!(name: "Other WS", creator: identity)
+      sign_in_global_identity(identity)
+      banned_membership = identity.workspace_memberships.find_by(tenant: banned_workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(banned_workspace.external_id.to_s) do
+        User.find(banned_membership.user_id).ban
+      end
+
+      workspace_get "/", workspace: banned_workspace
+
+      assert_redirected_to "/workspaces"
+      follow_redirect! while response.redirect?
+      assert_response :success
+      assert_no_match %r{href=["']/#{banned_workspace.external_id}(/|["'])},
+        response.body,
+        "destination workspace's sidebar must not link to the banned workspace"
+      assert_match %r{href=["']/#{other_workspace.external_id}(/|["'])},
+        response.body,
+        "destination workspace itself should be reachable in the sidebar"
+    ensure
+      banned_workspace&.destroy_with_database! if banned_workspace && Workspace.exists?(id: banned_workspace.id)
+      other_workspace&.destroy_with_database! if other_workspace && Workspace.exists?(id: other_workspace.id)
+      identity&.destroy
+    end
+
+    test "auth guard fail-closes when workspace_memberships.user_active is stale (drift case)" do
+      identity = GlobalIdentity.create!(email_address: "drift@example.com", name: "Drift")
+      workspace = Workspace.create_with_database!(name: "Drift Test", creator: identity)
+      sign_in_global_identity(identity)
+      membership = identity.workspace_memberships.find_by(tenant: workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).update!(status: :banned)
+      end
+      membership.update_column(:user_active, true)
+
+      workspace_get "/", workspace: workspace
+
+      assert_redirected_to "/workspaces"
+      assert_equal "You no longer have access to this workspace.", flash[:alert]
+    ensure
+      workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
+      identity&.destroy
+    end
+
+    test "deactivated workspace user with no other workspaces lands on workspace selector without sidebar link" do
+      identity = GlobalIdentity.create!(email_address: "deactivate-tester@example.com", name: "Deactivate Tester")
+      workspace = Workspace.create_with_database!(name: "Deactivate Test", creator: identity)
+      sign_in_global_identity(identity)
+      membership = identity.workspace_memberships.find_by(tenant: workspace.external_id.to_s)
 
       ApplicationRecord.with_tenant(workspace.external_id.to_s) do
         User.find(membership.user_id).deactivate
@@ -178,13 +234,19 @@ module Saas
       workspace_get "/", workspace: workspace
 
       assert_redirected_to "/workspaces"
-      follow_redirect!
-      assert_no_match %r{/#{workspace.external_id}(/|$)}, response.location.to_s,
-        "selector must not bounce a deactivated user back into their workspace"
+      assert_equal "You no longer have access to this workspace.", flash[:alert]
+      follow_redirect! while response.redirect?
+      assert_response :success
+      assert_match "You no longer have access to this workspace.", response.body,
+        "flash must survive the redirect chain and be rendered to the user"
+      assert_no_match %r{href=["']/#{workspace.external_id}(/|["'])},
+        response.body,
+        "rendered page must not link back to the deactivated workspace (sidebar would bounce the user)"
       assert WorkspaceMembership.exists?(membership.id),
         "membership must be preserved for staff admin visibility"
     ensure
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
+      identity&.destroy
     end
 
     test "authenticated user accessing workspace they are not a member of is redirected to workspace selector" do

--- a/saas/test/controllers/saas/authentication_test.rb
+++ b/saas/test/controllers/saas/authentication_test.rb
@@ -145,7 +145,7 @@ module Saas
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
     end
 
-    test "banned workspace user with no other workspaces lands on new-workspace page without sidebar link to the banned workspace" do
+    test "banned workspace user is redirected to /settings with an alert" do
       identity = GlobalIdentity.create!(email_address: "ban-tester@example.com", name: "Ban Tester")
       workspace = Workspace.create_with_database!(name: "Ban Test", creator: identity)
       sign_in_global_identity(identity)
@@ -157,21 +157,15 @@ module Saas
 
       workspace_get "/", workspace: workspace
 
-      assert_redirected_to "/workspaces/new"
-      assert_equal "You no longer have access to this workspace.", flash[:alert]
-      follow_redirect!
-      assert_response :success
-      assert_no_match %r{href=["']/#{workspace.external_id}(/|["'])},
-        response.body,
-        "rendered page must not link back to the banned workspace (sidebar would bounce the user)"
+      assert_redirected_to "/settings?denied=workspace"
       assert WorkspaceMembership.exists?(membership.id),
-        "membership must be preserved for staff admin visibility"
+        "membership must be preserved so the user can leave it from /settings"
     ensure
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
       identity&.destroy
     end
 
-    test "banned user with multiple workspaces is redirected directly to the next available workspace" do
+    test "banned user with multiple workspaces is also redirected to /settings (not into another workspace)" do
       identity = GlobalIdentity.create!(email_address: "multi-ban@example.com", name: "Multi Ban")
       banned_workspace = Workspace.create_with_database!(name: "Banned WS", creator: identity)
       other_workspace = Workspace.create_with_database!(name: "Other WS", creator: identity)
@@ -184,15 +178,7 @@ module Saas
 
       workspace_get "/", workspace: banned_workspace
 
-      assert_redirected_to "/#{other_workspace.external_id}"
-      follow_redirect! while response.redirect?
-      assert_response :success
-      assert_no_match %r{href=["']/#{banned_workspace.external_id}(/|["'])},
-        response.body,
-        "destination workspace's sidebar must not link to the banned workspace"
-      assert_match %r{href=["']/#{other_workspace.external_id}(/|["'])},
-        response.body,
-        "destination workspace itself should be reachable in the sidebar"
+      assert_redirected_to "/settings?denied=workspace"
     ensure
       banned_workspace&.destroy_with_database! if banned_workspace && Workspace.exists?(id: banned_workspace.id)
       other_workspace&.destroy_with_database! if other_workspace && Workspace.exists?(id: other_workspace.id)
@@ -212,14 +198,13 @@ module Saas
 
       workspace_get "/", workspace: workspace
 
-      assert_redirected_to "/workspaces/new"
-      assert_equal "You no longer have access to this workspace.", flash[:alert]
+      assert_redirected_to "/settings?denied=workspace"
     ensure
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
       identity&.destroy
     end
 
-    test "deactivated workspace user with no other workspaces lands on new-workspace page without sidebar link" do
+    test "deactivated workspace user is redirected to /settings with an alert" do
       identity = GlobalIdentity.create!(email_address: "deactivate-tester@example.com", name: "Deactivate Tester")
       workspace = Workspace.create_with_database!(name: "Deactivate Test", creator: identity)
       sign_in_global_identity(identity)
@@ -231,15 +216,9 @@ module Saas
 
       workspace_get "/", workspace: workspace
 
-      assert_redirected_to "/workspaces/new"
-      assert_equal "You no longer have access to this workspace.", flash[:alert]
-      follow_redirect!
-      assert_response :success
-      assert_no_match %r{href=["']/#{workspace.external_id}(/|["'])},
-        response.body,
-        "rendered page must not link back to the deactivated workspace (sidebar would bounce the user)"
+      assert_redirected_to "/settings?denied=workspace"
       assert WorkspaceMembership.exists?(membership.id),
-        "membership must be preserved for staff admin visibility"
+        "membership must be preserved so the user can leave it from /settings"
     ensure
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
       identity&.destroy

--- a/saas/test/controllers/saas/authentication_test.rb
+++ b/saas/test/controllers/saas/authentication_test.rb
@@ -145,6 +145,48 @@ module Saas
       workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
     end
 
+    test "banned workspace user is redirected and selector does not loop back into the banned workspace" do
+      workspace = Workspace.create_with_database!(name: "Ban Test", creator: global_identities(:alice))
+      sign_in_global_identity(global_identities(:alice))
+      membership = global_identities(:alice).workspace_memberships.find_by(tenant: workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).ban
+      end
+
+      workspace_get "/", workspace: workspace
+
+      assert_redirected_to "/workspaces"
+      follow_redirect!
+      assert_no_match %r{/#{workspace.external_id}(/|$)}, response.location.to_s,
+        "selector must not bounce a banned user back into their banned workspace"
+      assert WorkspaceMembership.exists?(membership.id),
+        "membership must be preserved for staff admin visibility"
+    ensure
+      workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
+    end
+
+    test "deactivated workspace user is redirected and selector does not loop back" do
+      workspace = Workspace.create_with_database!(name: "Deactivate Test", creator: global_identities(:alice))
+      sign_in_global_identity(global_identities(:alice))
+      membership = global_identities(:alice).workspace_memberships.find_by(tenant: workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).deactivate
+      end
+
+      workspace_get "/", workspace: workspace
+
+      assert_redirected_to "/workspaces"
+      follow_redirect!
+      assert_no_match %r{/#{workspace.external_id}(/|$)}, response.location.to_s,
+        "selector must not bounce a deactivated user back into their workspace"
+      assert WorkspaceMembership.exists?(membership.id),
+        "membership must be preserved for staff admin visibility"
+    ensure
+      workspace&.destroy_with_database! if workspace && Workspace.exists?(id: workspace.id)
+    end
+
     test "authenticated user accessing workspace they are not a member of is redirected to workspace selector" do
       # Bob is NOT a member of acme workspace
       sign_in_global_identity(global_identities(:bob))

--- a/saas/test/controllers/users_controller_join_test.rb
+++ b/saas/test/controllers/users_controller_join_test.rb
@@ -78,6 +78,20 @@ class SaasUsersControllerJoinTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test "join page redirects banned member to workspace selector instead of guest join flow" do
+    sign_in_global_identity(@alice)
+    membership = workspace_memberships(:alice_acme)
+    setup_user_for_membership(membership)
+
+    ApplicationRecord.with_tenant(@workspace.external_id.to_s) do
+      User.find(membership.user_id).ban
+    end
+
+    workspace_get "/join/#{@join_code.code}", workspace: @workspace
+
+    assert_redirected_to "/workspaces"
+  end
+
   # ============================================================================
   # POST /workspace_id/join/:join_code (signed out)
   # ============================================================================

--- a/saas/test/controllers/users_controller_join_test.rb
+++ b/saas/test/controllers/users_controller_join_test.rb
@@ -78,7 +78,7 @@ class SaasUsersControllerJoinTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test "join page redirects banned member to workspace selector instead of guest join flow" do
+  test "join page redirects banned member away from the guest join flow" do
     sign_in_global_identity(@alice)
     membership = workspace_memberships(:alice_acme)
     setup_user_for_membership(membership)
@@ -89,7 +89,10 @@ class SaasUsersControllerJoinTest < ActionDispatch::IntegrationTest
 
     workspace_get "/join/#{@join_code.code}", workspace: @workspace
 
-    assert_redirected_to "/workspaces"
+    assert_response :redirect
+    assert_no_match %r{/#{@workspace.external_id}(/|$)}, URI(response.location).path,
+      "banned member must not be redirected back into the workspace they were banned from"
+    assert_equal "You no longer have access to this workspace.", flash[:alert]
   end
 
   # ============================================================================

--- a/saas/test/controllers/users_controller_join_test.rb
+++ b/saas/test/controllers/users_controller_join_test.rb
@@ -89,10 +89,7 @@ class SaasUsersControllerJoinTest < ActionDispatch::IntegrationTest
 
     workspace_get "/join/#{@join_code.code}", workspace: @workspace
 
-    assert_response :redirect
-    assert_no_match %r{/#{@workspace.external_id}(/|$)}, URI(response.location).path,
-      "banned member must not be redirected back into the workspace they were banned from"
-    assert_equal "You no longer have access to this workspace.", flash[:alert]
+    assert_redirected_to "/settings?denied=workspace"
   end
 
   # ============================================================================

--- a/saas/test/models/workspace_membership_test.rb
+++ b/saas/test/models/workspace_membership_test.rb
@@ -196,17 +196,15 @@ class WorkspaceMembershipTest < ActiveSupport::TestCase
       membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
       user_id = membership.user_id
 
-      WorkspaceMembership.any_instance.stubs(:update).returns(false).then.returns(true)
-      WorkspaceMembership.any_instance.stubs(:errors).returns(stub(full_messages: [ "Simulated" ]))
+      WorkspaceMembership.any_instance.stubs(:update_column).raises(ActiveRecord::StatementInvalid.new("simulated"))
 
       ApplicationRecord.with_tenant(workspace.external_id.to_s) do
         user = User.find(user_id)
         assert_nothing_raised { user.deactivate }
-        assert user.reload.deactivated?, "ban must succeed even when mirror write fails"
+        assert user.reload.deactivated?, "deactivate must succeed even when mirror write fails"
       end
     ensure
-      WorkspaceMembership.any_instance.unstub(:update)
-      WorkspaceMembership.any_instance.unstub(:errors)
+      WorkspaceMembership.any_instance.unstub(:update_column)
     end
   end
 end

--- a/saas/test/models/workspace_membership_test.rb
+++ b/saas/test/models/workspace_membership_test.rb
@@ -190,21 +190,4 @@ class WorkspaceMembershipTest < ActiveSupport::TestCase
         "after_create_commit must re-flip user_active=true when a new User is provisioned"
     end
   end
-
-  test "mirror write failure logs and does not roll back the User#deactivate transaction" do
-    with_provisioned_workspace(name: "Mirror Failure Test", creator: global_identities(:alice)) do |workspace|
-      membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
-      user_id = membership.user_id
-
-      WorkspaceMembership.any_instance.stubs(:update_column).raises(ActiveRecord::StatementInvalid.new("simulated"))
-
-      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
-        user = User.find(user_id)
-        assert_nothing_raised { user.deactivate }
-        assert user.reload.deactivated?, "deactivate must succeed even when mirror write fails"
-      end
-    ensure
-      WorkspaceMembership.any_instance.unstub(:update_column)
-    end
-  end
 end

--- a/saas/test/models/workspace_membership_test.rb
+++ b/saas/test/models/workspace_membership_test.rb
@@ -125,4 +125,55 @@ class WorkspaceMembershipTest < ActiveSupport::TestCase
       assert rejoined_user.active?, "User should have active status"
     end
   end
+
+  test "User#unban flips workspace_memberships.user_active back to true" do
+    with_provisioned_workspace(name: "Unban Mirror Test", creator: global_identities(:alice)) do |workspace|
+      membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).ban
+      end
+      assert_not membership.reload.user_active, "ban must mirror to user_active=false"
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).unban
+      end
+      assert membership.reload.user_active, "unban must mirror to user_active=true"
+    end
+  end
+
+  test "User#reactivate flips workspace_memberships.user_active back to true" do
+    with_provisioned_workspace(name: "Reactivate Mirror Test", creator: global_identities(:alice)) do |workspace|
+      membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).deactivate
+      end
+      assert_not membership.reload.user_active, "deactivate must mirror to user_active=false"
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).reactivate
+      end
+      assert membership.reload.user_active, "reactivate must mirror to user_active=true"
+    end
+  end
+
+  test "mirror write failure logs and does not roll back the User#deactivate transaction" do
+    with_provisioned_workspace(name: "Mirror Failure Test", creator: global_identities(:alice)) do |workspace|
+      membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
+      user_id = membership.user_id
+
+      WorkspaceMembership.any_instance.stubs(:update).returns(false).then.returns(true)
+      WorkspaceMembership.any_instance.stubs(:errors).returns(stub(full_messages: [ "Simulated" ]))
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        user = User.find(user_id)
+        assert_nothing_raised { user.deactivate }
+        assert user.reload.deactivated?, "ban must succeed even when mirror write fails"
+      end
+    ensure
+      WorkspaceMembership.any_instance.unstub(:update)
+      WorkspaceMembership.any_instance.unstub(:errors)
+    end
+  end
 end

--- a/saas/test/models/workspace_membership_test.rb
+++ b/saas/test/models/workspace_membership_test.rb
@@ -158,6 +158,39 @@ class WorkspaceMembershipTest < ActiveSupport::TestCase
     end
   end
 
+  test "User hard-destroy flips workspace_memberships.user_active to false so the workspace selector hides the orphan" do
+    with_provisioned_workspace(name: "Hard Destroy Test", creator: global_identities(:alice)) do |workspace|
+      membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
+      assert membership.user_active, "precondition: membership starts active"
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).destroy!
+      end
+
+      membership.reload
+      assert_nil membership.user_id, "destroy must clear cached user_id"
+      assert_not membership.user_active, "destroy must drop the user_active mirror"
+      assert_not_includes global_identities(:alice).active_workspaces_recent_first, workspace,
+        "workspace selector must not surface the orphaned membership"
+    end
+  end
+
+  test "create_user! after a hard-destroy restores user_active so the workspace becomes reachable again" do
+    with_provisioned_workspace(name: "Recreate After Destroy", creator: global_identities(:alice)) do |workspace|
+      membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)
+
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        User.find(membership.user_id).destroy!
+      end
+      assert_not membership.reload.user_active
+
+      membership.create_user!
+
+      assert membership.reload.user_active,
+        "after_create_commit must re-flip user_active=true when a new User is provisioned"
+    end
+  end
+
   test "mirror write failure logs and does not roll back the User#deactivate transaction" do
     with_provisioned_workspace(name: "Mirror Failure Test", creator: global_identities(:alice)) do |workspace|
       membership = WorkspaceMembership.find_by(tenant: workspace.external_id.to_s)

--- a/test/controllers/users/bans_controller_test.rb
+++ b/test/controllers/users/bans_controller_test.rb
@@ -123,4 +123,30 @@ class Users::BansControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to root_path
   end
+
+  test "create enqueues a ban notification email to the user" do
+    user = users(:kevin)
+
+    assert_enqueued_email_with(UserMailer, :banned, args: [ user ]) do
+      post user_ban_url(user)
+    end
+  end
+
+  test "destroy enqueues an unban notification email to the user" do
+    user = users(:kevin)
+    user.ban
+
+    assert_enqueued_email_with(UserMailer, :unbanned, args: [ user ]) do
+      delete user_ban_url(user)
+    end
+  end
+
+  test "deactivate and reactivate do not enqueue ban or unban emails" do
+    user = users(:kevin)
+
+    assert_no_enqueued_emails do
+      user.deactivate
+      user.reactivate
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- In SaaS mode, banned and deactivated workspace users are denied at the auth layer and bounced to `/settings`, which renders a persistent banner explaining the redirect. The settings workspace list labels affected memberships as "Inactive" so the user sees why the row is there without leaking the specific reason.
- Sends a ban / unban email to the affected user (no email on plain deactivate/reactivate).
- Mirrors `User#active?` onto a new `workspace_memberships.user_active` column via an `after_update_commit` callback so the workspace selector can filter without crossing tenants. Hard-destroy clears the mirror; rejoin via `create_user!` restores it. The auth guard reads the per-tenant `User#status` directly, so a stale mirror cannot let a banned user through — only hide a workspace they should still see.

## Notes for reviewers

- New migration: `saas/db/untenanted_migrate/20260507000001_add_user_active_to_workspace_memberships.rb` adds the column with `default: true` so existing memberships stay visible.
- Drift repair: `bin/rails workspace_membership:backfill_user_active` — idempotent, flips false where the per-tenant `User` is inactive or missing.
- Tradeoff on the mirror column: buys throughput on the workspace selector (no cross-tenant lookups) at the cost of a denormalized cache that can drift. Drift is harmless in the deny direction (the auth guard fail-closes against the source of truth) and surface-only in the selector, repaired by the backfill task.