### PR TITLE
Split account#edit into show + edit; polish admin settings

### DIFF
--- a/app/assets/stylesheets/application/avatars.css
+++ b/app/assets/stylesheets/application/avatars.css
@@ -117,6 +117,10 @@
   }
 }
 
+.account-logo--display {
+  --avatar-size: var(--btn-size);
+}
+
 /* Monogram avatars for users without images */
 .avatar-monogram {
   /* Match the same structure as .avatar */

--- a/app/assets/stylesheets/application/inputs.css
+++ b/app/assets/stylesheets/application/inputs.css
@@ -262,6 +262,33 @@ input[type="radio"]:disabled::after {
   opacity: 0.1;
 }
 
+/* Settings toggle row: label + hint stack on the left, switch flush-right.
+   Whole row is the click target. */
+.setting-row {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: var(--inline-space);
+  justify-content: space-between;
+  padding-block: var(--block-space-half);
+  text-align: start;
+}
+
+.setting-row__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.setting-row__title {
+  font-weight: 500;
+}
+
+.setting-row .switch {
+  flex-shrink: 0;
+  margin-inline-start: var(--block-space);
+}
+
 .switch__btn {
   background-color: var(--color-border-darker);
   border-radius: 2em;

--- a/app/assets/stylesheets/application/panels.css
+++ b/app/assets/stylesheets/application/panels.css
@@ -488,3 +488,16 @@
   display: none;
 }
 
+/* Inline message block — sits inside a form or section, not the page-level flash. */
+.callout {
+  align-items: flex-start;
+  border-radius: 1em;
+  display: flex;
+  gap: var(--inline-space);
+  padding: var(--block-space-half) var(--inline-space-half);
+}
+
+.callout--alert {
+  background-color: color-mix(in oklch, var(--color-alert) 12%, transparent);
+}
+

--- a/app/assets/stylesheets/application/separators.css
+++ b/app/assets/stylesheets/application/separators.css
@@ -4,3 +4,15 @@
   flex-grow: 1;
   min-inline-size: var(--inline-space-double);
 }
+
+/* Solid hairline that sits inside a vertical stack — no flex-grow, no min-width. */
+.separator--row {
+  --border-style: solid;
+  flex-grow: 0;
+  min-inline-size: 0;
+}
+
+/* Lighter weight for sub-dividers within a section. */
+.separator--soft {
+  opacity: 0.5;
+}

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,12 +1,13 @@
 class AccountsController < ApplicationController
-  before_action :ensure_can_administer, only: %i[update]
+  before_action :ensure_can_administer, only: %i[edit update]
   before_action :set_account
 
+  def show
+    @member_count = User.without_bots.active.verified.count
+    @room_count = Room.where(type: %w[Rooms::Open Rooms::Closed]).count
+  end
+
   def edit
-    unless Current.user.can_administer?
-      @member_count = User.without_bots.active.verified.count
-      @room_count = Room.where(type: %w[Rooms::Open Rooms::Closed]).count
-    end
   end
 
   def update

--- a/app/views/accounts/_admin_settings.html.erb
+++ b/app/views/accounts/_admin_settings.html.erb
@@ -1,94 +1,53 @@
-<div class="margin-block pad fill-shade border-radius txt-align-center">
-  <div class="flex flex-column gap align-center">
+<% email_configured = Sabha.email_configured? %>
 
-    <!-- Permissions -->
-    <div class="flex flex-column gap align-center" style="--row-gap: 0.5rem">
-      <strong>Permissions</strong>
-      <div class="flex flex-column gap">
-        <%= form_with model: @account, method: :put, data: { controller: "form" }, class: "flex align-center gap" do |form| %>
-          <%= form.fields_for :settings, @account.settings do |settings_form| %>
-            <%= settings_form.hidden_field :restrict_room_creation_to_administrators,
-                value: !Current.account.settings.restrict_room_creation_to_administrators? %>
-          <% end %>
-          <label class="switch">
-            <input type="checkbox"
-                  class="switch__input"
-                  <%= "checked" if Current.account.settings.restrict_room_creation_to_administrators? %>
-                  data-action="change->form#submit">
-            <span class="switch__btn"></span>
-          </label>
-          <span>Must be admin to create new rooms</span>
-        <% end %>
+<div class="margin-block pad fill-shade border-radius">
+  <section>
+    <p class="txt-small txt-muted txt-label margin-block-end-half">Permissions</p>
 
-        <%= form_with model: @account, method: :put, data: { controller: "form" }, class: "flex align-center gap" do |form| %>
-          <%= form.fields_for :settings, @account.settings do |settings_form| %>
-            <%= settings_form.hidden_field :restrict_direct_messages_to_administrators,
-                value: !Current.account.settings.restrict_direct_messages_to_administrators? %>
-          <% end %>
-          <label class="switch">
-            <input type="checkbox"
-                  class="switch__input"
-                  <%= "checked" if Current.account.settings.restrict_direct_messages_to_administrators? %>
-                  data-action="change->form#submit">
-            <span class="switch__btn"></span>
-          </label>
-          <span>Must be admin to start DMs</span>
-        <% end %>
+    <%= render "accounts/setting_toggle", account: @account, scope: :settings,
+          attribute: :restrict_room_creation_to_administrators,
+          title:     "Must be admin to create new rooms",
+          hint:      "Members can still join and post in rooms that already exist." %>
+    <hr class="separator separator--row separator--soft">
 
-        <%= form_with model: @account, method: :put, data: { controller: "form" }, class: "flex align-center gap" do |form| %>
-          <%= form.fields_for :settings, @account.settings do |settings_form| %>
-            <%= settings_form.hidden_field :allow_users_to_create_invite_links,
-                value: !Current.account.settings.allow_users_to_create_invite_links? %>
-          <% end %>
-          <label class="switch">
-            <input type="checkbox"
-                  class="switch__input"
-                  <%= "checked" if Current.account.settings.allow_users_to_create_invite_links? %>
-                  data-action="change->form#submit">
-            <span class="switch__btn"></span>
-          </label>
-          <span>Allow everyone to create invite links</span>
-        <% end %>
+    <%= render "accounts/setting_toggle", account: @account, scope: :settings,
+          attribute: :restrict_direct_messages_to_administrators,
+          title:     "Must be admin to start DMs",
+          hint:      "Existing DMs keep working — only new ones are restricted." %>
+    <hr class="separator separator--row separator--soft">
 
-      </div>
-    </div>
+    <%= render "accounts/setting_toggle", account: @account, scope: :settings,
+          attribute: :allow_users_to_create_invite_links,
+          title:     "Allow everyone to create invite links",
+          hint:      "Off means only admins can generate invite URLs." %>
+  </section>
 
-    <!-- Email -->
-    <% if Sabha.email_configured? %>
-      <div class="flex flex-column gap align-center" style="--row-gap: 0.5rem">
-        <strong>Email</strong>
-        <% unless Sabha.saas? %>
-          <p class="txt-small txt-secondary" style="max-width: 36ch">
-            Outbound email needs a verified sending domain. Confirm yours before flipping these on.
-          </p>
-        <% end %>
-        <div class="flex flex-column gap">
-          <%= form_with model: @account, method: :put, data: { controller: "form" }, class: "flex align-center gap" do |form| %>
-            <%= form.hidden_field :email_notifications_enabled, value: !Current.account.email_notifications_enabled? %>
-            <label class="switch">
-              <input type="checkbox"
-                    class="switch__input"
-                    <%= "checked" if Current.account.email_notifications_enabled? %>
-                    data-action="change->form#submit">
-              <span class="switch__btn"></span>
-            </label>
-            <span>Send missed-notification emails</span>
-          <% end %>
+  <hr class="separator separator--row margin-block">
 
-          <%= form_with model: @account, method: :put, data: { controller: "form" }, class: "flex align-center gap" do |form| %>
-            <%= form.hidden_field :weekly_digest_enabled, value: !Current.account.weekly_digest_enabled? %>
-            <label class="switch">
-              <input type="checkbox"
-                    class="switch__input"
-                    <%= "checked" if Current.account.weekly_digest_enabled? %>
-                    data-action="change->form#submit">
-              <span class="switch__btn"></span>
-            </label>
-            <span>Send the weekly community digest</span>
-          <% end %>
+  <section>
+    <p class="txt-small txt-muted txt-label margin-block-end-half">Email</p>
+
+    <% unless email_configured %>
+      <div class="callout callout--alert margin-block-end-half">
+        <%= icon_tag "alert", class: "flex-item-no-shrink" %>
+        <div class="txt-small">
+          <strong>Email isn't set up yet.</strong>
+          Add a verified Resend sending domain and set <code>RESEND_API_KEY</code> to turn these on.
         </div>
       </div>
     <% end %>
 
-  </div>
+    <%= render "accounts/setting_toggle", account: @account,
+          attribute: :email_notifications_enabled,
+          title:     "Send missed-notification emails",
+          hint:      "Emails users a recap when they miss a mention or DM while offline.",
+          disabled:  !email_configured %>
+    <hr class="separator separator--row separator--soft">
+
+    <%= render "accounts/setting_toggle", account: @account,
+          attribute: :weekly_digest_enabled,
+          title:     "Send the weekly community digest",
+          hint:      "A Monday recap of top rooms and threads, sent to everyone who opted in.",
+          disabled:  !email_configured %>
+  </section>
 </div>

--- a/app/views/accounts/_admin_settings.html.erb
+++ b/app/views/accounts/_admin_settings.html.erb
@@ -22,32 +22,34 @@
           hint:      "Off means only admins can generate invite URLs." %>
   </section>
 
-  <hr class="separator separator--row margin-block">
+  <% unless Sabha.email_globally_disabled? %>
+    <hr class="separator separator--row margin-block">
 
-  <section>
-    <p class="txt-small txt-muted txt-label margin-block-end-half">Email</p>
+    <section>
+      <p class="txt-small txt-muted txt-label margin-block-end-half">Email</p>
 
-    <% unless email_configured %>
-      <div class="callout callout--alert margin-block-end-half">
-        <%= icon_tag "alert", class: "flex-item-no-shrink" %>
-        <div class="txt-small">
-          <strong>Email isn't set up yet.</strong>
-          Add a verified Resend sending domain and set <code>RESEND_API_KEY</code> to turn these on.
+      <% unless email_configured %>
+        <div class="callout callout--alert margin-block-end-half">
+          <%= icon_tag "alert", class: "flex-item-no-shrink" %>
+          <div class="txt-small">
+            <strong>Email isn't set up yet.</strong>
+            Add a verified Resend sending domain and set <code>RESEND_API_KEY</code> to turn these on.
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
 
-    <%= render "accounts/setting_toggle", account: @account,
-          attribute: :email_notifications_enabled,
-          title:     "Send missed-notification emails",
-          hint:      "Emails users a recap when they miss a mention or DM while offline.",
-          disabled:  !email_configured %>
-    <hr class="separator separator--row separator--soft">
+      <%= render "accounts/setting_toggle", account: @account,
+            attribute: :email_notifications_enabled,
+            title:     "Send missed-notification emails",
+            hint:      "Emails users a recap when they miss a mention or DM while offline.",
+            disabled:  !email_configured %>
+      <hr class="separator separator--row separator--soft">
 
-    <%= render "accounts/setting_toggle", account: @account,
-          attribute: :weekly_digest_enabled,
-          title:     "Send the weekly community digest",
-          hint:      "A Monday recap of top rooms and threads, sent to everyone who opted in.",
-          disabled:  !email_configured %>
-  </section>
+      <%= render "accounts/setting_toggle", account: @account,
+            attribute: :weekly_digest_enabled,
+            title:     "Send the weekly community digest",
+            hint:      "A Monday recap of top rooms and threads, sent to everyone who opted in.",
+            disabled:  !email_configured %>
+    </section>
+  <% end %>
 </div>

--- a/app/views/accounts/_setting_toggle.html.erb
+++ b/app/views/accounts/_setting_toggle.html.erb
@@ -1,0 +1,27 @@
+<%# locals: (account:, attribute:, title:, hint:, scope: nil, disabled: false) %>
+<% current = scope ? account.public_send(scope).public_send("#{attribute}?") : account.public_send("#{attribute}?") %>
+
+<%= form_with model: account, method: :put, data: { controller: "form" } do |form| %>
+  <% if scope %>
+    <%= form.fields_for scope, account.public_send(scope) do |scoped| %>
+      <%= scoped.hidden_field attribute, value: !current %>
+    <% end %>
+  <% else %>
+    <%= form.hidden_field attribute, value: !current %>
+  <% end %>
+
+  <label class="setting-row">
+    <span class="setting-row__text">
+      <span class="setting-row__title"><%= title %></span>
+      <span class="txt-small txt-muted"><%= hint %></span>
+    </span>
+    <span class="switch">
+      <input type="checkbox"
+             class="switch__input"
+             <%= "checked" if current %>
+             <%= "disabled" if disabled %>
+             data-action="change->form#submit">
+      <span class="switch__btn"></span>
+    </span>
+  </label>
+<% end %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -1,109 +1,78 @@
-<% @page_title = Current.user.administrator? ? "Account settings" : "About" %>
+<% @page_title = "Account settings" %>
 
 <% content_for :nav do %>
   <div class="flex-item-justify-start">
-    <%= link_back_to_last_room_visited %>
+    <%= link_back_to account_path %>
   </div>
 
-  <% if Current.user.administrator? %>
-    <div class="flex align-center gap flex-item-justify-end">
-      <%= link_to account_users_path, class: "btn" do %>
-        <%= icon_tag "everyone" %>
-        <span class="for-screen-reader">Manage members</span>
-      <% end %>
+  <div class="flex align-center gap flex-item-justify-end">
+    <%= link_to account_users_path, class: "btn" do %>
+      <%= icon_tag "everyone" %>
+      <span class="for-screen-reader">Manage members</span>
+    <% end %>
 
-      <%= link_to account_bots_path, class: "btn", style: "view-transition-name: chat-bots" do %>
-        <%= icon_tag "bot" %>
-        <span class="for-screen-reader">Set up chat bots</span>
-      <% end %>
+    <%= link_to account_bots_path, class: "btn", style: "view-transition-name: chat-bots" do %>
+      <%= icon_tag "bot" %>
+      <span class="for-screen-reader">Set up chat bots</span>
+    <% end %>
 
-      <%= link_to edit_account_custom_styles_path, class: "btn", style: "view-transition-name: custom-styles" do %>
-        <%= icon_tag "art" %>
-        <span class="for-screen-reader">Custom styles</span>
-      <% end %>
-    </div>
-  <% end %>
+    <%= link_to edit_account_custom_styles_path, class: "btn", style: "view-transition-name: custom-styles" do %>
+      <%= icon_tag "art" %>
+      <span class="for-screen-reader">Custom styles</span>
+    <% end %>
+  </div>
 <% end %>
 
 <section class="panel txt-align-center flex flex-column gap" style="view-transition-name: account-settings">
-  <% if Current.user.can_administer? %>
-    <div class="align-center center avatar__form gap" data-controller="upload-preview">
-      <%= form_with model: @account, method: :patch, class: "txt-medium", data: { controller: "form" } do |form| %>
-        <label class="btn input--file">
-          <%= icon_tag "camera" %>
-          <%= form.file_field :logo, class: "input", accept: "image/*",
-                data: { action: "upload-preview#previewImage change->form#submit" } %>
-          <span class="for-screen-reader">Upload logo</span>
-        </label>
-      <% end %>
-
-      <%= form_with model: @account, method: :patch, data: { controller: "form" } do |form| %>
-        <label class="btn avatar input--file account-logo txt-xx-large">
-          <%= image_tag fresh_account_logo_path, role: "presentation", size: 48, data: { upload_preview_target: "image" } %>
-          <%= form.file_field :logo, class: "input", accept: "image/*",
-                data: { action: "upload-preview#previewImage change->form#submit" } %>
-          <span class="for-screen-reader">Upload logo</span>
-        </label>
-      <% end %>
-
-      <% if @account.logo.attached? %>
-        <%= button_to fresh_account_logo_path, method: :delete, class: "btn btn--negative txt-small avatar__delete-btn" do %>
-          <%= icon_tag "minus" %>
-          <span class="for-screen-reader">Delete logo</span>
-        <% end %>
-      <% end %>
-    </div>
-
-    <%= form_with model: @account, data: { controller: "form" }, class: "flex flex-column gap" do |form| %>
-      <div class="flex align-center gap">
-        <%= translation_button(:account_name) %>
-
-        <label class="flex align-center gap flex-item-grow">
-          <%= form.text_field :name, class: "input txt-large", autocomplete: "off", placeholder: "Name this account", autofocus: true,
-                data: { action: "keydown.enter->form#submit" } %>
-        </label>
-
-        <%= form.button class: "btn btn--reversed center txt-large", type: "submit" do %>
-          <%= icon_tag "check" %>
-          <span class="for-screen-reader">Save changes</span>
-        <% end %>
-      </div>
+  <div class="align-center center avatar__form gap" data-controller="upload-preview">
+    <%= form_with model: @account, method: :patch, class: "txt-medium", data: { controller: "form" } do |form| %>
+      <label class="btn input--file">
+        <%= icon_tag "camera" %>
+        <%= form.file_field :logo, class: "input", accept: "image/*",
+              data: { action: "upload-preview#previewImage change->form#submit" } %>
+        <span class="for-screen-reader">Upload logo</span>
+      </label>
     <% end %>
-  <% else %>
-    <%= account_logo_tag style: "txt-xx-large center" %>
-    <h1 class="flex-item-grow txt-x-large"><%= @account.name %></h1>
 
-    <div class="flex justify-center gap txt-small txt-muted">
-      <span><%= pluralize(@member_count, "member") %></span>
-      <span>&middot;</span>
-      <span><%= pluralize(online_users_count, "online") %></span>
-      <span>&middot;</span>
-      <span><%= pluralize(@room_count, "room") %></span>
+    <%= form_with model: @account, method: :patch, data: { controller: "form" } do |form| %>
+      <label class="btn avatar input--file account-logo txt-xx-large">
+        <%= image_tag fresh_account_logo_path, role: "presentation", size: 48, data: { upload_preview_target: "image" } %>
+        <%= form.file_field :logo, class: "input", accept: "image/*",
+              data: { action: "upload-preview#previewImage change->form#submit" } %>
+        <span class="for-screen-reader">Upload logo</span>
+      </label>
+    <% end %>
+
+    <% if @account.logo.attached? %>
+      <%= button_to fresh_account_logo_path, method: :delete, class: "btn btn--negative txt-small avatar__delete-btn" do %>
+        <%= icon_tag "minus" %>
+        <span class="for-screen-reader">Delete logo</span>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= form_with model: @account, data: { controller: "form" }, class: "flex flex-column gap" do |form| %>
+    <div class="flex align-center gap">
+      <%= translation_button(:account_name) %>
+
+      <label class="flex align-center gap flex-item-grow">
+        <%= form.text_field :name, class: "input txt-large", autocomplete: "off", placeholder: "Name this account", autofocus: true,
+              data: { action: "keydown.enter->form#submit" } %>
+      </label>
+
+      <%= form.button class: "btn btn--reversed center txt-large", type: "submit" do %>
+        <%= icon_tag "check" %>
+        <span class="for-screen-reader">Save changes</span>
+      <% end %>
     </div>
   <% end %>
 
-  <% if Current.user.administrator? %>
-    <%= render "accounts/admin_settings" %>
-
-    <div class="pad-inline pad-block fill-shade border-radius txt-align-center">
-      <%= render "accounts/invite" %>
-    </div>
-  <% elsif Current.account.settings.allow_users_to_create_invite_links? %>
-    <div class="pad-inline pad-block fill-shade border-radius txt-align-center">
-      <%= render "users/profiles/invite_link" %>
-    </div>
-  <% end %>
+  <%= render "accounts/admin_settings" %>
 
   <div class="flex justify-center">
     <%= link_to account_users_path, class: "btn btn--reversed" do %>
       <%= icon_tag "everyone" %>
-      <span><%= Current.user.staff? ? "Manage members" : "Members" %></span>
+      <span>Manage members</span>
     <% end %>
   </div>
 </section>
-
-<% unless Sabha.saas? %>
-  <% content_for :footer do %>
-    <div class="txt-align-center center margin-block-double txt-subtle">Sabha&trade; version <%= version_badge %></div>
-  <% end %>
-<% end %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -17,12 +17,12 @@
 
 <section class="panel txt-align-center flex flex-column gap" style="view-transition-name: account-settings">
   <%= account_logo_tag style: "account-logo--display txt-xx-large center" %>
-  <h1 class="flex-item-grow txt-x-large"><%= @account.name %></h1>
+  <h1 class="txt-x-large margin-none"><%= @account.name %></h1>
 
   <div class="flex justify-center gap txt-small txt-muted">
     <span><%= pluralize(@member_count, "member") %></span>
     <span>&middot;</span>
-    <span><%= pluralize(online_users_count, "online") %></span>
+    <span><%= online_users_count %> online</span>
     <span>&middot;</span>
     <span><%= pluralize(@room_count, "room") %></span>
   </div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,0 +1,52 @@
+<% @page_title = "About" %>
+
+<% content_for :nav do %>
+  <div class="flex-item-justify-start">
+    <%= link_back_to_last_room_visited %>
+  </div>
+
+  <% if Current.user.can_administer? %>
+    <div class="flex align-center gap flex-item-justify-end">
+      <%= link_to edit_account_path, class: "btn", style: "view-transition-name: account-settings" do %>
+        <%= icon_tag "settings" %>
+        <span class="for-screen-reader">Configure account</span>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<section class="panel txt-align-center flex flex-column gap" style="view-transition-name: account-settings">
+  <%= account_logo_tag style: "account-logo--display txt-xx-large center" %>
+  <h1 class="flex-item-grow txt-x-large"><%= @account.name %></h1>
+
+  <div class="flex justify-center gap txt-small txt-muted">
+    <span><%= pluralize(@member_count, "member") %></span>
+    <span>&middot;</span>
+    <span><%= pluralize(online_users_count, "online") %></span>
+    <span>&middot;</span>
+    <span><%= pluralize(@room_count, "room") %></span>
+  </div>
+
+  <% if Current.account.settings.allow_users_to_create_invite_links? || Current.user.can_administer? %>
+    <div class="pad-inline pad-block fill-shade border-radius txt-align-center">
+      <% if Current.user.can_administer? %>
+        <%= render "accounts/invite" %>
+      <% else %>
+        <%= render "users/profiles/invite_link" %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="flex justify-center">
+    <%= link_to account_users_path, class: "btn btn--reversed" do %>
+      <%= icon_tag "everyone" %>
+      <span><%= Current.user.staff? ? "Manage members" : "Members" %></span>
+    <% end %>
+  </div>
+</section>
+
+<% unless Sabha.saas? %>
+  <% content_for :footer do %>
+    <div class="txt-align-center center margin-block-double txt-subtle">Sabha&trade; version <%= version_badge %></div>
+  <% end %>
+<% end %>

--- a/app/views/accounts/users/index.html.erb
+++ b/app/views/accounts/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :nav do %>
   <div class="flex-item-justify-start">
-    <%= link_to edit_account_path, class: "btn" do %>
+    <%= link_to account_path, class: "btn" do %>
       <%= icon_tag "arrow-left" %>
       <span class="for-screen-reader">Back</span>
     <% end %>

--- a/app/views/users/sidebars/show.html.erb
+++ b/app/views/users/sidebars/show.html.erb
@@ -118,7 +118,7 @@
         <span class="sidebar__tool-label">Bookmarks</span>
       <% end %>
 
-      <%= link_to edit_account_path, class: "btn sidebar__tool" do %>
+      <%= link_to account_path, class: "btn sidebar__tool" do %>
         <%= icon_tag Current.user&.staff? ? "crown" : "world", style: "view-transition-name: account-settings" %>
         <span class="for-screen-reader">About</span>
         <span class="sidebar__tool-label">About</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
 
   resources :password_resets, only: [ :new, :create, :edit, :update ], param: :token
 
-  resource :account do
+  resource :account, only: %i[ show edit update ] do
     scope module: "accounts" do
       resources :users do
         resource :reactivation, only: :create, module: "users"

--- a/lib/sabha.rb
+++ b/lib/sabha.rb
@@ -63,9 +63,8 @@ module Sabha
       end
     end
 
-    private
-      def email_globally_disabled?
-        ENV["EMAIL_GLOBALLY_DISABLED"] == "true"
-      end
+    def email_globally_disabled?
+      ENV["EMAIL_GLOBALLY_DISABLED"] == "true"
+    end
   end
 end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -5,9 +5,30 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     sign_in :david
   end
 
+  test "show is accessible to admins" do
+    get account_url
+    assert_response :ok
+  end
+
+  test "show is accessible to non-admins as the about page" do
+    sign_in :kevin
+    assert users(:kevin).member?
+
+    get account_url
+    assert_response :success
+  end
+
   test "edit" do
     get edit_account_url
     assert_response :ok
+  end
+
+  test "non-admins cannot access edit" do
+    sign_in :kevin
+    assert users(:kevin).member?
+
+    get edit_account_url
+    assert_redirected_to root_path
   end
 
   test "update" do
@@ -25,14 +46,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
 
     put account_url, params: { account: { name: "Different" } }
     assert_redirected_to root_path
-  end
-
-  test "non-admins can access edit as read-only about page" do
-    sign_in :kevin
-    assert users(:kevin).member?
-
-    get edit_account_url
-    assert_response :success
   end
 
   test "admin can flip email_notifications_enabled" do


### PR DESCRIPTION
## Summary
- Splits the dual-purpose `GET /account/edit` into `GET /account` (read-only About page for everyone) and `GET /account/edit` (admin-only config UI). `edit` is now gated by `ensure_can_administer`, members are redirected. Sidebar "About" + the members-index back-link now point to `account_path`.
- Refactors the admin settings panel out of the old `<strong>` + center-aligned soup into a Rails-shaped partial. Extracts `accounts/_setting_toggle.html.erb` (locals: account, attribute, title, hint, scope, disabled) and replaces the seven stamped `form_with` blocks with five `render` calls. Promotes the inline `style="..."` declarations into named CSS classes: `.setting-row` / `.setting-row__title` / `.setting-row__text` in `inputs.css`, `.separator--row` / `.separator--soft` in `separators.css`, `.callout` / `.callout--alert` in `panels.css`.
- Simplifies admin email gating: the Email section is hidden entirely when `EMAIL_GLOBALLY_DISABLED=true`; when only the provider key is missing the section still renders with a single "Email isn't set up yet" callout and the two toggles disabled. `Sabha.email_globally_disabled?` is now public so the view can ask it directly.
- Show page now uses `account_logo_tag` with a new `.account-logo--display` modifier (sets `--avatar-size: var(--btn-size)`) so the read-only logo matches the edit page's `.btn`-wrapped clickable logo in size, without smuggling `.btn` or screen-reader spans into static markup.

## Test plan
- [ ] `unset UNTENANTED_DATABASE_URL && bin/rails test` — full suite green (1437 runs). Run with `EMAIL_GLOBALLY_DISABLED=false` if your local `.env` has the kill switch on.
- [ ] `SAAS=true bin/rails test saas/test/` — SaaS suite green.
- [ ] Sign in as `david` (admin in fixtures), visit `/account` — see the About page with the configure-icon button in the nav.
- [ ] Click the configure button → land on `/account/edit` with the admin settings panel; toggle a Permissions switch and confirm the value persists after reload.
- [ ] Sign in as `kevin` (member), visit `/account` — same About page, no configure button; visiting `/account/edit` directly redirects to root.
- [ ] On the edit page, unset `RESEND_API_KEY` and reload — Email section still renders with the disabled toggles and the alert callout.
- [ ] Set `EMAIL_GLOBALLY_DISABLED=true` and reload — Email section + its preceding divider disappear cleanly.