### PR TITLE
Add SaaS SSO provider endpoint

### DIFF
--- a/app/models/sso/payload.rb
+++ b/app/models/sso/payload.rb
@@ -37,7 +37,7 @@ class Sso::Payload
     raise InvalidPayload, "Invalid Base64 payload" unless encoded_payload.match?(BASE64_PATTERN)
     raise InvalidSignature, "Bad signature for payload" unless valid_signature?(encoded_payload, signature, secret)
 
-    decoded_payload = Base64.decode64(encoded_payload)
+    decoded_payload = Base64.strict_decode64(encoded_payload)
     decoded_hash = Rack::Utils.parse_query(decoded_payload)
     attributes = parse_fields(decoded_hash)
 

--- a/app/models/sso/provider_client.rb
+++ b/app/models/sso/provider_client.rb
@@ -1,0 +1,80 @@
+class Sso::ProviderClient
+  # Registered relying apps allowed to use Sabha SaaS as their SSO identity
+  # provider. This is the provider-side complement to the self-hosted SSO
+  # consumer config on Account, not another way for a workspace to sign in.
+  #
+  # sabha.co (Sabha SaaS mode) is the SSO provider / identity authority.
+  # cloud.sabha.co (sabha_cloud) is the SSO client / relying app.
+  class Error < StandardError; end
+  class NotConfigured < Error; end
+  class InvalidReturnUrl < Error; end
+
+  DEFAULT_RETURN_PATH = "/session/sso/callback"
+
+  attr_reader :name, :return_host, :return_path, :secret
+
+  def self.authenticate(encoded_payload, signature)
+    raise NotConfigured, "No SSO provider clients are configured" if active.none?
+    raise Sso::Payload::InvalidPayload, "Missing SSO payload" if encoded_payload.blank?
+    raise Sso::Payload::InvalidSignature, "Missing SSO signature" if signature.blank?
+
+    client = active.find { |candidate| Sso::Payload.valid_signature?(encoded_payload, signature, candidate.secret) }
+    raise Sso::Payload::InvalidSignature, "Bad signature for payload" unless client
+
+    payload = Sso::Payload.decode(encoded_payload, signature, client.secret)
+    raise Sso::Payload::InvalidPayload, "Missing SSO nonce" if payload["nonce"].blank?
+
+    client.verify_return_url!(payload["return_sso_url"])
+
+    [ client, payload ]
+  end
+
+  def self.active
+    all.select(&:active?)
+  end
+
+  def self.all
+    ENV.fetch("SSO_PROVIDER_CLIENTS", "").split(",").filter_map do |name|
+      from_env(name.strip)
+    end
+  end
+
+  def self.from_env(name)
+    return if name.blank?
+
+    key = name.upcase
+    new(
+      name: name,
+      return_host: ENV["SSO_#{key}_RETURN_HOST"],
+      return_path: ENV.fetch("SSO_#{key}_RETURN_PATH", DEFAULT_RETURN_PATH),
+      secret: ENV["SSO_#{key}_SECRET"],
+      active: ENV.fetch("SSO_#{key}_ACTIVE", "true")
+    )
+  end
+
+  def initialize(name:, return_host:, return_path:, secret:, active:)
+    @name = name
+    @return_host = return_host
+    @return_path = return_path
+    @secret = secret
+    @active = active
+  end
+
+  def active?
+    ActiveModel::Type::Boolean.new.cast(@active) && return_host.present? && secret.present?
+  end
+
+  def verify_return_url!(url)
+    raise InvalidReturnUrl, "Missing SSO return URL" if url.blank?
+
+    uri = URI.parse(url)
+
+    unless uri.is_a?(URI::HTTPS) && uri.host == return_host && uri.path == return_path && uri.userinfo.blank?
+      raise InvalidReturnUrl, "Untrusted SSO return URL"
+    end
+
+    true
+  rescue URI::InvalidURIError
+    raise InvalidReturnUrl, "Invalid SSO return URL"
+  end
+end

--- a/saas/app/controllers/saas/single_sign_ons_controller.rb
+++ b/saas/app/controllers/saas/single_sign_ons_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Saas
+  class SingleSignOnsController < BaseController
+    allow_unauthenticated_access
+
+    before_action :set_sso_request
+
+    def show
+      unless signed_in?
+        return redirect_to new_session_path(return_to: request.fullpath), alert: "Please sign in to continue"
+      end
+
+      sso, sig = Sso::Payload.encode(sso_response_payload, @sso_client.secret)
+
+      redirect_to return_sso_url(sso:, sig:), allow_other_host: true
+    end
+
+    private
+
+      def set_sso_request
+        @sso_client, @sso_request = Sso::ProviderClient.authenticate(params[:sso], params[:sig])
+      rescue Sso::ProviderClient::NotConfigured
+        head :service_unavailable
+      rescue Sso::Payload::Error, Sso::ProviderClient::Error
+        head :forbidden
+      end
+
+      def sso_response_payload
+        {
+          nonce: @sso_request["nonce"],
+          external_id: "global_identity:#{current_global_identity.id}",
+          email: current_global_identity.email_address,
+          name: current_global_identity.name,
+          require_activation: !current_global_identity.verified?
+        }
+      end
+
+      def return_sso_url(sso:, sig:)
+        uri = URI.parse(@sso_request["return_sso_url"])
+        query = Rack::Utils.parse_query(uri.query).merge("sso" => sso, "sig" => sig)
+        uri.query = Rack::Utils.build_query(query)
+        uri.to_s
+      end
+  end
+end

--- a/saas/lib/sabha/saas/engine.rb
+++ b/saas/lib/sabha/saas/engine.rb
@@ -49,6 +49,7 @@ module Sabha
             root to: "saas/landing#show", as: :saas_root
 
             # Session (login/logout) - uses GlobalIdentity
+            get "/session/sso", to: "saas/single_sign_ons#show"
             resource :session, only: [ :new, :create, :destroy ], controller: "saas/sessions"
 
             # Auth code OTP verification

--- a/saas/test/controllers/saas/single_sign_ons_controller_test.rb
+++ b/saas/test/controllers/saas/single_sign_ons_controller_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module Saas
+  class SingleSignOnsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @original_clients = ENV["SSO_PROVIDER_CLIENTS"]
+      @original_return_host = ENV["SSO_CLOUD_RETURN_HOST"]
+      @original_return_path = ENV["SSO_CLOUD_RETURN_PATH"]
+      @original_secret = ENV["SSO_CLOUD_SECRET"]
+
+      ENV["SSO_PROVIDER_CLIENTS"] = "cloud"
+      ENV["SSO_CLOUD_RETURN_HOST"] = "cloud.sabha.co"
+      ENV["SSO_CLOUD_RETURN_PATH"] = "/session/sso/callback"
+      ENV["SSO_CLOUD_SECRET"] = "cloud-sso-secret"
+    end
+
+    teardown do
+      restore_env("SSO_PROVIDER_CLIENTS", @original_clients)
+      restore_env("SSO_CLOUD_RETURN_HOST", @original_return_host)
+      restore_env("SSO_CLOUD_RETURN_PATH", @original_return_path)
+      restore_env("SSO_CLOUD_SECRET", @original_secret)
+    end
+
+    test "redirects unauthenticated users to global session login with the sso request as return_to" do
+      sso, sig = provider_request
+
+      get "/session/sso", params: { sso:, sig: }
+
+      assert_redirected_to new_session_path(return_to: "/session/sso?sso=#{CGI.escape(sso)}&sig=#{sig}")
+    end
+
+    test "redirects back to registered client with signed global identity payload" do
+      identity = global_identities(:alice)
+      sign_in_global_identity(identity)
+      sso, sig = provider_request
+
+      get "/session/sso", params: { sso:, sig: }
+
+      assert_response :redirect
+      assert_match %r{\Ahttps://cloud\.sabha\.co/session/sso/callback\?}, response.location
+
+      response_payload = callback_payload(response.location)
+      assert_equal "cloud-nonce", response_payload["nonce"]
+      assert_equal "global_identity:#{identity.id}", response_payload["external_id"]
+      assert_equal identity.email_address, response_payload["email"]
+      assert_equal identity.name, response_payload["name"]
+      assert_equal false, response_payload["require_activation"]
+    end
+
+    test "requires activation for unverified global identities" do
+      identity = global_identities(:unverified)
+      sign_in_global_identity(identity)
+      sso, sig = provider_request
+
+      get "/session/sso", params: { sso:, sig: }
+
+      response_payload = callback_payload(response.location)
+      assert_equal true, response_payload["require_activation"]
+    end
+
+    test "rejects request with bad signature" do
+      sso, = provider_request
+
+      get "/session/sso", params: { sso:, sig: "bad-signature" }
+
+      assert_response :forbidden
+    end
+
+    test "rejects request with missing payload" do
+      get "/session/sso"
+
+      assert_response :forbidden
+    end
+
+    test "rejects request without return url" do
+      sso, sig = provider_request(return_sso_url: nil)
+
+      get "/session/sso", params: { sso:, sig: }
+
+      assert_response :forbidden
+    end
+
+    test "rejects unregistered return host" do
+      sso, sig = provider_request(return_sso_url: "https://evil.example.com/session/sso/callback")
+
+      get "/session/sso", params: { sso:, sig: }
+
+      assert_response :forbidden
+    end
+
+    test "rejects unregistered return path" do
+      sso, sig = provider_request(return_sso_url: "https://cloud.sabha.co/other/callback")
+
+      get "/session/sso", params: { sso:, sig: }
+
+      assert_response :forbidden
+    end
+
+    test "fails closed when no provider client is configured" do
+      ENV.delete("SSO_PROVIDER_CLIENTS")
+      sso, sig = provider_request
+
+      get "/session/sso", params: { sso:, sig: }
+
+      assert_response :service_unavailable
+    end
+
+    private
+      def provider_request(attributes = {})
+        Sso::Payload.encode({
+          nonce: "cloud-nonce",
+          return_sso_url: "https://cloud.sabha.co/session/sso/callback"
+        }.merge(attributes), ENV["SSO_CLOUD_SECRET"])
+      end
+
+      def callback_payload(location)
+        uri = URI.parse(location)
+        query = Rack::Utils.parse_query(uri.query)
+
+        Sso::Payload.decode(query["sso"], query["sig"], ENV["SSO_CLOUD_SECRET"])
+      end
+
+      def restore_env(key, value)
+        if value.nil?
+          ENV.delete(key)
+        else
+          ENV[key] = value
+        end
+      end
+  end
+end

--- a/test/models/sso/payload_test.rb
+++ b/test/models/sso/payload_test.rb
@@ -73,6 +73,15 @@ class Sso::PayloadTest < ActiveSupport::TestCase
     end
   end
 
+  test "strictly rejects malformed base64 with valid characters" do
+    sso = "abc="
+    sig = Sso::Payload.sign(sso, SECRET)
+
+    assert_raises Sso::Payload::InvalidPayload do
+      Sso::Payload.decode(sso, sig, SECRET)
+    end
+  end
+
   test "raises on malformed payload" do
     sso = Base64.strict_encode64("%")
     sig = Sso::Payload.sign(sso, SECRET)


### PR DESCRIPTION
## Summary

Sabha SaaS can now act as the SSO identity authority for registered relying apps such as cloud.sabha.co. The provider flow validates the signed request, requires a GlobalIdentity session outside workspace context, and returns a signed identity payload using the global identity rather than a workspace user.

The provider client config is ENV-backed for the initial cloud.sabha.co integration, with return URL validation so the request payload cannot redirect signed identity data to an unregistered host or path. Shared SSO payload decoding now rejects malformed Base64 strictly, matching the existing strict encoder.

## Tests

- `bin/rails test test/controllers/sso_controller_test.rb test/controllers/sso_routes_test.rb test/models/sso/payload_test.rb`
- `SAAS=true bin/rails test saas/test/controllers/saas/single_sign_ons_controller_test.rb`
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bin/rubocop app/models/sso/provider_client.rb`
- pre-commit RuboCop hook
- pre-push Brakeman hook

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
