### PR TITLE
Make banned/deactivated members reachable from the member list and profile

### DIFF
--- a/app/assets/stylesheets/application/panels.css
+++ b/app/assets/stylesheets/application/panels.css
@@ -140,6 +140,39 @@
   opacity: 0.6;
 }
 
+.member-status-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  margin-block-end: var(--block-space);
+}
+
+.member-status-tab {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  position: relative;
+
+  &:hover {
+    color: var(--color-text);
+  }
+
+  & + & {
+    padding-inline-start: 0.875rem;
+
+    &::before {
+      content: "·";
+      color: var(--color-text-muted);
+      position: absolute;
+      inset-inline-start: -0.125rem;
+    }
+  }
+}
+
+.member-status-tab--active {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
 /* Member management responsive styles */
 .panel--members {
   --panel-width: 60ch;

--- a/app/controllers/accounts/users_controller.rb
+++ b/app/controllers/accounts/users_controller.rb
@@ -78,7 +78,8 @@ class Accounts::UsersController < ApplicationController
       @searching = true
       query = params[:query].to_s.strip
       pattern = "%#{User.sanitize_sql_like(query)}%"
-      people = users_scope.active.where("name LIKE ?", pattern)
+      people_scope = Current.user.staff? ? users_scope : users_scope.active
+      people = people_scope.where("name LIKE ?", pattern)
       bots = bots_scope.where("name LIKE ?", pattern)
       @users = (people + bots).first(50)
       preload_activity(@users)

--- a/app/controllers/accounts/users_controller.rb
+++ b/app/controllers/accounts/users_controller.rb
@@ -3,6 +3,7 @@ class Accounts::UsersController < ApplicationController
 
   before_action :ensure_can_administer, only: %i[update destroy]
   before_action :set_user, only: %i[update destroy]
+  before_action :load_status_counts, only: :index, if: -> { Current.user.staff? }
 
   def index
     @badges = Badge.ordered.to_a if Current.user.can_administer?
@@ -114,11 +115,11 @@ class Accounts::UsersController < ApplicationController
       @members = sort_by_activity(@members)
 
       @bots = bots_scope.ordered.to_a
+    end
 
-      if Current.user.staff?
-        @deactivated_count = User.without_bots.deactivated.count
-        @banned_count = User.without_bots.banned.count
-      end
+    def load_status_counts
+      @deactivated_count = User.without_bots.deactivated.count
+      @banned_count = User.without_bots.banned.count
     end
 
     ACTIVITY_SORT_ORDER = { active: 0, away: 1, offline: 2 }.freeze

--- a/app/views/accounts/users/index.html.erb
+++ b/app/views/accounts/users/index.html.erb
@@ -40,16 +40,16 @@
     <% end %>
   </div>
 
-  <% if Current.user.staff? && (@deactivated_count.to_i > 0 || @banned_count.to_i > 0) %>
+  <% if Current.user.staff? && (@deactivated_count.to_i > 0 || @banned_count.to_i > 0 || @filtering_deactivated || @filtering_banned) %>
     <nav class="member-status-tabs txt-small" aria-label="Member status">
       <%= link_to "All", account_users_path,
             class: class_names("member-status-tab", "member-status-tab--active": !@filtering_deactivated && !@filtering_banned) %>
-      <% if @deactivated_count.to_i > 0 %>
-        <%= link_to "Deactivated (#{@deactivated_count})", account_users_path(status: "deactivated"),
+      <% if @deactivated_count.to_i > 0 || @filtering_deactivated %>
+        <%= link_to "Deactivated (#{@deactivated_count.to_i})", account_users_path(status: "deactivated"),
               class: class_names("member-status-tab", "member-status-tab--active": @filtering_deactivated) %>
       <% end %>
-      <% if @banned_count.to_i > 0 %>
-        <%= link_to "Banned (#{@banned_count})", account_users_path(status: "banned"),
+      <% if @banned_count.to_i > 0 || @filtering_banned %>
+        <%= link_to "Banned (#{@banned_count.to_i})", account_users_path(status: "banned"),
               class: class_names("member-status-tab", "member-status-tab--active": @filtering_banned) %>
       <% end %>
     </nav>

--- a/app/views/accounts/users/index.html.erb
+++ b/app/views/accounts/users/index.html.erb
@@ -40,6 +40,21 @@
     <% end %>
   </div>
 
+  <% if Current.user.staff? && (@deactivated_count.to_i > 0 || @banned_count.to_i > 0) %>
+    <nav class="member-status-tabs txt-small" aria-label="Member status">
+      <%= link_to "All", account_users_path,
+            class: class_names("member-status-tab", "member-status-tab--active": !@filtering_deactivated && !@filtering_banned) %>
+      <% if @deactivated_count.to_i > 0 %>
+        <%= link_to "Deactivated (#{@deactivated_count})", account_users_path(status: "deactivated"),
+              class: class_names("member-status-tab", "member-status-tab--active": @filtering_deactivated) %>
+      <% end %>
+      <% if @banned_count.to_i > 0 %>
+        <%= link_to "Banned (#{@banned_count})", account_users_path(status: "banned"),
+              class: class_names("member-status-tab", "member-status-tab--active": @filtering_banned) %>
+      <% end %>
+    </nav>
+  <% end %>
+
   <div class="flex flex-column gap members-list">
     <turbo-frame id="account_users">
       <% if @searching %>
@@ -50,20 +65,12 @@
           <p class="txt-small txt-muted">No members found</p>
         <% end %>
       <% elsif @filtering_deactivated %>
-        <div class="flex align-center justify-between margin-block-half">
-          <p class="txt-small txt-muted margin-none role-section__heading">Deactivated</p>
-          <%= link_to "Back to all users", account_users_path, class: "btn txt-small" %>
-        </div>
         <% if @users.any? %>
           <%= render partial: "accounts/users/user", collection: @users, as: :user %>
         <% else %>
           <p class="txt-small txt-muted">No deactivated members</p>
         <% end %>
       <% elsif @filtering_banned %>
-        <div class="flex align-center justify-between margin-block-half">
-          <p class="txt-small txt-muted margin-none role-section__heading">Banned</p>
-          <%= link_to "Back to all users", account_users_path, class: "btn txt-small" %>
-        </div>
         <% if @users.any? %>
           <%= render partial: "accounts/users/user", collection: @users, as: :user %>
         <% else %>
@@ -94,22 +101,6 @@
             <p class="txt-small txt-muted margin-block-half role-section__heading">Bots</p>
             <%= render partial: "accounts/users/user", collection: @bots, as: :user %>
           </div>
-        <% end %>
-
-        <% if Current.user.staff? %>
-          <% if @deactivated_count > 0 %>
-            <div class="flex align-center justify-between margin-block-half">
-              <p class="txt-small txt-muted margin-none role-section__heading">Deactivated</p>
-              <%= link_to "View", account_users_path(status: "deactivated"), class: "btn txt-small" %>
-            </div>
-          <% end %>
-
-          <% if @banned_count > 0 %>
-            <div class="flex align-center justify-between margin-block-half">
-              <p class="txt-small txt-muted margin-none role-section__heading">Banned</p>
-              <%= link_to "View", account_users_path(status: "banned"), class: "btn txt-small" %>
-            </div>
-          <% end %>
         <% end %>
       <% end %>
     </turbo-frame>

--- a/app/views/users/_deactivate_button.html.erb
+++ b/app/views/users/_deactivate_button.html.erb
@@ -1,0 +1,15 @@
+<% if user.active? %>
+  <%= button_to account_user_path(user), method: :delete,
+        class: "btn",
+        data: { turbo_confirm: "Deactivate #{user.name}? They will be logged out and can't sign in again. Their messages stay visible. You can reactivate them from the member list." } do %>
+    <%= icon_tag "minus" %>
+    <span>Deactivate</span>
+  <% end %>
+<% elsif user.deactivated? %>
+  <%= button_to account_user_reactivation_path(user), method: :post,
+        class: "btn btn--reversed",
+        data: { turbo_confirm: "Reactivate #{user.name}? They will be able to sign in again." } do %>
+    <%= icon_tag "add" %>
+    <span>Reactivate</span>
+  <% end %>
+<% end %>

--- a/app/views/users/_deactivate_button.html.erb
+++ b/app/views/users/_deactivate_button.html.erb
@@ -1,14 +1,17 @@
+<%# Profile-page partial. Turbo is disabled so submissions go through format.html
+    and follow the redirect — the turbo_stream responses target dom_id(@user),
+    which only exists on the member list, not on the profile. %>
 <% if user.active? %>
   <%= button_to account_user_path(user), method: :delete,
         class: "btn",
-        data: { turbo_confirm: "Deactivate #{user.name}? They will be logged out and can't sign in again. Their messages stay visible. You can reactivate them from the member list." } do %>
+        data: { turbo: false, turbo_confirm: "Deactivate #{user.name}? They will be logged out and can't sign in again. Their messages stay visible. You can reactivate them from the member list." } do %>
     <%= icon_tag "minus" %>
     <span>Deactivate</span>
   <% end %>
 <% elsif user.deactivated? %>
   <%= button_to account_user_reactivation_path(user), method: :post,
         class: "btn btn--reversed",
-        data: { turbo_confirm: "Reactivate #{user.name}? They will be able to sign in again." } do %>
+        data: { turbo: false, turbo_confirm: "Reactivate #{user.name}? They will be able to sign in again." } do %>
     <%= icon_tag "add" %>
     <span>Reactivate</span>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -125,12 +125,31 @@
 
     <% if Current.user != @user && !@user.bot? %>
       <hr class="margin-block-start borderless">
-      <div class="flex justify-center gap">
-        <%= render "blocks/button", user: @user, compact: false %>
+
+      <div class="flex flex-column align-center gap-half">
         <% if Current.user.staff? %>
-          <%= render "users/ban_button", user: @user %>
+          <p class="txt-x-small txt-muted txt-label margin-none">For you</p>
         <% end %>
+        <%= render "blocks/button", user: @user, compact: false %>
+        <p class="txt-x-small txt-muted txt-align-center margin-none">
+          Block stops the user from messaging or mentioning you.
+        </p>
       </div>
+
+      <% if Current.user.staff? %>
+        <div class="flex flex-column align-center gap-half margin-block-start">
+          <p class="txt-x-small txt-muted txt-label margin-none">Moderation</p>
+          <div class="flex justify-center gap">
+            <% if @user.removable_by?(Current.user) %>
+              <%= render "users/deactivate_button", user: @user %>
+            <% end %>
+            <%= render "users/ban_button", user: @user %>
+          </div>
+          <p class="txt-x-small txt-muted txt-align-center margin-none">
+            Deactivate revokes the user's access. Ban also deletes their messages and blocks their IPs.
+          </p>
+        </div>
+      <% end %>
     <% end %>
 
   <% elsif @user.banned? %>
@@ -161,7 +180,14 @@
 
     <div class="flex flex-column align-center gap-half">
       <h1 class="txt-x-large margin-none"><%= @user.name %></h1>
-      <span class="txt-small txt-muted">No longer active</span>
+      <span class="txt-small txt-muted">Deactivated</span>
     </div>
+
+    <% if @user.reactivatable_by?(Current.user) %>
+      <hr class="margin-block-start borderless">
+      <div class="flex justify-center">
+        <%= render "users/deactivate_button", user: @user %>
+      </div>
+    <% end %>
   <% end %>
 </section>

--- a/test/controllers/accounts/users_controller_test.rb
+++ b/test/controllers/accounts/users_controller_test.rb
@@ -37,6 +37,26 @@ class Accounts::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#user_#{banned.id}"
   end
 
+  test "empty deactivated filter still shows All chip so staff can navigate back" do
+    assert_equal 0, User.without_bots.deactivated.count
+
+    get account_users_url(status: "deactivated")
+
+    assert_response :success
+    assert_select ".member-status-tab", text: "All"
+    assert_select ".member-status-tab--active", text: "Deactivated (0)"
+  end
+
+  test "empty banned filter still shows All chip so staff can navigate back" do
+    assert_equal 0, User.without_bots.banned.count
+
+    get account_users_url(status: "banned")
+
+    assert_response :success
+    assert_select ".member-status-tab", text: "All"
+    assert_select ".member-status-tab--active", text: "Banned (0)"
+  end
+
   test "non-staff search hides deactivated and banned users" do
     deactivated = users(:jz)
     deactivated.deactivate

--- a/test/controllers/accounts/users_controller_test.rb
+++ b/test/controllers/accounts/users_controller_test.rb
@@ -23,6 +23,36 @@ class Accounts::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: "No members found"
   end
 
+  test "staff search finds deactivated and banned users" do
+    deactivated = users(:jz)
+    deactivated.deactivate
+    banned = users(:rachel)
+    banned.sessions.create!(ip_address: "203.0.113.1", user_agent: "Test")
+    banned.ban
+
+    get account_users_url, params: { query: "JZ" }
+    assert_select "turbo-frame#user_#{deactivated.id}"
+
+    get account_users_url, params: { query: "Rachel" }
+    assert_select "turbo-frame#user_#{banned.id}"
+  end
+
+  test "non-staff search hides deactivated and banned users" do
+    deactivated = users(:jz)
+    deactivated.deactivate
+    banned = users(:rachel)
+    banned.sessions.create!(ip_address: "203.0.113.1", user_agent: "Test")
+    banned.ban
+
+    sign_in :kevin
+
+    get account_users_url, params: { query: "JZ" }
+    assert_select "turbo-frame#user_#{deactivated.id}", count: 0
+
+    get account_users_url, params: { query: "Rachel" }
+    assert_select "turbo-frame#user_#{banned.id}", count: 0
+  end
+
   test "update role" do
     user = users(:kevin)
     assert user.member?


### PR DESCRIPTION
## Summary

- **Member-list search includes banned/deactivated users for staff.** Previously search was scoped to `users_scope.active`, so once you banned or deactivated a member they vanished from the only search box on the page. Now staff (administrators + moderators) can find them; non-staff still see active users only.
- **Filter chips above the member list replace the easy-to-miss View links at the bottom.** When staff are on the page and at least one banned or deactivated member exists, the title row gets a `All · Deactivated (n) · Banned (m)` chip nav. The active filter is bolded; chips never render for non-staff or for accounts with zero banned/deactivated members. The redundant per-page "Back to all users" link is gone — "All" is right there.
- **Profile page surfaces Deactivate alongside Ban, grouped by audience.** Staff now see two labeled rows on the user profile: `For you` (Block) and `Moderation` (Deactivate, Ban). A short helper line under each row explains the consequence in plain words so admins don't have to click into the confirm dialog to learn the difference. Deactivated users get a Reactivate button on their profile, symmetric with the existing Unban button on banned profiles.
- **Profile-page moderation buttons disable Turbo** so they go through `format.html` and follow the redirect to `/account/users`. The `format.turbo_stream` response was a no-op on the show page (it removes `dom_id(@user)`, which only exists in the member list).
- **Filter chips stay reachable when the count drops to zero.** Bookmarked or stale links to `?status=deactivated` / `?status=banned` always have an "All" chip back to the full list, and the active filter chip stays visible (showing `(0)`) for context.

## Notes for reviewers

- New partial: `app/views/users/_deactivate_button.html.erb` (profile-only — Turbo disabled by design; member-list rows render their own inline buttons).
- The chip CSS reuses existing tokens (`--color-text`, `--color-text-muted`); no new color introduced.
- Visibility model is consistent across the page: staff see the chips and the Moderation row; non-staff see neither — they search and view actives only.