### PR TITLE
Hide cleared activity notifications

### DIFF
--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -87,7 +87,9 @@ class InboxesController < ApplicationController
     end
 
     def find_notifications
-      paginate(Inbox::ActivityQuery.new(Current.user).call).tap do |notifications|
+      query = Inbox::ActivityQuery.new(Current.user, cleared_at: session[:inbox_activity_cleared_at])
+
+      paginate(query.call).tap do |notifications|
         messages = notifications.filter_map(&:message)
         Message.with_thread_participants(messages)
         preload_bookmark_status(messages)

--- a/app/models/inbox/activity_query.rb
+++ b/app/models/inbox/activity_query.rb
@@ -1,17 +1,30 @@
 # Fetches notifications for the user's Activity tab:
 # @mentions, boost reactions, and thread replies.
 class Inbox::ActivityQuery
-  def initialize(user)
+  def initialize(user, cleared_at: nil)
     @user = user
+    @cleared_at = cleared_at
   end
 
   def call
-    Notification.where(user: user)
-                .with_message_and_creator
-                .ordered
+    scope = Notification.where(user: user)
+                        .with_message_and_creator
+                        .ordered
+
+    if (time = cleared_at_time)
+      scope = scope.where("notifications.created_at > ?", time)
+    end
+
+    scope
   end
 
   private
 
-  attr_reader :user
+  attr_reader :user, :cleared_at
+
+  def cleared_at_time
+    return unless cleared_at.present?
+
+    Time.iso8601(cleared_at)
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -91,6 +91,10 @@ class Membership < ApplicationRecord
     broadcast_read
   end
 
+  def clear_unread_notifications_until(time)
+    update!(unread_notifications_count: count_unread_notifications_after(time))
+  end
+
   def read?
     unread_at.blank?
   end
@@ -179,6 +183,16 @@ class Membership < ApplicationRecord
     def broadcast_unread
       UserUnreadRoomsChannel.broadcast_to(user, unread_payload)
       UnreadNotificationsChannel.broadcast_to(user, notification_payload) if has_unread_notifications?
+    end
+
+    def count_unread_notifications_after(time)
+      return 0 if unread_at.nil?
+
+      Notification.joins(:message)
+        .where(user_id: user_id, activity_type: "mention", messages: { room_id: room_id })
+        .where("messages.created_at >= ?", unread_at)
+        .where("notifications.created_at > ?", time)
+        .count
     end
 
     def broadcast_involvement

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -589,7 +589,11 @@ class User < ApplicationRecord
           .where.not(id: notified_message_ids)
           .between(m.unread_at, until_time)
 
-        m.read_until(until_time) if non_notified.none?
+        if non_notified.none?
+          m.read_until(until_time)
+        else
+          m.clear_unread_notifications_until(until_time)
+        end
       end
     end
 

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -134,11 +134,12 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
     assert_match "Thread reply visible in activity", response.body
   end
 
-  test "activity shows all notifications" do
+  test "activity hides notifications cleared in this session and shows newer notifications" do
     room = rooms(:pets)
+    Notification.where(user: @david).delete_all
 
     room.messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)} all visible</div>",
+      body: "<div>Hey #{mention_attachment_for(:david)} cleared activity marker</div>",
       creator: @jason,
       client_message_id: "all_visible"
     )
@@ -146,17 +147,18 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
     get activity_inbox_url
     post clear_inbox_url, params: { scope: "activity", stay: true }
 
-    room.messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)} also visible</div>",
-      creator: @jason,
-      client_message_id: "also_visible"
-    )
+    travel 1.second do
+      room.messages.create!(
+        body: "<div>Hey #{mention_attachment_for(:david)} newer activity marker</div>",
+        creator: @jason,
+        client_message_id: "also_visible"
+      )
+    end
 
-    # Both should appear
     get activity_inbox_url
     assert_response :success
-    assert_match "all visible", response.body
-    assert_match "also visible", response.body
+    assert_no_match "cleared activity marker", response.body
+    assert_match "newer activity marker", response.body
   end
 
   test "mentioning a non-member does not add them to the room" do
@@ -423,6 +425,32 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
 
     assert membership_with_mention.read?, "Room with mention should be marked as read"
     assert membership_without_mention.unread?, "Room without mention should remain unread"
+  end
+
+  test "clear with scope activity clears notification badge without reading regular messages" do
+    room = rooms(:pets)
+    membership = room.memberships.find_by(user: @david)
+    membership.update!(unread_at: 1.hour.ago)
+
+    room.messages.create!(
+      body: "Regular unread chatter",
+      creator: @jason,
+      client_message_id: "activity_badge_regular"
+    )
+    room.messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: @jason,
+      client_message_id: "activity_badge_mention"
+    )
+
+    assert membership.reload.unread?
+    assert_equal 1, membership.unread_notifications_count
+
+    get activity_inbox_url
+    post clear_inbox_url, params: { scope: "activity" }
+
+    assert membership.reload.unread?, "Regular unread messages should remain unread"
+    assert_equal 0, membership.unread_notifications_count, "Activity badge should clear"
   end
 
   test "clear with scope direct_messages only clears DM rooms" do


### PR DESCRIPTION
## Summary

Clearing Activity now removes the notifications the user already saw and clears the Activity dot without marking unrelated unread room chatter as read.

The Activity list now honors the existing session clear timestamp, so older notifications stop rendering after `Mark all as read`. Room membership notification counts are also reduced for cleared mentions while preserving the existing unread-message invariant when a room has other unread messages in the same window.

## Test Plan

- `bin/rails test test/controllers/inboxes_controller_test.rb`
- `bin/rails test`
- `SAAS=true bin/rails test saas/test/`
- Manual log check: clear request updated affected `memberships.unread_notifications_count` to `0`, then the Activity and sidebar frames reloaded.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
