### PR TITLE
Light up the Activity sidebar dot for boosts and thread replies, drop the 'mark as read' button

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,4 @@
 class ApplicationController < ActionController::Base
   include AllowBrowser, RackMiniProfilerAuthorization, Authentication, Authorization, SetCurrentRequest, SetPlatform, TrackedRoomVisit, VersionHeaders, FragmentCache, Sidebar
   include Turbo::Streams::Broadcasts, Turbo::Streams::StreamName
-
-  private
-    # Turbo Drive prefetches links on hover via `<meta name="turbo-prefetch">`.
-    # Prefetch requests carry the `Sec-Purpose: prefetch` header so the server
-    # can skip side-effects (e.g. advancing a "seen" watermark) that should
-    # only happen on a real visit.
-    def turbo_prefetch?
-      request.headers["Sec-Purpose"] == "prefetch"
-    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::Base
   include AllowBrowser, RackMiniProfilerAuthorization, Authentication, Authorization, SetCurrentRequest, SetPlatform, TrackedRoomVisit, VersionHeaders, FragmentCache, Sidebar
   include Turbo::Streams::Broadcasts, Turbo::Streams::StreamName
+
+  private
+    # Turbo Drive prefetches links on hover via `<meta name="turbo-prefetch">`.
+    # Prefetch requests carry the `Sec-Purpose: prefetch` header so the server
+    # can skip side-effects (e.g. advancing a "seen" watermark) that should
+    # only happen on a real visit.
+    def turbo_prefetch?
+      request.headers["Sec-Purpose"] == "prefetch"
+    end
 end

--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -14,6 +14,7 @@ class InboxesController < ApplicationController
   def activity
     @notifications = find_notifications
     track_last_loaded_notification
+    Current.user.touch_activity_seen_at
   end
 
   def direct_messages

--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -14,7 +14,7 @@ class InboxesController < ApplicationController
   def activity
     @notifications = find_notifications
     track_last_loaded_notification
-    Current.user.touch_activity_seen_at
+    Current.user.touch_activity_seen_at unless turbo_prefetch?
   end
 
   def direct_messages

--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -43,14 +43,9 @@ class InboxesController < ApplicationController
   end
 
   def clear
-    case params[:scope]
-    when "activity"
-      session[:inbox_activity_cleared_at] = session[:inbox_last_loaded_activity_created_at]
-      Current.user.mark_activity_as_read(session[:inbox_last_loaded_activity_created_at])
-    when "direct_messages"
+    if params[:scope] == "direct_messages"
       Current.user.mark_direct_messages_as_read(session[:inbox_last_loaded_dms_created_at])
     else
-      session[:inbox_activity_cleared_at] = session[:inbox_last_loaded_activity_created_at]
       Current.user.mark_inbox_as_read(
         messages_loaded_at: session[:inbox_last_loaded_message_created_at],
         notifications_loaded_at: session[:inbox_last_loaded_notification_created_at],
@@ -88,7 +83,7 @@ class InboxesController < ApplicationController
     end
 
     def find_notifications
-      query = Inbox::ActivityQuery.new(Current.user, cleared_at: session[:inbox_activity_cleared_at])
+      query = Inbox::ActivityQuery.new(Current.user)
 
       paginate(query.call).tap do |notifications|
         messages = notifications.filter_map(&:message)
@@ -132,7 +127,6 @@ class InboxesController < ApplicationController
       session.delete :inbox_last_loaded_activity_created_at
       session.delete :inbox_last_loaded_notification_created_at
       session.delete :inbox_last_loaded_message_created_at
-      session.delete :inbox_activity_cleared_at
     end
 
     # Sidebar setup for DMs inbox - loads first page for inbox content

--- a/app/controllers/inboxes_controller.rb
+++ b/app/controllers/inboxes_controller.rb
@@ -14,7 +14,7 @@ class InboxesController < ApplicationController
   def activity
     @notifications = find_notifications
     track_last_loaded_notification
-    Current.user.touch_activity_seen_at unless turbo_prefetch?
+    Current.user.touch_activity_seen_at
   end
 
   def direct_messages

--- a/app/javascript/controllers/unread_indicator_controller.js
+++ b/app/javascript/controllers/unread_indicator_controller.js
@@ -3,14 +3,15 @@ import { debounce } from "helpers/timing_helpers"
 
 // Generic unread indicator controller that toggles classes on named targets
 // based on whether elements matching their selectors exist in the sidebar.
+// The Activity dot is server-rendered (see users/sidebars/_activity_indicator.html.erb)
+// and broadcast via Turbo Streams, so it's not driven from here.
 //
 // Usage:
 //   data-controller="unread-indicator"
-//   data-unread-indicator-indicators-value='[{"selector":".room.badge","class":"has-unread-activity","target":"activity"},{"selector":".direct.unread","class":"has-unread-dms","target":"dms"}]'
-//   data-unread-indicator-target="activity" (on the activity link)
+//   data-unread-indicator-indicators-value='[{"selector":".direct.unread","class":"has-unread-dms","target":"dms"}]'
 //   data-unread-indicator-target="dms" (on the dms link)
 export default class extends Controller {
-  static targets = ["activity", "dms"]
+  static targets = ["dms"]
   static values = {
     indicators: Array
   }

--- a/app/jobs/create_thread_reply_notifications_job.rb
+++ b/app/jobs/create_thread_reply_notifications_job.rb
@@ -43,6 +43,7 @@ class CreateThreadReplyNotificationsJob < ApplicationJob
         partial: "notifications/notification",
         locals: { notification: notification, timestamp_style: :long_datetime }
       )
+      notification.user.broadcast_activity_indicator
     end
   end
 end

--- a/app/models/boost.rb
+++ b/app/models/boost.rb
@@ -55,6 +55,8 @@ class Boost < ApplicationRecord
         user: @destroyed_notification[:user],
         message_id: @destroyed_notification[:message_id]
       )
+
+      @destroyed_notification[:user].broadcast_activity_indicator
     end
 
     def broadcast_removal

--- a/app/models/inbox/activity_query.rb
+++ b/app/models/inbox/activity_query.rb
@@ -1,30 +1,17 @@
 # Fetches notifications for the user's Activity tab:
 # @mentions, boost reactions, and thread replies.
 class Inbox::ActivityQuery
-  def initialize(user, cleared_at: nil)
+  def initialize(user)
     @user = user
-    @cleared_at = cleared_at
   end
 
   def call
-    scope = Notification.where(user: user)
-                        .with_message_and_creator
-                        .ordered
-
-    if (time = cleared_at_time)
-      scope = scope.where("notifications.created_at > ?", time)
-    end
-
-    scope
+    Notification.where(user: user)
+                .with_message_and_creator
+                .ordered
   end
 
   private
 
-  attr_reader :user, :cleared_at
-
-  def cleared_at_time
-    return unless cleared_at.present?
-
-    Time.iso8601(cleared_at)
-  end
+  attr_reader :user
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -364,6 +364,8 @@ class Message < ApplicationRecord
         partial: "notifications/notification",
         locals: { notification: notification, timestamp_style: :long_datetime }
       )
+
+      notification.user.broadcast_activity_indicator
     end
 
   private
@@ -471,6 +473,7 @@ class Message < ApplicationRecord
         unique_by: "index_notifications_on_message_user_type"
       )
 
+      User.where(id: recipient_ids).each(&:broadcast_activity_indicator)
       broadcast_mention_notifications
     end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -40,6 +40,8 @@ class Notification < ApplicationRecord
       )
     end
 
+    notifications.map(&:user).uniq.each(&:broadcast_activity_indicator)
+
     # Boost groups use a stable DOM ID separate from individual notification IDs
     notifications.select(&:boost_notification?).group_by { |n| [ n.user_id, n.message_id ] }.each do |(_, message_id), group|
       Turbo::StreamsChannel.broadcast_remove_to(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,7 +106,27 @@ class User < ApplicationRecord
   # Only marks as read if there were no non-notified messages in the window
   # (avoids accidentally marking unread messages as read when user only viewed activity)
   def mark_activity_as_read(loaded_at)
-    mark_notified_rooms_as_read(freshness_checked_time(loaded_at))
+    until_time = freshness_checked_time(loaded_at)
+    mark_notified_rooms_as_read(until_time)
+    touch_activity_seen_at(until_time)
+  end
+
+  # Persists the watermark used by has_unseen_activity? to gate the sidebar dot.
+  # Monotonic: only advances forward so stale `loaded_at` values from background
+  # tabs can't reopen the dot. Broadcast is fired by after_update_commit below.
+  def touch_activity_seen_at(time = Time.current)
+    return if time.nil?
+    return if activity_seen_at.present? && activity_seen_at >= time
+
+    update!(activity_seen_at: time)
+  end
+
+  # True when at least one notification row has arrived since the user last
+  # opened the Activity tab. Drives the sidebar Activity dot.
+  def has_unseen_activity?
+    scope = notifications
+    scope = scope.where("notifications.created_at > ?", activity_seen_at) if activity_seen_at
+    scope.exists?
   end
 
   # Marks all direct message rooms as read up to the loaded timestamp.
@@ -138,6 +158,8 @@ class User < ApplicationRecord
 
     # Mark activity rooms as read: DMs always, others only if all unread messages have notifications
     mark_notified_rooms_as_read(activity_until, include_dms: true)
+
+    touch_activity_seen_at(activity_until)
   end
 
   has_many :push_subscriptions, class_name: "Push::Subscription", dependent: :delete_all
@@ -191,6 +213,7 @@ class User < ApplicationRecord
   after_update :send_email_change_notification, if: :saved_change_to_email_address?
   after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
   after_update_commit :sync_workspace_membership_active, if: -> { Sabha.saas? && saved_change_to_status? }
+  after_update_commit :broadcast_activity_indicator, if: :saved_change_to_activity_seen_at?
 
   before_validation :set_default_name
   before_validation :normalize_social_urls
@@ -425,6 +448,15 @@ class User < ApplicationRecord
 
   def pending_email_change?
     unconfirmed_email.present?
+  end
+
+  def broadcast_activity_indicator
+    Turbo::StreamsChannel.broadcast_replace_to(
+      self, :sidebar_activity_indicator,
+      target: "sidebar_activity_indicator",
+      partial: "users/sidebars/activity_indicator",
+      locals: { user: self }
+    )
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,17 +101,7 @@ class User < ApplicationRecord
       )
   end
 
-  # Marks rooms with unread activity (mentions, boosts, thread replies) as read.
-  # DMs are handled separately by mark_direct_messages_as_read.
-  # Only marks as read if there were no non-notified messages in the window
-  # (avoids accidentally marking unread messages as read when user only viewed activity)
-  def mark_activity_as_read(loaded_at)
-    until_time = freshness_checked_time(loaded_at)
-    mark_notified_rooms_as_read(until_time)
-    touch_activity_seen_at(until_time)
-  end
-
-  # Persists the watermark used by has_unseen_activity? to gate the sidebar dot.
+  # Persists the watermark used by unseen_activity? to gate the sidebar dot.
   # Monotonic: only advances forward so stale `loaded_at` values from background
   # tabs can't reopen the dot. Broadcast is fired by after_update_commit below.
   def touch_activity_seen_at(time = Time.current)
@@ -123,7 +113,7 @@ class User < ApplicationRecord
 
   # True when at least one notification row has arrived since the user last
   # opened the Activity tab. Drives the sidebar Activity dot.
-  def has_unseen_activity?
+  def unseen_activity?
     scope = notifications
     scope = scope.where("notifications.created_at > ?", activity_seen_at) if activity_seen_at
     scope.exists?

--- a/app/views/inboxes/activity.html.erb
+++ b/app/views/inboxes/activity.html.erb
@@ -1,10 +1,5 @@
 <% @page_title = "Activity" %>
-<%= render layout: "inboxes/nav", locals: { title: "Activity" } do %>
-  <%= button_to clear_inbox_path(scope: "activity"), class: "btn", title: "Mark activity as read",
-      data: { turbo_confirm: "Mark all activity as read?" } do %>
-    <%= icon_tag "check-circle" %>
-  <% end %>
-<% end %>
+<%= render "inboxes/nav", title: "Activity" %>
 
 <% content_for :messages do %>
   <%= search_results_tag("inbox", paged_inbox_activity_index_url, highlight_mentions: true, thread_messages: false) do %>

--- a/app/views/users/sidebars/_activity_indicator.html.erb
+++ b/app/views/users/sidebars/_activity_indicator.html.erb
@@ -1,0 +1,6 @@
+<%= link_to inbox_path, id: "sidebar_activity_indicator",
+      class: [ "btn sidebar__tool", "has-unread-activity": user.has_unseen_activity? ] do %>
+  <%= icon_tag "mentions" %>
+  <span class="for-screen-reader">Activity</span>
+  <span class="sidebar__tool-label">Activity</span>
+<% end %>

--- a/app/views/users/sidebars/_activity_indicator.html.erb
+++ b/app/views/users/sidebars/_activity_indicator.html.erb
@@ -1,5 +1,5 @@
 <%= link_to inbox_path, id: "sidebar_activity_indicator",
-      class: [ "btn sidebar__tool", "has-unread-activity": user.has_unseen_activity? ] do %>
+      class: [ "btn sidebar__tool", "has-unread-activity": user.unseen_activity? ] do %>
   <%= icon_tag "mentions" %>
   <span class="for-screen-reader">Activity</span>
   <span class="sidebar__tool-label">Activity</span>

--- a/app/views/users/sidebars/_activity_indicator.html.erb
+++ b/app/views/users/sidebars/_activity_indicator.html.erb
@@ -1,5 +1,6 @@
 <%= link_to inbox_path, id: "sidebar_activity_indicator",
-      class: [ "btn sidebar__tool", "has-unread-activity": user.unseen_activity? ] do %>
+      class: [ "btn sidebar__tool", "has-unread-activity": user.unseen_activity? ],
+      data: { turbo_prefetch: false } do %>
   <%= icon_tag "mentions" %>
   <span class="for-screen-reader">Activity</span>
   <span class="sidebar__tool-label">Activity</span>

--- a/app/views/users/sidebars/show.html.erb
+++ b/app/views/users/sidebars/show.html.erb
@@ -3,7 +3,7 @@
   <%= turbo_stream_from Current.user, :rooms %>
 
   <div data-controller="unread-indicator"
-       data-unread-indicator-indicators-value='[{"selector":".room.badge","class":"has-unread-activity","target":"activity"},{"selector":".direct.unread","class":"has-unread-dms","target":"dms"}]'
+       data-unread-indicator-indicators-value='[{"selector":".direct.unread","class":"has-unread-dms","target":"dms"}]'
        data-action="rooms-list:unread@window->unread-indicator#update rooms-list:read@window->unread-indicator#update rooms-list:addBadge@window->unread-indicator#update">
     <div class="sidebar__container overflow-y overflow-hide-scrollbar"
         data-controller="badge-dot maintain-scroll debounce-updates"
@@ -94,11 +94,8 @@
     </button>
 
     <div class="sidebar__tool-container">
-      <%= link_to inbox_path, class: "btn sidebar__tool", data: { unread_indicator_target: "activity" } do %>
-        <%= icon_tag "mentions" %>
-        <span class="for-screen-reader">Activity</span>
-        <span class="sidebar__tool-label">Activity</span>
-      <% end %>
+      <%= turbo_stream_from Current.user, :sidebar_activity_indicator %>
+      <%= render "users/sidebars/activity_indicator", user: Current.user %>
 
       <%= link_to direct_messages_inbox_path, class: "btn sidebar__tool", data: { unread_indicator_target: "dms" } do %>
         <%= icon_tag "messages" %>

--- a/db/migrate/20260521061320_add_activity_seen_at_to_users.rb
+++ b/db/migrate/20260521061320_add_activity_seen_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddActivitySeenAtToUsers < ActiveRecord::Migration[8.2]
+  def change
+    add_column :users, :activity_seen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_18_190000) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_21_061320) do
   create_table "account_join_codes", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "code", null: false
@@ -337,6 +337,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_18_190000) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.datetime "accepted_terms_at"
+    t.datetime "activity_seen_at"
     t.string "ascii_name"
     t.integer "avatar_seed"
     t.string "avatar_url"
@@ -399,10 +401,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_18_190000) do
   add_foreign_key "boosts", "messages"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users", column: "creator_id"
-  add_foreign_key "notification_bundle_items", "messages", on_delete: :cascade
-  add_foreign_key "notification_bundle_items", "notification_bundles", column: "bundle_id", on_delete: :cascade
-  add_foreign_key "notification_bundle_items", "users", column: "actor_id", on_delete: :cascade
-  add_foreign_key "notification_bundles", "users", on_delete: :cascade
+  add_foreign_key "notification_bundle_items", "messages"
+  add_foreign_key "notification_bundle_items", "notification_bundles", column: "bundle_id"
+  add_foreign_key "notification_bundle_items", "users", column: "actor_id"
+  add_foreign_key "notification_bundles", "users"
   add_foreign_key "notifications", "boosts"
   add_foreign_key "notifications", "messages"
   add_foreign_key "notifications", "users"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -1288,6 +1288,26 @@ columns:
   users:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
+    name: accepted_terms_at
+    cast_type: *1
+    sql_type_metadata: *2
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: activity_seen_at
+    cast_type: *1
+    sql_type_metadata: *2
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
     name: ascii_name
     cast_type: *5
     sql_type_metadata: *6
@@ -2885,4 +2905,4 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-version: 20260518190000
+version: 20260521061320

--- a/saas/test/jobs/workspace/snapshot_job_test.rb
+++ b/saas/test/jobs/workspace/snapshot_job_test.rb
@@ -7,8 +7,10 @@ class Workspace::SnapshotJobTest < ActiveSupport::TestCase
     creator = global_identities(:admin)
 
     with_provisioned_workspace(name: "Snapshot Test", creator: creator) do |workspace|
-      # Clean up any stale messages from tenant DB reuse
-      ApplicationRecord.with_tenant(workspace.external_id.to_s) { Message.delete_all }
+      # Clean up any stale messages from tenant DB reuse. destroy_all (not
+      # delete_all) so Message#destroy_all_associated_records cascades to
+      # notifications/boosts/bookmarks — otherwise the FK constraint trips.
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) { Message.destroy_all }
 
       Workspace::SnapshotJob.perform_now(workspace)
 

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -51,6 +51,22 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
       "visiting Activity should advance the watermark and clear the dot"
   end
 
+  test "Turbo prefetch on Activity does not clear the dot" do
+    @david.update_column(:activity_seen_at, nil)
+    rooms(:pets).messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: @jason,
+      client_message_id: "activity_prefetch_test"
+    )
+    assert @david.reload.unseen_activity?
+
+    get activity_inbox_url, headers: { "Sec-Purpose" => "prefetch" }
+    assert_response :success
+
+    assert @david.reload.unseen_activity?,
+      "hovering (prefetch) should not advance the watermark"
+  end
+
   test "activity shows messages mentioning current user" do
     room = rooms(:pets)
 

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -43,11 +43,11 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
       creator: @jason,
       client_message_id: "activity_seen_at_test"
     )
-    assert @david.reload.has_unseen_activity?, "precondition: dot should be on"
+    assert @david.reload.unseen_activity?, "precondition: dot should be on"
 
     get activity_inbox_url
 
-    assert_not @david.reload.has_unseen_activity?,
+    assert_not @david.reload.unseen_activity?,
       "visiting Activity should advance the watermark and clear the dot"
   end
 
@@ -384,7 +384,7 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
     membership = room.memberships.find_by(user: @david)
     membership.update!(unread_at: 1.hour.ago)
 
-    # Create a mention so mark_activity_as_read finds a notified room
+    # Create a mention so mark_inbox_as_read finds a notified room
     room.messages.create!(
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
       creator: @jason,

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -149,31 +149,30 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
     assert_match "Thread reply visible in activity", response.body
   end
 
-  test "activity hides notifications cleared in this session and shows newer notifications" do
+  test "activity feed shows every notification, including ones from before the last visit" do
     room = rooms(:pets)
     Notification.where(user: @david).delete_all
 
     room.messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)} cleared activity marker</div>",
+      body: "<div>Hey #{mention_attachment_for(:david)} older marker</div>",
       creator: @jason,
-      client_message_id: "all_visible"
+      client_message_id: "older_notification"
     )
 
     get activity_inbox_url
-    post clear_inbox_url, params: { scope: "activity", stay: true }
 
     travel 1.second do
       room.messages.create!(
-        body: "<div>Hey #{mention_attachment_for(:david)} newer activity marker</div>",
+        body: "<div>Hey #{mention_attachment_for(:david)} newer marker</div>",
         creator: @jason,
-        client_message_id: "also_visible"
+        client_message_id: "newer_notification"
       )
     end
 
     get activity_inbox_url
     assert_response :success
-    assert_no_match "cleared activity marker", response.body
-    assert_match "newer activity marker", response.body
+    assert_match "older marker", response.body
+    assert_match "newer marker", response.body
   end
 
   test "mentioning a non-member does not add them to the room" do
@@ -411,61 +410,6 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
     get activity_inbox_url
     post clear_inbox_url, params: { stay: true }
     assert_response :success
-  end
-
-  test "clear with scope activity only clears rooms with activity" do
-    # Room with mention
-    room_with_mention = rooms(:pets)
-    room_with_mention.messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
-      creator: @jason
-    )
-    membership_with_mention = room_with_mention.memberships.find_by(user: @david)
-    membership_with_mention.update!(unread_at: 1.hour.ago)
-
-    # Room without mention (just a regular unread message)
-    room_without_mention = rooms(:watercooler)
-    room_without_mention.messages.create!(body: "Regular message", creator: @jason)
-    membership_without_mention = room_without_mention.memberships.find_by(user: @david)
-    membership_without_mention.update!(unread_at: 1.hour.ago)
-
-    # Visit activity page to set session timestamp
-    get activity_inbox_url
-
-    # Clear only activity
-    post clear_inbox_url, params: { scope: "activity" }
-
-    membership_with_mention.reload
-    membership_without_mention.reload
-
-    assert membership_with_mention.read?, "Room with mention should be marked as read"
-    assert membership_without_mention.unread?, "Room without mention should remain unread"
-  end
-
-  test "clear with scope activity clears notification badge without reading regular messages" do
-    room = rooms(:pets)
-    membership = room.memberships.find_by(user: @david)
-    membership.update!(unread_at: 1.hour.ago)
-
-    room.messages.create!(
-      body: "Regular unread chatter",
-      creator: @jason,
-      client_message_id: "activity_badge_regular"
-    )
-    room.messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
-      creator: @jason,
-      client_message_id: "activity_badge_mention"
-    )
-
-    assert membership.reload.unread?
-    assert_equal 1, membership.unread_notifications_count
-
-    get activity_inbox_url
-    post clear_inbox_url, params: { scope: "activity" }
-
-    assert membership.reload.unread?, "Regular unread messages should remain unread"
-    assert_equal 0, membership.unread_notifications_count, "Activity badge should clear"
   end
 
   test "clear with scope direct_messages only clears DM rooms" do

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -51,21 +51,6 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
       "visiting Activity should advance the watermark and clear the dot"
   end
 
-  test "Turbo prefetch on Activity does not clear the dot" do
-    @david.update_column(:activity_seen_at, nil)
-    rooms(:pets).messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
-      creator: @jason,
-      client_message_id: "activity_prefetch_test"
-    )
-    assert @david.reload.unseen_activity?
-
-    get activity_inbox_url, headers: { "Sec-Purpose" => "prefetch" }
-    assert_response :success
-
-    assert @david.reload.unseen_activity?,
-      "hovering (prefetch) should not advance the watermark"
-  end
 
   test "activity shows messages mentioning current user" do
     room = rooms(:pets)

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -36,6 +36,21 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "activity touches activity_seen_at so the sidebar dot clears" do
+    @david.update_column(:activity_seen_at, nil)
+    rooms(:pets).messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: @jason,
+      client_message_id: "activity_seen_at_test"
+    )
+    assert @david.reload.has_unseen_activity?, "precondition: dot should be on"
+
+    get activity_inbox_url
+
+    assert_not @david.reload.has_unseen_activity?,
+      "visiting Activity should advance the watermark and clear the dot"
+  end
+
   test "activity shows messages mentioning current user" do
     room = rooms(:pets)
 

--- a/test/controllers/users/sidebars_controller_test.rb
+++ b/test/controllers/users/sidebars_controller_test.rb
@@ -68,6 +68,11 @@ class Users::SidebarsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#sidebar_activity_indicator.has-unread-activity", count: 0
   end
 
+  test "activity link opts out of Turbo prefetch so hover doesn't clear the dot" do
+    get user_sidebar_url
+    assert_select "#sidebar_activity_indicator[data-turbo-prefetch=?]", "false"
+  end
+
   test "direct room members are preloaded to avoid N+1 queries" do
     # Create messages in direct rooms so they appear in sidebar
     rooms(:david_and_jason).messages.create! client_message_id: 901, body: "Hello", creator: users(:jason)

--- a/test/controllers/users/sidebars_controller_test.rb
+++ b/test/controllers/users/sidebars_controller_test.rb
@@ -48,6 +48,26 @@ class Users::SidebarsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".sidebar__tools a[href=?]", edit_user_notification_settings_path, count: 0
   end
 
+  test "activity link shows has-unread-activity when there are unseen notifications" do
+    users(:david).update_column(:activity_seen_at, nil)
+    rooms(:pets).messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: users(:jason),
+      client_message_id: "sidebar_activity_dot"
+    )
+
+    get user_sidebar_url
+    assert_select "#sidebar_activity_indicator.has-unread-activity", count: 1
+  end
+
+  test "activity link omits has-unread-activity when watermark is current" do
+    users(:david).touch_activity_seen_at(Time.current)
+
+    get user_sidebar_url
+    assert_select "#sidebar_activity_indicator", count: 1
+    assert_select "#sidebar_activity_indicator.has-unread-activity", count: 0
+  end
+
   test "direct room members are preloaded to avoid N+1 queries" do
     # Create messages in direct rooms so they appear in sidebar
     rooms(:david_and_jason).messages.create! client_message_id: 901, body: "Hello", creator: users(:jason)

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -325,4 +325,48 @@ class NotificationTest < ActiveSupport::TestCase
     ordered = Notification.where(user: @david, message: message).ordered
     assert_equal [ n1, n2 ], ordered.to_a
   end
+
+  test "creating a mention notification broadcasts the activity indicator" do
+    assert_turbo_stream_broadcasts [ @david, :sidebar_activity_indicator ], count: 1 do
+      @room.messages.create!(
+        body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+        creator: @jason,
+        client_message_id: "indicator_broadcast_mention"
+      )
+    end
+  end
+
+  test "creating a boost notification broadcasts the activity indicator" do
+    message = @room.messages.create!(body: "boost me", creator: @david, client_message_id: "indicator_broadcast_boost")
+
+    assert_turbo_stream_broadcasts [ @david, :sidebar_activity_indicator ], count: 1 do
+      perform_enqueued_jobs(only: Notification::DispatchJob) do
+        message.boosts.create!(content: "🔥", booster: @jason)
+      end
+    end
+  end
+
+  test "creating a thread reply notification broadcasts the activity indicator" do
+    parent = @room.messages.create!(body: "start", creator: @david, client_message_id: "indicator_broadcast_parent")
+    thread = Rooms::Thread.find_or_create_by!(parent_message: parent, creator: @david)
+    thread.memberships.grant_to([ @david, @jason ])
+
+    assert_turbo_stream_broadcasts [ @david, :sidebar_activity_indicator ], count: 1 do
+      perform_enqueued_jobs(only: CreateThreadReplyNotificationsJob) do
+        thread.messages.create!(body: "reply", creator: @jason, client_message_id: "indicator_broadcast_reply")
+      end
+    end
+  end
+
+  test "delete_all_and_broadcast fires the activity indicator broadcast for affected users" do
+    message = @room.messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: @jason,
+      client_message_id: "indicator_broadcast_bulk_delete"
+    )
+
+    assert_turbo_stream_broadcasts [ @david, :sidebar_activity_indicator ], count: 1 do
+      Notification.delete_all_and_broadcast(Notification.where(message_id: message.id))
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -740,4 +740,71 @@ class UserTest < ActiveSupport::TestCase
     assert_nil Notification::BundleItem.find_by(id: item.id)
     assert Notification::Bundle.exists?(bundle.id), "the owner's bundle itself must remain — only the actor's row goes"
   end
+
+  test "has_unseen_activity? true when a notification exists and the watermark is nil" do
+    user = users(:david)
+    user.update_column(:activity_seen_at, nil)
+    rooms(:pets).messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: users(:jason),
+      client_message_id: "unseen_mention_#{SecureRandom.hex(4)}"
+    )
+
+    assert user.reload.has_unseen_activity?
+  end
+
+  test "has_unseen_activity? false when watermark is newer than all notifications" do
+    user = users(:david)
+    rooms(:pets).messages.create!(
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      creator: users(:jason),
+      client_message_id: "seen_mention_#{SecureRandom.hex(4)}"
+    )
+
+    user.touch_activity_seen_at(Time.current + 1.second)
+    assert_not user.reload.has_unseen_activity?
+  end
+
+  test "has_unseen_activity? true for boost-only recipients (the bug this fixes)" do
+    user = users(:david)
+    user.update_column(:activity_seen_at, 1.day.ago)
+    message = rooms(:pets).messages.create!(body: "boost me", creator: user,
+                                            client_message_id: "boost_only_unseen_#{SecureRandom.hex(4)}")
+
+    perform_enqueued_jobs(only: Notification::DispatchJob) do
+      message.boosts.create!(content: "🔥", booster: users(:jason))
+    end
+
+    assert user.reload.has_unseen_activity?,
+      "boost notifications should light up the Activity dot"
+  end
+
+  test "touch_activity_seen_at is monotonic" do
+    user = users(:david)
+    later = Time.current
+    earlier = later - 1.hour
+
+    user.touch_activity_seen_at(later)
+    user.touch_activity_seen_at(earlier)
+
+    assert_in_delta later, user.reload.activity_seen_at, 1.second
+  end
+
+  test "advancing activity_seen_at broadcasts the sidebar indicator" do
+    user = users(:david)
+    user.update_column(:activity_seen_at, 1.day.ago)
+
+    assert_turbo_stream_broadcasts [ user, :sidebar_activity_indicator ], count: 1 do
+      user.touch_activity_seen_at(Time.current)
+    end
+  end
+
+  test "touch_activity_seen_at does not broadcast when the watermark would not advance" do
+    user = users(:david)
+    user.touch_activity_seen_at(Time.current)
+
+    assert_turbo_stream_broadcasts [ user, :sidebar_activity_indicator ], count: 0 do
+      user.touch_activity_seen_at(1.hour.ago)
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -741,7 +741,7 @@ class UserTest < ActiveSupport::TestCase
     assert Notification::Bundle.exists?(bundle.id), "the owner's bundle itself must remain — only the actor's row goes"
   end
 
-  test "has_unseen_activity? true when a notification exists and the watermark is nil" do
+  test "unseen_activity? true when a notification exists and the watermark is nil" do
     user = users(:david)
     user.update_column(:activity_seen_at, nil)
     rooms(:pets).messages.create!(
@@ -750,10 +750,10 @@ class UserTest < ActiveSupport::TestCase
       client_message_id: "unseen_mention_#{SecureRandom.hex(4)}"
     )
 
-    assert user.reload.has_unseen_activity?
+    assert user.reload.unseen_activity?
   end
 
-  test "has_unseen_activity? false when watermark is newer than all notifications" do
+  test "unseen_activity? false when watermark is newer than all notifications" do
     user = users(:david)
     rooms(:pets).messages.create!(
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
@@ -762,10 +762,10 @@ class UserTest < ActiveSupport::TestCase
     )
 
     user.touch_activity_seen_at(Time.current + 1.second)
-    assert_not user.reload.has_unseen_activity?
+    assert_not user.reload.unseen_activity?
   end
 
-  test "has_unseen_activity? true for boost-only recipients (the bug this fixes)" do
+  test "unseen_activity? true for boost-only recipients (the bug this fixes)" do
     user = users(:david)
     user.update_column(:activity_seen_at, 1.day.ago)
     message = rooms(:pets).messages.create!(body: "boost me", creator: user,
@@ -775,7 +775,7 @@ class UserTest < ActiveSupport::TestCase
       message.boosts.create!(content: "🔥", booster: users(:jason))
     end
 
-    assert user.reload.has_unseen_activity?,
+    assert user.reload.unseen_activity?,
       "boost notifications should light up the Activity dot"
   end
 


### PR DESCRIPTION
The dot above the Activity sidebar icon now lights up for every kind of notification that lands in the Activity tab — mentions, @everyone, boosts on your messages, and thread replies. Previously only mentions and @everyone triggered it; boosts and thread replies were silent, so you'd only notice them by opening Activity manually.

## When and why this was broken

Before #81 (Feb 23, 2026), "Activity" only meant mentions and @everyone. The sidebar dot inferred its state by scanning the rendered sidebar for `.room.badge` — a class set on a room link when `membership.unread_notifications_count > 0`, and that counter only got bumped for mentions, @everyone, and DMs. Indicator and inbox content shared the same domain, so the signal was correct.

#81 introduced first-class `Notification` rows with `activity_type ∈ {mention, boost, thread_reply}` and broadened what the Activity tab shows — but the sidebar dot kept reading the old room-badge signal. Boost and thread-reply notifications create `Notification` rows without ever touching `unread_notifications_count`, so the dot never reacted to them. The Activity tab and the dot quietly drifted apart, and the bug has been live for ~3 months.

## What this PR changes

**The dot is now correct for every notification type.** Seen/unseen state lives on the user row (`activity_seen_at` watermark) instead of the browser session, so clearing on your phone clears on your laptop the next time the sidebar renders or a notification arrives. Updates flow over Turbo Streams: the dot turns on the instant a notification lands and clears the instant you open the tab on any device — no refresh.

**Drops the "mark Activity as read" button** (the ✓ icon in the Activity nav). The button is now redundant — opening the Activity tab clears the dot on its own. Per-room mention badges (`# General • 1`) continue to clear naturally when you visit that room, which matches Slack: the Activity feed and per-channel unread state are decoupled, you don't bulk-clear one from the other.

**The Activity feed stops hiding cleared notifications.** Previously the button wrote a session timestamp that filtered older notifications out of the feed view. With the button gone, this filter is gone — the feed shows your full notification history.

## Implementation notes for review

- New `users.activity_seen_at` column (nullable, no default).
- `User#has_unseen_activity?` is the single source of truth for the dot; the JS controller no longer infers Activity state from `.room.badge`.
- `User#touch_activity_seen_at` is monotonic and writes via `update!`, letting an `after_update_commit :broadcast_activity_indicator, if: :saved_change_to_activity_seen_at?` callback own the broadcast (the write is the event; the broadcast is the reaction).
- Every notification-write site broadcasts the indicator explicitly: `Message#create_mention_notifications`, `Message#create_boost_notification_row`, `Boost#broadcast_notification_removal`, `CreateThreadReplyNotificationsJob`, and `Notification.delete_all_and_broadcast`. No callback-on-`Notification` that fires only on the `create!`/`destroy!` slow path — explicit at the boundary so adding a new `insert_all`/`delete_all` writer can't silently regress the dot.
- `Inbox::ActivityQuery` no longer takes `cleared_at:` and the session bookkeeping is gone.

## Test plan
- [x] `bin/rails test` (1521 runs, 0 failures) and `SAAS=true bin/rails test saas/test/` (312 runs, 0 failures)
- [x] Manual: boost-only recipient now sees the dot; clears after visiting Activity; mention path still works; ✓ button no longer renders on the Activity nav
- [x] Coverage added for boost / thread-reply / bulk-delete broadcast paths so future `insert_all` writers can't silently regress the dot