### PR TITLE
Stop admins from banning, unbanning, or deactivating themselves

### DIFF
--- a/app/controllers/accounts/users_controller.rb
+++ b/app/controllers/accounts/users_controller.rb
@@ -31,6 +31,8 @@ class Accounts::UsersController < ApplicationController
   end
 
   def destroy
+    return redirect_to account_users_url, alert: "You can't deactivate yourself." unless @user.removable_by?(Current.user)
+
     @user.deactivate
     notify_bots(@user, :deleted)
 

--- a/app/controllers/users/bans_controller.rb
+++ b/app/controllers/users/bans_controller.rb
@@ -3,11 +3,13 @@ class Users::BansController < ApplicationController
   before_action :set_user
 
   def create
+    return redirect_to @user, alert: ban_rejection_alert unless @user.bannable_by?(Current.user)
     @user.ban
     redirect_to @user
   end
 
   def destroy
+    return redirect_to @user, alert: unban_rejection_alert unless @user.unbannable_by?(Current.user)
     @user.unban
     redirect_to @user
   end
@@ -15,5 +17,21 @@ class Users::BansController < ApplicationController
   private
     def set_user
       @user = User.find(params[:user_id])
+    end
+
+    def ban_rejection_alert
+      if @user == Current.user
+        "You can't ban yourself."
+      elsif @user.banned?
+        "#{@user.name} is already banned."
+      end
+    end
+
+    def unban_rejection_alert
+      if @user == Current.user
+        "You can't unban yourself."
+      elsif !@user.banned?
+        "#{@user.name} is not banned."
+      end
     end
 end

--- a/app/models/user/role.rb
+++ b/app/models/user/role.rb
@@ -37,8 +37,12 @@ module User::Role
     admin.can_administer? && active? && admin != self
   end
 
+  def bannable_by?(admin)
+    admin.can_administer? && admin != self && !banned?
+  end
+
   def unbannable_by?(admin)
-    admin.can_administer? && banned?
+    admin.can_administer? && admin != self && banned?
   end
 
   def reactivatable_by?(admin)

--- a/test/controllers/accounts/users_controller_test.rb
+++ b/test/controllers/accounts/users_controller_test.rb
@@ -141,6 +141,17 @@ class Accounts::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_nil user.reload.badge
   end
 
+  test "destroy rejects an admin trying to deactivate themselves" do
+    sign_in :david
+    me = users(:david)
+
+    delete account_user_url(me)
+
+    assert_redirected_to account_users_url
+    assert_equal "You can't deactivate yourself.", flash[:alert]
+    assert me.reload.active?
+  end
+
   test "destroy deactivates user" do
     user = users(:kevin)
 

--- a/test/controllers/users/bans_controller_test.rb
+++ b/test/controllers/users/bans_controller_test.rb
@@ -149,4 +149,17 @@ class Users::BansControllerTest < ActionDispatch::IntegrationTest
       user.reactivate
     end
   end
+
+  test "create rejects an admin trying to ban themselves" do
+    sign_in :david
+    me = users(:david)
+
+    assert_no_difference -> { Ban.count } do
+      post user_ban_url(me)
+    end
+
+    assert_redirected_to user_url(me)
+    assert_equal "You can't ban yourself.", flash[:alert]
+    assert_not me.reload.banned?
+  end
 end

--- a/test/models/user/role_test.rb
+++ b/test/models/user/role_test.rb
@@ -20,4 +20,28 @@ class User::RoleTest < ActiveSupport::TestCase
     assert another_member.can_administer?(Room.new(creator: member))
     assert_not another_member.can_administer?(rooms(:designers))
   end
+
+  test "bannable_by? rejects self, non-admins, and already-banned users" do
+    admin = users(:david)
+    other = users(:kevin)
+
+    assert other.bannable_by?(admin)
+    assert_not admin.bannable_by?(admin), "admin should not be able to ban themselves"
+    assert_not other.bannable_by?(other), "non-admin actor cannot ban anyone"
+
+    other.update_column(:status, User.statuses[:banned])
+    assert_not other.bannable_by?(admin), "already-banned user should not be re-bannable"
+  end
+
+  test "unbannable_by? rejects self even if banned" do
+    admin = users(:david)
+    admin.update_column(:status, User.statuses[:banned])
+
+    assert_not admin.unbannable_by?(admin), "admin should not be able to unban themselves"
+  end
+
+  test "removable_by? rejects self" do
+    admin = users(:david)
+    assert_not admin.removable_by?(admin), "admin should not be able to deactivate themselves"
+  end
 end


### PR DESCRIPTION
## Summary

- Closes a footgun where an admin could lock themselves out of the account by curling `POST /users/:id/ban` or `DELETE /account/users/:id` with their own user id. The UI hid the action, but the controllers had no actor-vs-target check.
- Adds a `bannable_by?(admin)` predicate on `User::Role` mirroring the existing `removable_by?` shape, and tightens `unbannable_by?` to also reject `admin == self` (defense-in-depth — banned users can't sign in to even attempt a self-unban, but the predicate is also consumed by the view, so keeping it consistent matters).
- `Users::BansController` and `Accounts::UsersController#destroy` early-return with a `redirect_to … alert: …` when the predicate fails. Alert text is shaped to the actual rejection reason — self vs already-banned vs not banned — so curl users see something useful.

## Notes for reviewers

- Rules live on the model (`app/models/user/role.rb`), so the same predicate gates both the view-level button visibility and the controller-level guard. Single source of truth for "who can do what to whom."
- One predicate path (admin self-unban) isn't reachable via integration tests because banned users can't authenticate. Covered by a model unit test in `test/models/user/role_test.rb` instead.
- Admin-on-admin bans are still allowed — that was a separate concern flagged in an earlier audit and is not addressed here.