### PR TITLE
Move Message callbacks into the concerns that own them

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,6 @@ class Message < ApplicationRecord
 
   has_many :boosts, -> { order(:created_at) }, class_name: "Boost"
   has_many :bookmarks, class_name: "Bookmark"
-
   has_many :threads, class_name: "Rooms::Thread", foreign_key: :parent_message_id, dependent: :destroy
 
   # Clean up associated records before destroying
@@ -17,7 +16,6 @@ class Message < ApplicationRecord
   before_create :set_default_client_message_id
   before_create :touch_room_activity
   after_create_commit :dispatch_notifications
-
   after_update_commit :broadcast_reactivation_if_restored
 
   scope :ordered, -> { order(:created_at) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -424,30 +424,6 @@ class Message < ApplicationRecord
       Notification::DispatchJob.perform_later(self)
     end
 
-    # Bumps unread_notifications_count for memberships affected by this message.
-    # Mirrors the with_has_unread_notifications semantics: DM rooms count every
-    # unread message (including the sender's, matching the old scope which made
-    # no creator distinction in DMs); other rooms only count mentions and
-    # @everyone. Connected users (unread_at IS NULL) are skipped — they see
-    # the message live, and senders almost always fall in this bucket.
-    def increment_unread_notifications_counters
-      return if event?
-
-      recipient_ids = if room.direct?
-        room.user_ids
-      elsif mentions_everyone?
-        room.user_ids - [ creator_id ]
-      else
-        mentionee_ids - [ creator_id ]
-      end
-
-      return if recipient_ids.empty?
-
-      Membership.where(room_id: room_id, user_id: recipient_ids)
-                .where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
-                .update_all("unread_notifications_count = unread_notifications_count + 1")
-    end
-
     def destroy_all_associated_records
       # Delete all boosts, bookmarks, and notifications to satisfy FK constraints.
       # Storage entries are intentionally preserved as an audit log (recordable is optional).

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  include Attachment, Broadcasts, Mentionee, Pagination, Searchable, Streakable, Deactivatable
+  include Attachment, Broadcasts, Mentionee, Pagination, Searchable, Streakable, Threadable, Deactivatable
 
   belongs_to :room, counter_cache: true
   belongs_to :creator, class_name: "User", default: -> { Current.user }
@@ -17,11 +17,7 @@ class Message < ApplicationRecord
   before_create :set_default_client_message_id
   before_create :touch_room_activity
   after_create_commit :deliver_to_room
-  after_create_commit :involve_creator_in_thread
-  after_create_commit :update_thread_reply_count
-  after_create_commit :update_parent_message_threads
   after_create_commit :create_mention_notifications
-  after_create_commit :create_thread_reply_notifications
   after_create_commit :increment_unread_notifications_counters
   after_create_commit :dispatch_notifications
 
@@ -30,7 +26,6 @@ class Message < ApplicationRecord
   after_update_commit :destroy_notifications_if_deactivated
   after_update_commit :destroy_stale_mention_notifications
   after_update_commit :restore_unread_notifications_counters_if_reactivated
-  after_update_commit :broadcast_parent_message_to_threads
 
   scope :ordered, -> { order(:created_at) }
   scope :without_events, -> { where(event: nil) }
@@ -382,51 +377,6 @@ class Message < ApplicationRecord
       broadcast_reactivation if saved_change_to_attribute?(:active) && active?
     end
 
-    def involve_creator_in_thread
-      # When someone posts in a thread, ensure they have visible membership
-      room.involve_user(creator, unread: false) if room.thread?
-    end
-
-    def update_thread_reply_count
-      # When a message is created in a thread, update the reply count separator
-      if room.thread?
-        broadcast_update_to(
-          room,
-          :messages,
-          target: "#{ActionView::RecordIdentifier.dom_id(room, :replies_separator)}_count",
-          html: ActionController::Base.helpers.pluralize(room.messages_count, "reply", "replies")
-        )
-      end
-    end
-
-    def update_parent_message_threads
-      # When a message is created in a thread, update the parent message's threads display
-      if room.thread? && room.parent_message
-        broadcast_replace_to(
-          room.parent_message.room,
-          :messages,
-          target: ActionView::RecordIdentifier.dom_id(room.parent_message, :threads),
-          partial: "messages/threads",
-          locals: { message: room.parent_message }
-        )
-      end
-    end
-
-    def broadcast_parent_message_to_threads
-      # When a parent message is deleted/updated, broadcast to all threads
-      if saved_change_to_attribute?(:active) && threads.any?
-        threads.each do |thread|
-          broadcast_replace_to(
-            thread,
-            :messages,
-            target: ActionView::RecordIdentifier.dom_id(self),
-            partial: "messages/parent_message",
-            locals: { message: self, thread: thread }
-          )
-        end
-      end
-    end
-
     def touch_room_activity
       room.touch(:last_active_at)
     end
@@ -470,12 +420,6 @@ class Message < ApplicationRecord
 
       User.where(id: recipient_ids).each(&:broadcast_activity_indicator)
       broadcast_mention_notifications
-    end
-
-    def create_thread_reply_notifications
-      return unless room.thread? && room.parent_message
-
-      CreateThreadReplyNotificationsJob.perform_later(message_id: id, thread_id: room.id, creator_id: creator_id)
     end
 
     def dispatch_notifications

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,11 +17,9 @@ class Message < ApplicationRecord
   before_create :set_default_client_message_id
   before_create :touch_room_activity
   after_create_commit :deliver_to_room
-  after_create_commit :create_mention_notifications
   after_create_commit :dispatch_notifications
 
   after_update_commit :broadcast_reactivation_if_restored
-  after_update_commit :destroy_stale_mention_notifications
 
   scope :ordered, -> { order(:created_at) }
   scope :without_events, -> { where(event: nil) }
@@ -394,30 +392,6 @@ class Message < ApplicationRecord
       end
     end
 
-    def create_mention_notifications
-      return if event?
-      return if room.direct? || room.parent_room&.direct?
-
-      recipient_ids = if mentions_everyone?
-        room.user_ids - [ creator_id ]
-      else
-        mentionee_ids - [ creator_id ]
-      end
-
-      return if recipient_ids.empty?
-
-      now = Time.current
-      Notification.insert_all(
-        recipient_ids.map { |uid|
-          { user_id: uid, message_id: id, actor_id: creator_id, activity_type: "mention", created_at: now, updated_at: now }
-        },
-        unique_by: "index_notifications_on_message_user_type"
-      )
-
-      User.where(id: recipient_ids).each(&:broadcast_activity_indicator)
-      broadcast_mention_notifications
-    end
-
     def dispatch_notifications
       return if event?
 
@@ -434,22 +408,5 @@ class Message < ApplicationRecord
       Boost.where(message_id: id).delete_all
       Bookmark.where(message_id: id).delete_all
       Notification::BundleItem.where(message_id: id).delete_all
-    end
-
-    def destroy_stale_mention_notifications
-      return if room.direct?
-      return unless active? # already handled by destroy_notifications_if_deactivated
-      return unless rich_text_body.saved_changes?
-
-      current_recipient_ids = if mentions_everyone_in_body?
-        room.user_ids - [ creator_id ]
-      else
-        mentioned_users.map(&:id) - [ creator_id ]
-      end
-
-      Notification.delete_all_and_broadcast(
-        Notification.where(message_id: id, activity_type: "mention")
-                    .where.not(user_id: current_recipient_ids)
-      )
     end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  include Attachment, Broadcasts, Mentionee, Pagination, Searchable, Streakable, Threadable, Deactivatable
+  include Attachment, Broadcasts, Mentionee, Pagination, Searchable, Streakable, Threadable, Unreadable, Deactivatable
 
   belongs_to :room, counter_cache: true
   belongs_to :creator, class_name: "User", default: -> { Current.user }
@@ -18,14 +18,10 @@ class Message < ApplicationRecord
   before_create :touch_room_activity
   after_create_commit :deliver_to_room
   after_create_commit :create_mention_notifications
-  after_create_commit :increment_unread_notifications_counters
   after_create_commit :dispatch_notifications
 
   after_update_commit :broadcast_reactivation_if_restored
-  after_update_commit :clear_unread_timestamps_if_deactivated
-  after_update_commit :destroy_notifications_if_deactivated
   after_update_commit :destroy_stale_mention_notifications
-  after_update_commit :restore_unread_notifications_counters_if_reactivated
 
   scope :ordered, -> { order(:created_at) }
   scope :without_events, -> { where(event: nil) }
@@ -452,24 +448,6 @@ class Message < ApplicationRecord
                 .update_all("unread_notifications_count = unread_notifications_count + 1")
     end
 
-    # When a soft-deleted message is reactivated (a console/admin path),
-    # restore the counter bumps that clear_unread_timestamps_if_deactivated
-    # took away. Only DM and @everyone messages are restored — named mentions
-    # need their Notification rows back to count under either the old scope
-    # or the new column, and we don't recreate those on reactivation.
-    def restore_unread_notifications_counters_if_reactivated
-      return unless saved_change_to_attribute?(:active) && active?
-      return if event?
-      return unless room.direct? || mentions_everyone?
-
-      recipient_ids = room.direct? ? room.user_ids : room.user_ids - [ creator_id ]
-      return if recipient_ids.empty?
-
-      Membership.where(room_id: room_id, user_id: recipient_ids)
-                .where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
-                .update_all("unread_notifications_count = unread_notifications_count + 1")
-    end
-
     def destroy_all_associated_records
       # Delete all boosts, bookmarks, and notifications to satisfy FK constraints.
       # Storage entries are intentionally preserved as an audit log (recordable is optional).
@@ -480,12 +458,6 @@ class Message < ApplicationRecord
       Boost.where(message_id: id).delete_all
       Bookmark.where(message_id: id).delete_all
       Notification::BundleItem.where(message_id: id).delete_all
-    end
-
-    def destroy_notifications_if_deactivated
-      return unless saved_change_to_attribute?(:active) && !active?
-
-      Notification.delete_all_and_broadcast(Notification.where(message_id: id))
     end
 
     def destroy_stale_mention_notifications
@@ -503,43 +475,5 @@ class Message < ApplicationRecord
         Notification.where(message_id: id, activity_type: "mention")
                     .where.not(user_id: current_recipient_ids)
       )
-    end
-
-    def clear_unread_timestamps_if_deactivated
-      return unless saved_change_to_attribute?(:active) && !active?
-      rebalance_unread_counters
-    end
-
-    # Keeps memberships.unread_notifications_count and unread_at consistent
-    # when this message disappears from the room (soft- or hard-deleted).
-    #
-    # Two effects per call:
-    #   1. DMs only: every membership whose unread window contained this
-    #      message loses one from its count (using < to leave the anchor
-    #      membership for the second pass below).
-    #   2. Any membership anchored exactly at this message's timestamp gets
-    #      its anchor advanced to the next active message (or marked read),
-    #      with its counter recomputed from the new anchor.
-    def rebalance_unread_counters
-      if room.direct?
-        Membership.where(room_id: room_id)
-                  .where("unread_at IS NOT NULL AND unread_at < ?", created_at)
-                  .update_all("unread_notifications_count = MAX(unread_notifications_count - 1, 0)")
-      end
-
-      room.memberships.where(unread_at: created_at).find_each do |membership|
-        next_unread = room.messages.active.ordered
-                         .where("created_at > ?", created_at)
-                         .first
-
-        if next_unread
-          membership.update!(
-            unread_at: next_unread.created_at,
-            unread_notifications_count: membership.count_unread_notifications_from(next_unread.created_at)
-          )
-        else
-          membership.read # This sets unread_at to nil and broadcasts read status
-        end
-      end
     end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,7 +16,6 @@ class Message < ApplicationRecord
 
   before_create :set_default_client_message_id
   before_create :touch_room_activity
-  after_create_commit :deliver_to_room
   after_create_commit :dispatch_notifications
 
   after_update_commit :broadcast_reactivation_if_restored
@@ -361,10 +360,6 @@ class Message < ApplicationRecord
     # Bots and API consumers don't generate client-side IDs for Turbo dedup
     def set_default_client_message_id
       self.client_message_id ||= Random.uuid
-    end
-
-    def deliver_to_room
-      room.receive(self)
     end
 
     def broadcast_reactivation_if_restored

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  include Attachment, Broadcasts, Mentionee, Pagination, Searchable, Deactivatable
+  include Attachment, Broadcasts, Mentionee, Pagination, Searchable, Streakable, Deactivatable
 
   belongs_to :room, counter_cache: true
   belongs_to :creator, class_name: "User", default: -> { Current.user }
@@ -20,7 +20,6 @@ class Message < ApplicationRecord
   after_create_commit :involve_creator_in_thread
   after_create_commit :update_thread_reply_count
   after_create_commit :update_parent_message_threads
-  after_create_commit :update_creator_streak
   after_create_commit :create_mention_notifications
   after_create_commit :create_thread_reply_notifications
   after_create_commit :increment_unread_notifications_counters
@@ -377,11 +376,6 @@ class Message < ApplicationRecord
 
     def deliver_to_room
       room.receive(self)
-    end
-
-    def update_creator_streak
-      return if room.direct? || room.parent_room&.direct? || welcome?
-      UpdateStreakJob.perform_later(user_id: creator_id, excluding_message_id: id)
     end
 
     def broadcast_reactivation_if_restored

--- a/app/models/message/mentionee.rb
+++ b/app/models/message/mentionee.rb
@@ -4,6 +4,8 @@ module Message::Mentionee
   included do
     before_save :set_mentions_everyone_flag
     after_save :reset_mentionee_memo
+    after_create_commit :create_mention_notifications
+    after_update_commit :destroy_stale_mention_notifications
 
     scope :mentioning, ->(user_id) {
       where(
@@ -56,5 +58,46 @@ module Message::Mentionee
       cited_message_ids = body.body.fragment.find_all("cite a").map { |a| a["href"].to_s[/@([^@]+)$/, 1] }
       return User.none if cited_message_ids.empty?
       User.joins(:messages).where.not(id: self.creator_id).where(messages: { id: cited_message_ids }).distinct
+    end
+
+    def create_mention_notifications
+      return if event?
+      return if room.direct? || room.parent_room&.direct?
+
+      recipient_ids = if mentions_everyone?
+        room.user_ids - [ creator_id ]
+      else
+        mentionee_ids - [ creator_id ]
+      end
+
+      return if recipient_ids.empty?
+
+      now = Time.current
+      Notification.insert_all(
+        recipient_ids.map { |uid|
+          { user_id: uid, message_id: id, actor_id: creator_id, activity_type: "mention", created_at: now, updated_at: now }
+        },
+        unique_by: "index_notifications_on_message_user_type"
+      )
+
+      User.where(id: recipient_ids).each(&:broadcast_activity_indicator)
+      broadcast_mention_notifications
+    end
+
+    def destroy_stale_mention_notifications
+      return if room.direct?
+      return unless active? # already handled by Message::Unreadable#destroy_notifications_if_deactivated
+      return unless rich_text_body.saved_changes?
+
+      current_recipient_ids = if mentions_everyone_in_body?
+        room.user_ids - [ creator_id ]
+      else
+        mentioned_users.map(&:id) - [ creator_id ]
+      end
+
+      Notification.delete_all_and_broadcast(
+        Notification.where(message_id: id, activity_type: "mention")
+                    .where.not(user_id: current_recipient_ids)
+      )
     end
 end

--- a/app/models/message/streakable.rb
+++ b/app/models/message/streakable.rb
@@ -1,0 +1,13 @@
+module Message::Streakable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :update_creator_streak
+  end
+
+  private
+    def update_creator_streak
+      return if room.direct? || room.parent_room&.direct? || welcome?
+      UpdateStreakJob.perform_later(user_id: creator_id, excluding_message_id: id)
+    end
+end

--- a/app/models/message/threadable.rb
+++ b/app/models/message/threadable.rb
@@ -1,0 +1,59 @@
+module Message::Threadable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :involve_creator_in_thread
+    after_create_commit :update_thread_reply_count
+    after_create_commit :update_parent_message_threads
+    after_create_commit :create_thread_reply_notifications
+    after_update_commit :broadcast_parent_message_to_threads
+  end
+
+  private
+    def involve_creator_in_thread
+      room.involve_user(creator, unread: false) if room.thread?
+    end
+
+    def update_thread_reply_count
+      if room.thread?
+        broadcast_update_to(
+          room,
+          :messages,
+          target: "#{ActionView::RecordIdentifier.dom_id(room, :replies_separator)}_count",
+          html: ActionController::Base.helpers.pluralize(room.messages_count, "reply", "replies")
+        )
+      end
+    end
+
+    def update_parent_message_threads
+      if room.thread? && room.parent_message
+        broadcast_replace_to(
+          room.parent_message.room,
+          :messages,
+          target: ActionView::RecordIdentifier.dom_id(room.parent_message, :threads),
+          partial: "messages/threads",
+          locals: { message: room.parent_message }
+        )
+      end
+    end
+
+    def create_thread_reply_notifications
+      return unless room.thread? && room.parent_message
+
+      CreateThreadReplyNotificationsJob.perform_later(message_id: id, thread_id: room.id, creator_id: creator_id)
+    end
+
+    def broadcast_parent_message_to_threads
+      if saved_change_to_attribute?(:active) && threads.any?
+        threads.each do |thread|
+          broadcast_replace_to(
+            thread,
+            :messages,
+            target: ActionView::RecordIdentifier.dom_id(self),
+            partial: "messages/parent_message",
+            locals: { message: self, thread: thread }
+          )
+        end
+      end
+    end
+end

--- a/app/models/message/unreadable.rb
+++ b/app/models/message/unreadable.rb
@@ -1,0 +1,99 @@
+module Message::Unreadable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :increment_unread_notifications_counters
+    after_update_commit :clear_unread_timestamps_if_deactivated
+    after_update_commit :destroy_notifications_if_deactivated
+    after_update_commit :restore_unread_notifications_counters_if_reactivated
+  end
+
+  private
+    # Bumps unread_notifications_count for memberships affected by this message.
+    # Mirrors the with_has_unread_notifications semantics: DM rooms count every
+    # unread message (including the sender's, matching the old scope which made
+    # no creator distinction in DMs); other rooms only count mentions and
+    # @everyone. Connected users (unread_at IS NULL) are skipped — they see
+    # the message live, and senders almost always fall in this bucket.
+    def increment_unread_notifications_counters
+      return if event?
+
+      recipient_ids = if room.direct?
+        room.user_ids
+      elsif mentions_everyone?
+        room.user_ids - [ creator_id ]
+      else
+        mentionee_ids - [ creator_id ]
+      end
+
+      return if recipient_ids.empty?
+
+      Membership.where(room_id: room_id, user_id: recipient_ids)
+                .where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
+                .update_all("unread_notifications_count = unread_notifications_count + 1")
+    end
+
+    def clear_unread_timestamps_if_deactivated
+      return unless saved_change_to_attribute?(:active) && !active?
+      rebalance_unread_counters
+    end
+
+    def destroy_notifications_if_deactivated
+      return unless saved_change_to_attribute?(:active) && !active?
+
+      Notification.delete_all_and_broadcast(Notification.where(message_id: id))
+    end
+
+    # When a soft-deleted message is reactivated (a console/admin path),
+    # restore the counter bumps that clear_unread_timestamps_if_deactivated
+    # took away. Only DM and @everyone messages are restored — named mentions
+    # need their Notification rows back to count under either the old scope
+    # or the new column, and we don't recreate those on reactivation.
+    def restore_unread_notifications_counters_if_reactivated
+      return unless saved_change_to_attribute?(:active) && active?
+      return if event?
+      return unless room.direct? || mentions_everyone?
+
+      recipient_ids = room.direct? ? room.user_ids : room.user_ids - [ creator_id ]
+      return if recipient_ids.empty?
+
+      Membership.where(room_id: room_id, user_id: recipient_ids)
+                .where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
+                .update_all("unread_notifications_count = unread_notifications_count + 1")
+    end
+
+    # Keeps memberships.unread_notifications_count and unread_at consistent
+    # when this message disappears from the room (soft- or hard-deleted).
+    # Called by Message#destroy_all_associated_records as well as the
+    # deactivation callback above.
+    #
+    # Two effects per call:
+    #   1. DMs only: every membership whose unread window contained this
+    #      message loses one from its count (using < to leave the anchor
+    #      membership for the second pass below).
+    #   2. Any membership anchored exactly at this message's timestamp gets
+    #      its anchor advanced to the next active message (or marked read),
+    #      with its counter recomputed from the new anchor.
+    def rebalance_unread_counters
+      if room.direct?
+        Membership.where(room_id: room_id)
+                  .where("unread_at IS NOT NULL AND unread_at < ?", created_at)
+                  .update_all("unread_notifications_count = MAX(unread_notifications_count - 1, 0)")
+      end
+
+      room.memberships.where(unread_at: created_at).find_each do |membership|
+        next_unread = room.messages.active.ordered
+                         .where("created_at > ?", created_at)
+                         .first
+
+        if next_unread
+          membership.update!(
+            unread_at: next_unread.created_at,
+            unread_notifications_count: membership.count_unread_notifications_from(next_unread.created_at)
+          )
+        else
+          membership.read
+        end
+      end
+    end
+end

--- a/app/models/message/unreadable.rb
+++ b/app/models/message/unreadable.rb
@@ -2,6 +2,11 @@ module Message::Unreadable
   extend ActiveSupport::Concern
 
   included do
+    # Order matters: deliver_to_room sets unread_at for disconnected read
+    # memberships, and increment_unread_notifications_counters then bumps the
+    # counter for memberships with unread_at <= created_at. Swap them and the
+    # counter never bumps for a read → unread transition.
+    after_create_commit :deliver_to_room
     after_create_commit :increment_unread_notifications_counters
     after_update_commit :clear_unread_timestamps_if_deactivated
     after_update_commit :destroy_notifications_if_deactivated
@@ -9,6 +14,10 @@ module Message::Unreadable
   end
 
   private
+    def deliver_to_room
+      room.receive(self)
+    end
+
     # Bumps unread_notifications_count for memberships affected by this message.
     # Mirrors the with_has_unread_notifications semantics: DM rooms count every
     # unread message (including the sender's, matching the old scope which made

--- a/docs/plans/DHH-RAILS-STYLE-REFACTOR.md
+++ b/docs/plans/DHH-RAILS-STYLE-REFACTOR.md
@@ -1,0 +1,200 @@
+# DHH/37signals Style Refactor Plan
+
+Findings from a style review of `app/` against once-campfire (the direct ancestor) and Fizzy (a more mature 37signals codebase). Items are ordered roughly by leverage-to-effort. Each item names the reference codebase pattern that justifies the change.
+
+## Background
+
+Sabha forked from Campfire and inherits most of its conventions verbatim. Where Sabha diverges from Campfire **and** Fizzy points at a sharper version of the same pattern, it's worth a refactor. Where Sabha matches Campfire literally (even if it looks unusual), it's the house style — leave alone.
+
+This doc only lists divergences worth acting on. Things Sabha got right (REST decomposition into nested singular resources, `Current` attributes, model-level authorization, Hotwire/Turbo, Solid Queue, importmap/propshaft, broadcasting from controllers) are not catalogued here.
+
+## Status
+
+- **Quick wins #1–#5: shipped in [PR #79](https://github.com/sabha-co/sabha/pull/79).** Kept below as a reference for future similar cleanups.
+- **Structural refactors #6–#7: not started.**
+- **Architectural spike #8 (`Deactivatable`): not started; treat as a separate project.**
+
+## Quick wins (shipped — PR #79)
+
+### 1. Delete `app/services/`; move `SlackImporter` under a model namespace ✅
+
+Neither once-campfire nor Fizzy has an `app/services/` directory. Fizzy keeps similarly complex flows (`Export`, `Signup`) at the top of the models tree or under model namespaces. A single occupant establishes the directory as a precedent without justifying it.
+
+**Shipped:** Moved `app/services/slack_importer.rb` → `lib/slack/importer.rb` as `Slack::Importer`, next to its existing `Slack::UsersImporter` / `Slack::ImportContext` collaborators rather than under `app/models/` (the namespace was already established in `lib/`). `app/services/` deleted.
+
+### 2. Fix `Users::ProfilesController#update` (and siblings) to handle validation failure ✅
+
+Sabha copied a Campfire idiom that ignores `@user.update`'s return value and always redirects with a success notice. **Fizzy demonstrates the right version.**
+
+**Reference — `fizzy/app/controllers/users_controller.rb`:**
+```ruby
+def update
+  if @user.update(user_params)
+    redirect_to @user
+  else
+    render :edit, status: :unprocessable_entity
+  end
+end
+```
+
+**Sites to fix:**
+- `app/controllers/users/profiles_controller.rb:11` and `:34`
+- `app/controllers/accounts/users_controller.rb:24`
+- Audit any other `\.update\(` in controllers without a return-value check.
+
+Non-bang `.update` is fine (Fizzy uses it); silently ignoring the return value is the bug.
+
+### 3. Align `MessagesController#create` with the once-campfire canonical version
+
+**Reference — `once-campfire/app/controllers/messages_controller.rb`:**
+```ruby
+def create
+  set_room
+  @message = @room.messages.create_with_attachment!(message_params)
+
+  @message.broadcast_create
+  deliver_webhooks_to_bots
+rescue ActiveRecord::RecordNotFound
+  render action: :room_not_found
+end
+```
+
+**Sabha changes:**
+- Switch `create_with_attachment` → `create_with_attachment!` and rescue `ActiveRecord::RecordInvalid` instead of branching on `@message.persisted?`.
+- The rescue **must still `render action: :not_allowed`** — that template is the deliberate composer-error UI for `ensure_can_message_recipient` and `ensure_everyone_mention_allowed` failures. The refactor swaps the *trigger* (return value → exception); it doesn't change the response. Don't accidentally turn validation failures into 500s or a different Turbo response.
+- Keep the controller-driven `broadcast_create` / `broadcast_mentionee_sidebar_updates` / `notify_bots` calls — broadcasting from controllers **is** the Campfire convention.
+
+### 4. Scope all controller lookups through `Current.user.<accessible_*>`
+
+Most of Sabha already does this (`Current.user.reachable_messages.find(...)`). The one outlier is `Rooms::MembershipsController#set_joinable_room`:
+
+```ruby
+@room = Room.active.find(params[:room_id])
+head(:forbidden) and return unless @room.open?
+```
+
+Fizzy and Campfire both fetch through the user (`Current.user.boards.find`, `Current.user.rooms.find_by`). The 403 falls out of `ActiveRecord::RecordNotFound`.
+
+**Definition matters here:** "joinable rooms" is not `Current.user.rooms.open` — that only includes rooms the user is already a *visible* member of. Joinability also has to cover the **re-join** case: a user with an inactive or invisible membership in an open room should still be able to POST to `/rooms/:id/membership`. Define joinable as **"active rooms of type `Rooms::Open`, regardless of the user's membership state"**, and let `Room#accept_join!` do the find-or-restore-or-create dance via `memberships.grant_to`.
+
+In practice this is `Rooms::Open.active.find(params[:room_id])` — broader than `Current.user.rooms` because joinability doesn't depend on user identity beyond authentication. If a stricter "exclude users who already have an active visible membership" feels needed, prefer adding it on top via `Rooms::Open.browsable_by(Current.user)` (which already exists) rather than narrowing the join scope itself.
+
+### 5. Reuse the `Sidebar` concern's `broadcast_sidebar_room_removed` instead of inlining the loop
+
+once-campfire's version is one line. Sabha's `RoomsController#broadcast_remove_room` (and the duplicate copy in `api/bots/rooms_controller.rb`) iterates `Sidebar::SIDEBAR_SECTIONS` and calls `helpers.dom_prefix` from the controller — that's view/sidebar internals leaking into the controller, and it's duplicated.
+
+**Action:** The `Sidebar` controller concern already exposes `broadcast_sidebar_room_removed(streamable, room)` for the per-user case. Generalize the first arg from `user` to `streamable` and call it from both `RoomsController` and `API::Bots::RoomsController` with `Current.account`. The room model doesn't need to know about sidebar list names; the concern is the right host because it already owns `SIDEBAR_SECTIONS` and `dom_prefix` access.
+
+## Structural refactors
+
+### 6. Push callbacks and their handlers down into the concern that owns the behavior
+
+**The single biggest divergence from Fizzy.**
+
+Fizzy's rule: a concern that adds behavior owns both the associations *and* the callbacks that trigger it. Example from `fizzy/app/models/card/pinnable.rb`:
+
+```ruby
+module Card::Pinnable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :pin, dependent: :destroy
+    after_update_commit :broadcast_pin_updates, if: :preview_changed?
+  end
+
+  # ... method definitions ...
+end
+```
+
+`Card` itself ends up with 2 callbacks. Fizzy Card with 22 concerns has 8 callbacks total across all of them.
+
+Sabha Message currently has **15 callbacks declared in the parent class**, with the handler methods also defined in `Message` (private). That's the structural bug.
+
+**Decomposition plan for Message:**
+
+| Move to concern | Callbacks |
+|---|---|
+| `Message::Mentionee` (exists) | `:create_mention_notifications`, `:destroy_stale_mention_notifications` |
+| `Message::Threadable` (new) | `:involve_creator_in_thread`, `:update_thread_reply_count`, `:update_parent_message_threads`, `:create_thread_reply_notifications`, `:broadcast_parent_message_to_threads` |
+| `Message::Unreadable` (new) | `:increment_unread_notifications_counters`, `:clear_unread_timestamps_if_deactivated`, `:restore_unread_notifications_counters_if_reactivated`, `:destroy_notifications_if_deactivated` |
+| `Message::Streakable` (new) | `:update_creator_streak` |
+| Stays on `Message` | `:set_default_client_message_id`, `:touch_room_activity`, `:deliver_to_room`, `:dispatch_notifications`, `:broadcast_reactivation_if_restored` |
+
+Apply the same audit to:
+- **Room:** `:broadcast_reactivation_if_restored`, `:announce_creation`, `:broadcast_updates`, plus `deactivate` / `reactivate` / `destroy_all_associated_records` → consider `Room::Deactivatable` (Sabha-specific, not the generic concern) that owns lifecycle + the callbacks that fire on it.
+- **Membership:** `:reset_user_connections_if_deactivated`, `:reset_user_connections`, `:invalidate_room_member_count_cache`, `:broadcast_involvement`, `:broadcast_star_change` → distribute to `Connectable`, `Notifiable`, or new `Starrable`.
+
+### 7. Decompose `User` (637 lines) into more concerns
+
+Fizzy Card is 92 lines + 22 concerns. Sabha's User has 8 concerns and 600+ lines of inline behavior. Targets:
+
+| New concern | What moves |
+|---|---|
+| `User::Verifiable` | `verified?`, `verify_email!`, `send_verification_email`, `generates_token_for :email_verification` |
+| `User::EmailChangeable` | `update_email`, `confirm_email_change!`, `cancel_email_change!`, `pending_email_change?`, `send_email_reconfirmation`, `send_email_change_notification`, `generates_token_for :email_change` |
+| `User::Streakable` | `current_streak`, `recalculate_streak!`, `posted_on?` |
+| `User::Blockable` | `blocked_in?`, `can_ping?`, `blocked?`, `blocked_by?`, `block!`, `unblock!`, the `blocks_given`/`blocks_received` associations |
+| `User::PasswordAuthable` | `has_secure_password`, password validation, `send_password_reset_email`, `generates_token_for :password_reset` |
+| `User::Notifiable` | `unsubscribe_from_email!`, `deliver_weekly_digest_now`, `active_notification_bundle`, `open_notification_bundle!` |
+| `User::SaasBridged` | `global_identity`, `sync_workspace_membership_active`, `sync_name_to_global_identity` |
+
+**`User::SaasBridged` should be `include`d unconditionally**, with each method guarding internally on `Sabha.saas?` (and short-circuiting in single-tenant mode). Don't `include` it conditionally — that makes the model's shape vary by deployment, which breaks tooling that introspects the class (test helpers, fixtures, schema cache invalidation) and means a method that works in CI may not exist in production or vice versa. The pattern matches how `Current#workspace`/`#account` already guard internally on `Sabha.saas?`.
+
+`User` becomes the persistence shell + the small handful of methods that don't fit any one bucket.
+
+## Architectural spike (separate track)
+
+### 8. Replace `Deactivatable` soft-delete with hard-delete + state records (Fizzy way) or `enum :status` (Campfire way)
+
+> **Not a style refactor — treat as an architectural spike.** This is a data-model change with high blast radius: tests around reactivation, unread counters, room deletion, membership visibility, broadcasting, and the SaaS workspace lifecycle all depend on the current semantics. Don't mentally bundle this with the quick-win style cleanups. Plan it as a discrete project, with a design doc, a feature-flagged rollout, and a single model migrated at a time.
+
+`Deactivatable` (boolean `active` column + scope + manual `destroy_all_associated_records`) is **not** Campfire heritage — it came from the Small Bets fork. once-campfire uses `dependent: :destroy` on Room and Message (hard delete). once-campfire User uses `enum :status, %i[ active deactivated banned ]` — which Sabha already does for User.
+
+Costs Sabha pays for the current pattern:
+- `User#destroy_all_associated_records` has 15 explicit `delete_all` calls because `dependent: :destroy` misses `active: false` rows.
+- `Room#destroy_all_associated_records` and `Message#destroy_all_associated_records` exist for the same reason.
+- `rewhere(active: false)` needed in reactivation paths.
+- `Room#post_system_message` uses `Message.insert!` to bypass callbacks, then re-fetches — partially because the soft-delete model means callbacks fire in contexts they shouldn't.
+- New deletable models require remembering to update three `destroy_all_associated_records` methods.
+
+**Two options:**
+
+**(a) Hard delete + state record (Fizzy convention).** Drop the `active` column. Add `Message::Deactivation`, `Room::Deactivation`, `Membership::Deactivation` records (creator, created_at, reason). Scopes become joins:
+```ruby
+Message.joins(:deactivation)         # deactivated
+Message.where.missing(:deactivation) # active
+```
+Reactivation = `deactivation.destroy`. Hard delete = `message.destroy` (and the deactivation cascades via `dependent: :destroy`).
+
+**(b) `enum :status` (Campfire User convention).** Add `status` column with `%i[ active deactivated ]`. Scopes become `where(status: :active)`. Less rich than (a) — no who/when/why — but a smaller migration.
+
+**Recommendation:** **Don't propagate `Deactivatable` to new models** starting now. Pick (a) or (b) for an existing model when you next touch one of {Message, Room, Membership}; do them one at a time, behind a feature flag if needed. Don't migrate all three in one PR.
+
+## Don't act on these (false positives from the initial review)
+
+These were flagged in the first pass but are actually Campfire idioms. Documenting them so future reviews don't re-raise:
+
+- **`delete :clear, on: :collection` on `searches`** — once-campfire routes do exactly this.
+- **`get "webmanifest" => "pwa#manifest"` / `get "service-worker" => "pwa#service_worker"`** — verbatim in once-campfire/config/routes.rb.
+- **`set_room` redirecting inside the setter** — once-campfire/app/controllers/rooms_controller.rb uses the same pattern.
+- **Broadcasting from controllers (`@message.broadcast_create` in `MessagesController#create`)** — once-campfire/app/controllers/messages_controller.rb does this on purpose. Controllers decide *when* to broadcast; models decide *how* (via `room.receive`).
+- **Small `Authorization` controller concern (10 lines)** — once-campfire's is comparable. Concerns don't need to be big.
+- **Soft-delete predicates like `deactivated?`** — fine as a model-API surface; the issue is the *implementation* (boolean column + manual cleanup), not the predicate names.
+- **`User#status` enum** — matches once-campfire exactly. Don't conflate this with the `Deactivatable` boolean.
+
+## Suggested execution order
+
+Each item is independent unless noted.
+
+1. Quick wins #1–#5. Small PRs, each <100 LOC change. Land within a week.
+2. Concern-callback decomposition for Message (#6, Message slice only). One PR, well-tested.
+3. Same decomposition for Room and Membership (#6, remaining slices).
+4. User decomposition (#7). Can be split into one PR per new concern.
+
+**Separate track (not part of the style cleanup):** the `Deactivatable` migration in #8. Treat this as a standalone architectural project with its own design doc and feature-flagged rollout. Pick the lowest-blast-radius model (probably Membership) for a spike before committing to the rest.
+
+## References
+
+- once-campfire: `/Users/ashwin/dev/once-campfire`
+- Fizzy: `/Users/ashwin/dev/fizzy`
+- 37signals style guide: `/Users/ashwin/dev/unofficial-37signals-coding-style-guide`

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -20,6 +20,27 @@ class MessageTest < ActiveSupport::TestCase
     end
   end
 
+  test "creating a message advances room.last_active_at" do
+    room = rooms(:pets)
+    room.update_column(:last_active_at, 1.hour.ago)
+    before = room.last_active_at
+
+    room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "last_active_create")
+
+    assert_operator room.reload.last_active_at, :>, before
+  end
+
+  test "creating a message marks disconnected read memberships as unread" do
+    room = rooms(:pets)
+    recipient_membership = room.memberships.find_by!(user: users(:david))
+    recipient_membership.update!(unread_at: nil)
+    recipient_membership.update_columns(connected_at: nil, connections: 0)
+
+    message = room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "deliver_to_room_marks_unread")
+
+    assert_equal message.created_at, recipient_membership.reload.unread_at
+  end
+
   # Event messages
 
   test "event? returns true when event is present" do
@@ -198,6 +219,16 @@ class MessageTest < ActiveSupport::TestCase
     assert_includes message.errors[:base], "@everyone is only allowed in open rooms"
   end
 
+  test "creating a message in a one-on-one DM where users have blocked each other fails validation" do
+    room = Rooms::Direct.find_or_create_for([ users(:david), users(:jason) ])
+    users(:david).block!(users(:jason))
+
+    message = room.messages.build(creator: users(:jason), body: "Hey", client_message_id: "blocked_dm_invalid")
+
+    assert_not message.valid?
+    assert_includes message.errors[:base], "Messaging this user isn't allowed"
+  end
+
   test "Message.mentioning scope includes @everyone messages" do
     everyone_sgid = Everyone.new.attachable_sgid
     body_html = "<div><action-text-attachment sgid=\"#{everyone_sgid}\" content-type=\"application/vnd.sabha.mention\"></action-text-attachment></div>"
@@ -353,6 +384,48 @@ class MessageTest < ActiveSupport::TestCase
     end
 
     assert_not_equal before, message.reload.thread_fingerprint
+  end
+
+  test "creating a message in a thread broadcasts the reply count to the thread room" do
+    parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent", client_message_id: "thread_reply_count_parent")
+    thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
+    thread.memberships.grant_to(users(:david))
+
+    assert_turbo_stream_broadcasts [ thread, :messages ], count: 1 do
+      thread.messages.create!(creator: users(:david), body: "Reply", client_message_id: "thread_reply_count_reply")
+    end
+  end
+
+  test "creating a message in a thread broadcasts the threads partial to the parent room" do
+    parent_room = rooms(:pets)
+    parent = parent_room.messages.create!(creator: users(:david), body: "Parent", client_message_id: "parent_threads_partial_parent")
+    thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
+    thread.memberships.grant_to(users(:david))
+
+    assert_turbo_stream_broadcasts [ parent_room, :messages ], count: 1 do
+      thread.messages.create!(creator: users(:david), body: "Reply", client_message_id: "parent_threads_partial_reply")
+    end
+  end
+
+  test "deactivating a parent message broadcasts a replace to each thread room" do
+    parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent", client_message_id: "deactivate_parent_thread_broadcast")
+    thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
+    thread.memberships.grant_to(users(:david))
+
+    assert_turbo_stream_broadcasts [ thread, :messages ], count: 1 do
+      parent.deactivate
+    end
+  end
+
+  test "reactivating a parent message broadcasts a replace to each thread room" do
+    parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent", client_message_id: "reactivate_parent_thread_broadcast")
+    thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
+    thread.memberships.grant_to(users(:david))
+    parent.deactivate
+
+    assert_turbo_stream_broadcasts [ thread, :messages ], count: 1 do
+      parent.activate!
+    end
   end
 
   # boost_summary

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -42,6 +42,23 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal message.created_at, recipient_membership.reload.unread_at
   end
 
+  test "mention to a read disconnected recipient sets unread_at and bumps unread_notifications_count" do
+    room = rooms(:pets)
+    recipient_membership = room.memberships.find_by!(user: users(:david))
+    recipient_membership.update!(unread_at: nil, unread_notifications_count: 0)
+    recipient_membership.update_columns(connected_at: nil, connections: 0)
+
+    message = room.messages.create!(
+      creator: users(:jason),
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      client_message_id: "mention_to_read_disconnected"
+    )
+
+    recipient_membership.reload
+    assert_equal message.created_at, recipient_membership.unread_at
+    assert_equal 1, recipient_membership.unread_notifications_count
+  end
+
   # Event messages
 
   test "event? returns true when event is present" do

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
+require "rails/dom/testing/assertions"
 
 class MessageTest < ActiveSupport::TestCase
-  include ActionCable::TestHelper, ActiveJob::TestHelper
+  include ActionCable::TestHelper, ActiveJob::TestHelper, Rails::Dom::Testing::Assertions::SelectorAssertions
 
   test "client_message_id is auto-generated when not provided" do
     message = rooms(:pets).messages.create!(creator: users(:jason), body: "Hello")
@@ -386,46 +387,48 @@ class MessageTest < ActiveSupport::TestCase
     assert_not_equal before, message.reload.thread_fingerprint
   end
 
-  test "creating a message in a thread broadcasts the reply count to the thread room" do
+  test "creating a message in a thread broadcasts an update to the reply count target" do
     parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent", client_message_id: "thread_reply_count_parent")
     thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
     thread.memberships.grant_to(users(:david))
 
-    assert_turbo_stream_broadcasts [ thread, :messages ], count: 1 do
-      thread.messages.create!(creator: users(:david), body: "Reply", client_message_id: "thread_reply_count_reply")
-    end
+    thread.messages.create!(creator: users(:david), body: "Reply", client_message_id: "thread_reply_count_reply")
+
+    target = "#{ActionView::RecordIdentifier.dom_id(thread, :replies_separator)}_count"
+    assert_rendered_turbo_stream_broadcast thread, :messages, action: "update", target: target
   end
 
-  test "creating a message in a thread broadcasts the threads partial to the parent room" do
+  test "creating a message in a thread broadcasts a replace of the parent message's threads block" do
     parent_room = rooms(:pets)
     parent = parent_room.messages.create!(creator: users(:david), body: "Parent", client_message_id: "parent_threads_partial_parent")
     thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
     thread.memberships.grant_to(users(:david))
 
-    assert_turbo_stream_broadcasts [ parent_room, :messages ], count: 1 do
-      thread.messages.create!(creator: users(:david), body: "Reply", client_message_id: "parent_threads_partial_reply")
-    end
+    thread.messages.create!(creator: users(:david), body: "Reply", client_message_id: "parent_threads_partial_reply")
+
+    assert_rendered_turbo_stream_broadcast parent_room, :messages, action: "replace", target: [ parent, :threads ]
   end
 
-  test "deactivating a parent message broadcasts a replace to each thread room" do
+  test "deactivating a parent message broadcasts a replace of the parent message into each thread room" do
     parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent", client_message_id: "deactivate_parent_thread_broadcast")
     thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
     thread.memberships.grant_to(users(:david))
 
-    assert_turbo_stream_broadcasts [ thread, :messages ], count: 1 do
-      parent.deactivate
-    end
+    parent.deactivate
+
+    assert_rendered_turbo_stream_broadcast thread, :messages, action: "replace", target: parent
   end
 
-  test "reactivating a parent message broadcasts a replace to each thread room" do
+  test "reactivating a parent message broadcasts a replace of the parent message into each thread room" do
     parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent", client_message_id: "reactivate_parent_thread_broadcast")
     thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
     thread.memberships.grant_to(users(:david))
-    parent.deactivate
+    # Bypass callbacks so the assertion below narrows to the activate! call.
+    parent.update_columns(active: false)
 
-    assert_turbo_stream_broadcasts [ thread, :messages ], count: 1 do
-      parent.activate!
-    end
+    parent.activate!
+
+    assert_rendered_turbo_stream_broadcast thread, :messages, action: "replace", target: parent
   end
 
   # boost_summary


### PR DESCRIPTION
## Summary

- `Message` previously declared 15 callbacks with handlers defined privately on the class. Fizzy's convention is that a concern owns both the behavior **and** the callbacks that trigger it; this PR adopts that pattern for `Message`.
- Three new concerns (`Streakable`, `Threadable`, `Unreadable`), plus two callbacks moved into the existing `Mentionee`.
- `Message` is now down to 6 callbacks: identity (`set_default_client_message_id`), room activity (`touch_room_activity`), dispatch (`dispatch_notifications`), reactivation broadcast (`broadcast_reactivation_if_restored`), and the cross-cutting `destroy_all_associated_records` cleanup.
- 8 new tests pin the behavior of the moved callbacks (broadcast targets/actions, `unread_at` + counter transitions, validation failure) so a future regression in this area can't hide behind "the test suite is green."

## Decomposition

| Concern | Callbacks |
|---|---|
| `Message::Mentionee` (existing) | adds `create_mention_notifications`, `destroy_stale_mention_notifications` on top of the existing `set_mentions_everyone_flag` / `reset_mentionee_memo` |
| `Message::Streakable` (new) | `update_creator_streak` |
| `Message::Threadable` (new) | `involve_creator_in_thread`, `update_thread_reply_count`, `update_parent_message_threads`, `create_thread_reply_notifications`, `broadcast_parent_message_to_threads` |
| `Message::Unreadable` (new) | `deliver_to_room`, `increment_unread_notifications_counters`, `clear_unread_timestamps_if_deactivated`, `destroy_notifications_if_deactivated`, `restore_unread_notifications_counters_if_reactivated`, plus the shared `rebalance_unread_counters` helper |
| Stays on `Message` | `set_default_client_message_id`, `touch_room_activity`, `dispatch_notifications`, `broadcast_reactivation_if_restored`, `destroy_all_associated_records` |

## Callback ordering — load-bearing detail

Concerns are included before Message-level callbacks register, so moving callbacks into concerns changes the registration order. Most callbacks are order-independent, but one isn't: `deliver_to_room` sets `unread_at` for disconnected read memberships, and `increment_unread_notifications_counters` then bumps the counter for memberships with `unread_at <= created_at`. Swap their order and the counter never bumps for a read → unread transition — the room appears unread but the badge stays at 0.

That's why `deliver_to_room` lives in `Unreadable` declared **before** `increment_unread_notifications_counters`, with a comment naming the dependency. A new test (`mention to a read disconnected recipient sets unread_at and bumps unread_notifications_count`) asserts both fields together so this ordering can't drift silently. The existing unread-counter tests pre-set `unread_at` to a past time, which masked this regression — that's noted in the new test's setup.

## Tests added (`test/models/message_test.rb`)

- `creating a message advances room.last_active_at` — `touch_room_activity`
- `creating a message marks disconnected read memberships as unread` — `deliver_to_room`
- `mention to a read disconnected recipient sets unread_at and bumps unread_notifications_count` — the callback-order regression catcher
- `creating a message in a one-on-one DM where users have blocked each other fails validation` — `ensure_can_message_recipient`
- `creating a message in a thread broadcasts an update to the reply count target` — asserts `action="update"` and the exact target id
- `creating a message in a thread broadcasts a replace of the parent message's threads block` — asserts `action="replace"` and target
- `deactivating a parent message broadcasts a replace of the parent message into each thread room`
- `reactivating a parent message broadcasts a replace of the parent message into each thread room`

Broadcast tests use the existing `assert_rendered_turbo_stream_broadcast` helper (pulled in via `Rails::Dom::Testing::Assertions::SelectorAssertions`) so the assertions pin Turbo `action` + `target`, not just the count. Confirmed via a quick mutation: swapping `broadcast_update_to` → `broadcast_replace_to` in `update_thread_reply_count` makes the test fail with `found 0` matches.