### PR TITLE
Preload notification recipient and memoize mentionees to cut Activity-feed N+1s

### DIFF
--- a/app/models/message/mentionee.rb
+++ b/app/models/message/mentionee.rb
@@ -3,6 +3,7 @@ module Message::Mentionee
 
   included do
     before_save :set_mentions_everyone_flag
+    after_save :reset_mentionee_memo
 
     scope :mentioning, ->(user_id) {
       where(
@@ -15,18 +16,18 @@ module Message::Mentionee
   end
 
   def mentionees
-    if mentions_everyone?
-      room.users
-    else
-      room.users.where(id: mentioned_users.map(&:id))
-    end
+    @mentionees ||= mentions_everyone? ? room.users.to_a : room.users.where(id: mentioned_users.map(&:id)).to_a
   end
 
   def mentionee_ids
-    mentionees.pluck(:id)
+    @mentionee_ids ||= mentionees.map(&:id)
   end
 
   private
+    def reset_mentionee_memo
+      @mentionees = @mentionee_ids = nil
+    end
+
     def set_mentions_everyone_flag
       self.mentions_everyone = mentions_everyone_in_body?
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -10,6 +10,7 @@ class Notification < ApplicationRecord
   scope :with_message_and_creator, -> {
     includes(
       :boost,
+      :user,
       message: [
         :room,
         :rich_text_body,


### PR DESCRIPTION
Two small, independent N+1s spotted while profiling a 1230ms / 22-card Activity request. Both are pre-existing, not introduced by #73.

## What this changes

**`Notification.with_message_and_creator` now includes `:user`.** Every caller of the scope — `Inbox::ActivityQuery`, `BroadcastMentionNotificationsJob`, `CreateThreadReplyNotificationsJob`, `Notification.delete_all_and_broadcast`, `Notification::BoostGroup` — reads `notification.user` to broadcast or render. The recipient was the one association the scope was missing. The Activity feed mostly hid this behind query-cache hits (single viewer), but the broadcast jobs loop over distinct recipients where the cache doesn't help.

**`Message#mentionees` / `mentionee_ids` memoize per instance.** `_presentation.html.erb` reads `message.mentionee_ids` for the `data-mentioned-users` attribute, and the same `Message` instance can render in multiple places in one request (notification card, permalinked message, search result). Each call was firing `room.users.where(id: …).pluck(:id)` again. The memo is reset in an `after_save` so a body edit on the same instance can't read stale recipients — today no code does that, but it's free insurance against latent footguns at the callback boundary.

## Measurements

On the dev fixture (22-card Activity feed):
- Latency: **1230ms → 883ms** (~28% improvement on the request that surfaced this).
- Recipient `User Load` queries inside the broadcast jobs: per-recipient → single batched `WHERE id IN (…)`.
- Mentionee membership lookups: bounded to one per unique message instead of one per render site.

## Notes for review

- `mentionees` now returns an `Array` instead of a `Relation`. Grepped every caller — all use `.map`, `.any?`, `.include?`, `.count`, jbuilder iteration, or `==` against an array literal. No `.where`/`.pluck`/`.limit` chains exist.
- One pre-existing N+1 *not* touched here: `lib/rails_ext/action_text_attachables.rb` runs `attachable_from_possibly_expired_sgid` eagerly on every `<action-text-attachment>` node. It's ~109 hits per request but ~95% are query-cache hits and Rails' own SGID resolver does the same DB lookup either way, so reordering only saves CPU. Skipping unless profiling shows the JSON parse hot.

## Test plan
- [x] `bin/rails test` (1522 runs, 0 failures)
- [x] Manual: Activity page renders correctly; `room.users WHERE id IN (…)` count bounded; recipient `User Load` collapses to a single batched query