### PR TITLE
Move Room and Membership callbacks into the concerns that own them

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,5 +1,5 @@
 class Membership < ApplicationRecord
-  include Connectable, Deactivatable, Notifiable
+  include Cacheable, Connectable, Involvable, Starrable, Deactivatable, Notifiable
 
   class LastVisibleMemberError < StandardError; end
 
@@ -28,18 +28,6 @@ class Membership < ApplicationRecord
     end
   }, through: :room, source: :messages
 
-  after_update_commit :reset_user_connections_if_deactivated
-  after_destroy_commit :reset_user_connections
-  after_commit :invalidate_room_member_count_cache
-
-  enum :involvement, %w[ invisible nothing mentions everything ].index_by(&:itself), prefix: :involved_in
-
-  validate :starred_only_for_shared_visible_rooms, if: :starred?
-  before_validation :unstar_if_invisible
-
-  after_update :broadcast_involvement, if: :saved_change_to_involvement?
-  after_update_commit :broadcast_star_change, if: :saved_change_to_starred?
-
   scope :with_ordered_room, -> { includes(:room).joins(:room).order("rooms.sortable_name") }
   scope :with_room_by_activity, -> { includes(:room).joins(:room).order("rooms.messages_count DESC") }
   scope :with_room_by_last_active_newest_first, -> { includes(:room).joins(:room).order("rooms.last_active_at DESC") }
@@ -66,11 +54,7 @@ class Membership < ApplicationRecord
     joins(:room).where("memberships.unread_at IS NOT NULL OR rooms.updated_at > ?", since)
   }
 
-  scope :starred, -> { where(starred: true) }
-  scope :unstarred, -> { where(starred: false) }
-  scope :notifications_on, -> { where(involvement: :everything) }
-  scope :visible, -> { where.not(involvement: :invisible) }
-  scope :read,  -> { where(unread_at: nil) }
+  scope :read,    -> { where(unread_at: nil) }
   scope :unread,  -> { where.not(unread_at: nil) }
 
   def read_until(time)
@@ -149,33 +133,6 @@ class Membership < ApplicationRecord
   end
 
   private
-    def starred_only_for_shared_visible_rooms
-      if room.direct? || room.thread?
-        errors.add(:starred, "is not allowed for direct or thread rooms")
-      end
-    end
-
-    def unstar_if_invisible
-      self.starred = false if involved_in_invisible? && starred?
-    end
-
-    def reset_user_connections_if_deactivated
-      user.reset_remote_connections if deactivated?
-    end
-
-    def reset_user_connections
-      user.reset_remote_connections
-    end
-
-    def invalidate_room_member_count_cache
-      room&.invalidate_member_count_cache
-
-      # Also invalidate the previous room's cache if room_id changed
-      if saved_change_to_room_id? && room_id_before_last_save
-        Room.find_by(id: room_id_before_last_save)&.invalidate_member_count_cache
-      end
-    end
-
     def broadcast_read
       ReadRoomsChannel.broadcast_to(user, { room_id: room_id })
     end
@@ -193,29 +150,6 @@ class Membership < ApplicationRecord
         .where("messages.created_at >= ?", unread_at)
         .where("notifications.created_at > ?", time)
         .count
-    end
-
-    def broadcast_involvement
-      UserInvolvementsChannel.broadcast_to(user, { roomId: room_id, involvement: involvement })
-    end
-
-    def broadcast_star_change
-      return if involved_in_invisible? || room.direct? || room.thread?
-
-      old_list = starred_before_last_save ? :starred_rooms : :shared_rooms
-
-      Turbo::StreamsChannel.broadcast_remove_to(
-        user, :rooms,
-        target: [ room, "#{old_list}_list_node" ]
-      )
-
-      Turbo::StreamsChannel.broadcast_append_to(
-        user, :rooms,
-        target: sidebar_list_name,
-        partial: "users/sidebars/rooms/shared",
-        locals: { list_name: sidebar_list_name, membership: self },
-        attributes: { maintain_scroll: true }
-      )
     end
 
     def unread_payload

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,15 +1,6 @@
 class Membership < ApplicationRecord
   include Cacheable, Connectable, Involvable, Starrable, Deactivatable, Notifiable
 
-  class LastVisibleMemberError < StandardError; end
-
-  def leave!
-    with_lock do
-      room.ensure_visible_members_remain!(excluding: user_id)
-      update!(involvement: :invisible)
-    end
-  end
-
   belongs_to :room
   belongs_to :user
 
@@ -57,6 +48,15 @@ class Membership < ApplicationRecord
   scope :read,    -> { where(unread_at: nil) }
   scope :unread,  -> { where.not(unread_at: nil) }
 
+  class LastVisibleMemberError < StandardError; end
+
+  def leave!
+    with_lock do
+      room.ensure_visible_members_remain!(excluding: user_id)
+      update!(involvement: :invisible)
+    end
+  end
+
   def read_until(time)
     return if read? || time < unread_at
 
@@ -89,28 +89,6 @@ class Membership < ApplicationRecord
 
   def has_unread_notifications?
     unread_notifications_count > 0
-  end
-
-  def sidebar_list_name
-    starred? ? :starred_rooms : :shared_rooms
-  end
-
-  def receives_mentions?
-    involved_in_mentions? || involved_in_everything?
-  end
-
-  # Per-room involvement after applying the global mode override. Predicates
-  # ask this only — they don't read mode and involvement independently.
-  # Per-room :everything wins (opt-in beats global mute); otherwise global
-  # :nothing applies; else fall back to per-room involvement.
-  def effective_involvement
-    return :everything if involved_in_everything?
-    return :nothing if user.try(:notification_settings)&.mode == "nothing"
-    involvement.to_sym
-  end
-
-  def ensure_receives_mentions!
-    update(involvement: :mentions) unless receives_mentions?
   end
 
   # Recompute the count of notification-worthy unread messages from a given anchor.

--- a/app/models/membership/cacheable.rb
+++ b/app/models/membership/cacheable.rb
@@ -1,0 +1,17 @@
+module Membership::Cacheable
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :invalidate_room_member_count_cache
+  end
+
+  private
+    def invalidate_room_member_count_cache
+      room&.invalidate_member_count_cache
+
+      # Also invalidate the previous room's cache if room_id changed
+      if saved_change_to_room_id? && room_id_before_last_save
+        Room.find_by(id: room_id_before_last_save)&.invalidate_member_count_cache
+      end
+    end
+end

--- a/app/models/membership/connectable.rb
+++ b/app/models/membership/connectable.rb
@@ -6,6 +6,9 @@ module Membership::Connectable
   included do
     scope :connected,    -> { where(connected_at: CONNECTION_TTL.ago..) }
     scope :disconnected, -> { where(connected_at: [ nil, ...CONNECTION_TTL.ago ]) }
+
+    after_update_commit  :reset_user_connections_if_deactivated
+    after_destroy_commit :reset_user_connections
   end
 
   ACTIVITY_TIERS = { active: 10.minutes, away: 1.hour, recently_active: 24.hours }.freeze
@@ -84,4 +87,13 @@ module Membership::Connectable
   def decrement_connections
     connected? ? decrement!(:connections, touch: true) : update!(connections: 0)
   end
+
+  private
+    def reset_user_connections_if_deactivated
+      user.reset_remote_connections if deactivated?
+    end
+
+    def reset_user_connections
+      user.reset_remote_connections
+    end
 end

--- a/app/models/membership/involvable.rb
+++ b/app/models/membership/involvable.rb
@@ -1,0 +1,35 @@
+module Membership::Involvable
+  extend ActiveSupport::Concern
+
+  included do
+    enum :involvement, %w[ invisible nothing mentions everything ].index_by(&:itself), prefix: :involved_in
+
+    scope :visible,          -> { where.not(involvement: :invisible) }
+    scope :notifications_on, -> { where(involvement: :everything) }
+
+    after_update :broadcast_involvement, if: :saved_change_to_involvement?
+  end
+
+  def receives_mentions?
+    involved_in_mentions? || involved_in_everything?
+  end
+
+  # Per-room involvement after applying the global mode override. Predicates
+  # ask this only — they don't read mode and involvement independently.
+  # Per-room :everything wins (opt-in beats global mute); otherwise global
+  # :nothing applies; else fall back to per-room involvement.
+  def effective_involvement
+    return :everything if involved_in_everything?
+    return :nothing if user.try(:notification_settings)&.mode == "nothing"
+    involvement.to_sym
+  end
+
+  def ensure_receives_mentions!
+    update(involvement: :mentions) unless receives_mentions?
+  end
+
+  private
+    def broadcast_involvement
+      UserInvolvementsChannel.broadcast_to(user, { roomId: room_id, involvement: involvement })
+    end
+end

--- a/app/models/membership/starrable.rb
+++ b/app/models/membership/starrable.rb
@@ -1,0 +1,47 @@
+module Membership::Starrable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :starred,   -> { where(starred: true) }
+    scope :unstarred, -> { where(starred: false) }
+
+    validate :starred_only_for_shared_visible_rooms, if: :starred?
+    before_validation :unstar_if_invisible
+
+    after_update_commit :broadcast_star_change, if: :saved_change_to_starred?
+  end
+
+  def sidebar_list_name
+    starred? ? :starred_rooms : :shared_rooms
+  end
+
+  private
+    def starred_only_for_shared_visible_rooms
+      if room.direct? || room.thread?
+        errors.add(:starred, "is not allowed for direct or thread rooms")
+      end
+    end
+
+    def unstar_if_invisible
+      self.starred = false if involved_in_invisible? && starred?
+    end
+
+    def broadcast_star_change
+      return if involved_in_invisible? || room.direct? || room.thread?
+
+      old_list = starred_before_last_save ? :starred_rooms : :shared_rooms
+
+      Turbo::StreamsChannel.broadcast_remove_to(
+        user, :rooms,
+        target: [ room, "#{old_list}_list_node" ]
+      )
+
+      Turbo::StreamsChannel.broadcast_append_to(
+        user, :rooms,
+        target: sidebar_list_name,
+        partial: "users/sidebars/rooms/shared",
+        locals: { list_name: sidebar_list_name, membership: self },
+        attributes: { maintain_scroll: true }
+      )
+    end
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,5 +1,5 @@
 class Room < ApplicationRecord
-  include Deactivatable
+  include Announceable, Restorable, Sortable, Deactivatable
 
   CannotDeleteOriginalError = Class.new(StandardError)
 
@@ -48,9 +48,6 @@ class Room < ApplicationRecord
 
   before_validation :set_initial_last_active_at, on: :create
 
-  before_save :set_sortable_name
-  after_save_commit :broadcast_updates, if: :saved_change_to_sortable_name?
-
   scope :opens,           -> { where(type: "Rooms::Open") }
   scope :closeds,         -> { where(type: "Rooms::Closed") }
   scope :directs,         -> { where(type: "Rooms::Direct") }
@@ -61,9 +58,6 @@ class Room < ApplicationRecord
   scope :matching, ->(query) {
     query.present? ? where("name LIKE ?", "%#{sanitize_sql_like(query)}%") : all
   }
-
-  after_update_commit :broadcast_reactivation_if_restored
-  after_create_commit :announce_creation
 
   class << self
     def create_for(attributes, users:)
@@ -254,19 +248,6 @@ class Room < ApplicationRecord
     post_system_message(event: "member_left", body: "left", actor: user)
   end
 
-  def announce_membership_changes(granted: [], revoked: [], actor:)
-    if granted.present?
-      post_system_message(event: "member_joined", body: membership_change_text("added", granted), actor: actor)
-    end
-    if revoked.present?
-      post_system_message(event: "member_left", body: membership_change_text("removed", revoked), actor: actor)
-    end
-  end
-
-  def announce_rename(old_name, actor:)
-    post_system_message(event: "room_renamed", body: "renamed the room from #{old_name} to #{name}", actor: actor)
-  end
-
   def bot_memberships_for_events(item, event)
     bot_ids = User.active_bots.pluck(:id)
     return [] if bot_ids.empty?
@@ -309,30 +290,8 @@ class Room < ApplicationRecord
       [ tenant_prefix, "room", id, "active_member_count" ].compact.join(":")
     end
 
-    def membership_change_text(verb, users)
-      if users.size <= 2
-        "#{verb} #{users.map(&:name).to_sentence}"
-      else
-        "#{verb} #{users.size} members"
-      end
-    end
-
     def set_initial_last_active_at
       self.last_active_at = Time.current
-    end
-
-    def broadcast_reactivation_if_restored
-      broadcast_reactivation if saved_change_to_attribute?(:active) && active?
-    end
-
-    def announce_creation
-      return if direct? || thread?
-      return unless User.active.where.not(id: creator_id).exists? # No audience on fresh setup
-      post_system_message(event: "room_created", body: "created the room", actor: creator)
-    end
-
-    def set_sortable_name
-      self.sortable_name = name.to_s.gsub(/[[:^ascii:]\p{So}]/, "").strip.downcase
     end
 
     def unread_memberships(message)
@@ -357,27 +316,6 @@ class Room < ApplicationRecord
       }
       users.each do |user|
         UserUnreadRoomsChannel.broadcast_to(user, payload)
-      end
-    end
-
-    def broadcast_updates
-      RoomListChannel.broadcast_to(Account.sole, { roomId: id, sortableName: sortable_name })
-    rescue ActiveRecord::RecordNotFound
-      # No account yet (e.g., during setup or seed)
-    end
-
-    def broadcast_reactivation
-      return unless sidebar_room?
-
-      memberships.visible.includes(:user).find_each do |membership|
-        list_name = membership.sidebar_list_name
-        Turbo::StreamsChannel.broadcast_append_to(
-          membership.user, :rooms,
-          target: list_name,
-          partial: "users/sidebars/rooms/shared",
-          locals: { list_name:, membership: membership, room: self },
-          attributes: { maintain_scroll: true }
-        )
       end
     end
 

--- a/app/models/room/announceable.rb
+++ b/app/models/room/announceable.rb
@@ -1,0 +1,35 @@
+module Room::Announceable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :announce_creation
+  end
+
+  def announce_membership_changes(granted: [], revoked: [], actor:)
+    if granted.present?
+      post_system_message(event: "member_joined", body: membership_change_text("added", granted), actor: actor)
+    end
+    if revoked.present?
+      post_system_message(event: "member_left", body: membership_change_text("removed", revoked), actor: actor)
+    end
+  end
+
+  def announce_rename(old_name, actor:)
+    post_system_message(event: "room_renamed", body: "renamed the room from #{old_name} to #{name}", actor: actor)
+  end
+
+  private
+    def announce_creation
+      return if direct? || thread?
+      return unless User.active.where.not(id: creator_id).exists? # No audience on fresh setup
+      post_system_message(event: "room_created", body: "created the room", actor: creator)
+    end
+
+    def membership_change_text(verb, users)
+      if users.size <= 2
+        "#{verb} #{users.map(&:name).to_sentence}"
+      else
+        "#{verb} #{users.size} members"
+      end
+    end
+end

--- a/app/models/room/restorable.rb
+++ b/app/models/room/restorable.rb
@@ -1,0 +1,27 @@
+module Room::Restorable
+  extend ActiveSupport::Concern
+
+  included do
+    after_update_commit :broadcast_reactivation_if_restored
+  end
+
+  private
+    def broadcast_reactivation_if_restored
+      broadcast_reactivation if saved_change_to_attribute?(:active) && active?
+    end
+
+    def broadcast_reactivation
+      return unless sidebar_room?
+
+      memberships.visible.includes(:user).find_each do |membership|
+        list_name = membership.sidebar_list_name
+        Turbo::StreamsChannel.broadcast_append_to(
+          membership.user, :rooms,
+          target: list_name,
+          partial: "users/sidebars/rooms/shared",
+          locals: { list_name:, membership: membership, room: self },
+          attributes: { maintain_scroll: true }
+        )
+      end
+    end
+end

--- a/app/models/room/sortable.rb
+++ b/app/models/room/sortable.rb
@@ -1,0 +1,19 @@
+module Room::Sortable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :set_sortable_name
+    after_save_commit :broadcast_updates, if: :saved_change_to_sortable_name?
+  end
+
+  private
+    def set_sortable_name
+      self.sortable_name = name.to_s.gsub(/[[:^ascii:]\p{So}]/, "").strip.downcase
+    end
+
+    def broadcast_updates
+      RoomListChannel.broadcast_to(Account.sole, { roomId: id, sortableName: sortable_name })
+    rescue ActiveRecord::RecordNotFound
+      # No account yet (e.g., during setup or seed)
+    end
+end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require "rails/dom/testing/assertions"
 
 class MembershipTest < ActiveSupport::TestCase
+  include ActionCable::TestHelper, Rails::Dom::Testing::Assertions::SelectorAssertions
+
   setup do
     @membership = memberships(:david_watercooler)
   end
@@ -660,5 +663,118 @@ class MembershipTest < ActiveSupport::TestCase
       membership.user.create_notification_settings!(mode: :nothing)
 
     assert_equal :nothing, membership.effective_involvement
+  end
+
+  # The tests below pin observable Membership callback behavior: room member-count
+  # cache invalidation on save (including room_id moves), involvement broadcasts on
+  # UserInvolvementsChannel, and starred broadcasts to the user's room list — plus
+  # the guards that suppress star broadcasts for direct rooms and invisible
+  # memberships. They assert what the callbacks emit, not how they're wired, so
+  # they survive moves between the model and concerns.
+
+  test "saving a membership invalidates the room's active_member_count cache" do
+    room = @membership.room
+    cache_key = room.send(:active_member_count_cache_key)
+
+    Rails.cache.stubs(:delete)  # let unrelated cache deletes pass through
+    Rails.cache.expects(:delete).with(cache_key).at_least_once
+    @membership.update!(involvement: :mentions)
+  end
+
+  test "moving a membership to a new room invalidates both rooms' caches" do
+    # Use rachel — only in watercooler, not in pets — to avoid UNIQUE collision.
+    membership = memberships(:rachel_watercooler)
+    old_room = membership.room
+    new_room = rooms(:pets)
+    assert_not_equal old_room.id, new_room.id
+
+    old_key = old_room.send(:active_member_count_cache_key)
+    new_key = new_room.send(:active_member_count_cache_key)
+
+    Rails.cache.stubs(:delete)  # let unrelated cache deletes pass through
+    Rails.cache.expects(:delete).with(new_key).at_least_once
+    Rails.cache.expects(:delete).with(old_key).at_least_once
+
+    membership.update!(room: new_room)
+  end
+
+  test "changing involvement broadcasts to UserInvolvementsChannel" do
+    # fixture starts as :everything — move to a different value so the change fires
+    ActionCable.server.pubsub.clear
+
+    assert_broadcasts(UserInvolvementsChannel.broadcasting_for(@membership.user), 1) do
+      @membership.update!(involvement: :mentions)
+    end
+  end
+
+  test "non-involvement updates do not broadcast to UserInvolvementsChannel" do
+    ActionCable.server.pubsub.clear
+
+    assert_no_broadcasts(UserInvolvementsChannel.broadcasting_for(@membership.user)) do
+      @membership.update!(connected_at: Time.current)
+    end
+  end
+
+  test "starring a shared-room membership broadcasts remove from shared list and append to starred list" do
+    # fixture starts starred: true — reset to false without firing callbacks so
+    # the test's update! is the only star transition.
+    @membership.update_columns(starred: false)
+    ActionCable.server.pubsub.clear
+
+    @membership.update!(starred: true)
+
+    assert_rendered_turbo_stream_broadcast @membership.user, :rooms,
+      action: "remove", target: [ @membership.room, "shared_rooms_list_node" ]
+    assert_rendered_turbo_stream_broadcast @membership.user, :rooms,
+      action: "append", target: :starred_rooms
+  end
+
+  test "unstarring a shared-room membership broadcasts remove from starred list and append to shared list" do
+    @membership.update_columns(starred: true)  # ensure starting state
+    ActionCable.server.pubsub.clear
+
+    @membership.update!(starred: false)
+
+    assert_rendered_turbo_stream_broadcast @membership.user, :rooms,
+      action: "remove", target: [ @membership.room, "starred_rooms_list_node" ]
+    assert_rendered_turbo_stream_broadcast @membership.user, :rooms,
+      action: "append", target: :shared_rooms
+  end
+
+  test "non-star updates do not broadcast a star change" do
+    ActionCable.server.pubsub.clear
+
+    @membership.update!(connected_at: Time.current)
+
+    stream_name = "#{@membership.user.to_gid_param}:rooms"
+    assert_empty ActionCable.server.pubsub.broadcasts(stream_name),
+      "non-star updates should not emit star_change broadcasts"
+  end
+
+  test "star change on a direct-room membership does not broadcast" do
+    membership = memberships(:david_david_and_jason)
+    ActionCable.server.pubsub.clear
+
+    # Bypass starred_only_for_shared_visible_rooms validation but keep callbacks
+    # to exercise broadcast_star_change's room.direct? guard.
+    membership.update_attribute(:starred, true)
+
+    stream_name = "#{membership.user.to_gid_param}:rooms"
+    assert_empty ActionCable.server.pubsub.broadcasts(stream_name),
+      "star change on direct-room memberships should be guarded (room.direct?)"
+  end
+
+  test "star change on an invisible membership does not broadcast" do
+    @membership.update!(involvement: :invisible)  # also auto-unstars via unstar_if_invisible
+    ActionCable.server.pubsub.clear
+
+    # Force a starred change while invisible — exercises broadcast_star_change's
+    # involved_in_invisible? guard. Skip validations so unstar_if_invisible
+    # doesn't undo the change before save.
+    @membership.update_attribute(:starred, true)
+
+    stream_name = "#{@membership.user.to_gid_param}:rooms"
+    assert_empty ActionCable.server.pubsub.broadcasts(stream_name),
+      "star change on invisible memberships should be guarded (involved_in_invisible?)"
   end
 end

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require "rails/dom/testing/assertions"
 
 class RoomTest < ActiveSupport::TestCase
+  include ActionCable::TestHelper, Rails::Dom::Testing::Assertions::SelectorAssertions
+
   test "last_active_at is set on room creation" do
     room = Rooms::Open.create!(name: "New Room", creator: users(:david))
     assert room.last_active_at.present?
@@ -368,5 +371,98 @@ class RoomTest < ActiveSupport::TestCase
 
     result = thread.bot_memberships_for_events(message, :created)
     assert_includes result.map(&:user_id), bender.id, "bot in a thread should receive message events even without a mention"
+  end
+
+  # The tests below pin observable Room callback behavior: RoomListChannel
+  # broadcasts on sortable_name change, sidebar appends to each visible member
+  # on reactivation (suppressed for thread rooms), and the room_created event
+  # message posted on creation (suppressed for direct and thread rooms). They
+  # assert what the callbacks emit, not how they're wired, so they survive
+  # moves between the model and concerns.
+
+  test "renaming a room broadcasts to the room list channel" do
+    room = rooms(:pets)
+    ActionCable.server.pubsub.clear
+
+    assert_broadcasts(RoomListChannel.broadcasting_for(Account.sole), 1) do
+      room.update!(name: "Other Pets")
+    end
+  end
+
+  test "updating a room without changing its name does not broadcast to the room list channel" do
+    room = rooms(:pets)
+    room.save!  # ensure sortable_name is materialized (fixtures bypass callbacks)
+    ActionCable.server.pubsub.clear
+
+    assert_no_broadcasts(RoomListChannel.broadcasting_for(Account.sole)) do
+      room.update!(last_active_at: 1.second.from_now)
+    end
+  end
+
+  test "reactivating a sidebar room broadcasts an append to each visible member's sidebar" do
+    room = rooms(:pets)
+    room.update_columns(active: false)
+    visible = room.memberships.visible.includes(:user).to_a
+    assert visible.size >= 2, "fixture should have multiple visible members for this test to be meaningful"
+    ActionCable.server.pubsub.clear
+
+    room.activate!
+
+    visible.each do |membership|
+      assert_rendered_turbo_stream_broadcast membership.user, :rooms,
+        action: "append", target: membership.sidebar_list_name
+    end
+  end
+
+  test "non-active updates do not broadcast a reactivation" do
+    room = rooms(:pets)
+    user = room.memberships.visible.first.user
+    ActionCable.server.pubsub.clear
+
+    room.update!(last_active_at: 1.second.from_now)
+
+    stream_name = "#{user.to_gid_param}:rooms"
+    assert_empty ActionCable.server.pubsub.broadcasts(stream_name),
+      "non-active updates should not emit sidebar reactivation broadcasts"
+  end
+
+  test "reactivating a thread room does not broadcast sidebar appends" do
+    parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent",
+                                            client_message_id: "thread_reactivate_skip_sidebar")
+    thread = Rooms::Thread.create!(parent_message: parent, creator: users(:david))
+    thread.memberships.grant_to(users(:david))
+    thread.update_columns(active: false)
+    ActionCable.server.pubsub.clear
+
+    thread.activate!
+
+    stream_name = "#{users(:david).to_gid_param}:rooms"
+    assert_empty ActionCable.server.pubsub.broadcasts(stream_name),
+      "thread room reactivation should not emit sidebar broadcasts (sidebar_room? guard)"
+  end
+
+  test "creating a non-direct, non-thread room with an audience posts a room_created event" do
+    assert_difference -> { Message.unscoped.where(event: "room_created").count }, 1 do
+      Rooms::Open.create!(name: "Greenhouse", creator: users(:david))
+    end
+  end
+
+  test "creating a direct room does not post a room_created event" do
+    Current.set(user: users(:david)) do
+      assert_no_difference -> { Message.unscoped.where(event: "room_created").count } do
+        Rooms::Direct.find_or_create_for([ users(:david), users(:bender) ])
+      end
+    end
+  end
+
+  test "creating a thread room does not post a room_created event" do
+    parent = rooms(:pets).messages.create!(creator: users(:david), body: "Parent",
+                                            client_message_id: "thread_create_no_event")
+
+    # Don't scope to parent's room — if announce_creation fired on the thread,
+    # the room_created message would have room_id = thread.id, not parent.room_id.
+    assert_no_difference -> { Message.unscoped.where(event: "room_created").count } do
+      Rooms::Thread.create!(parent_message: parent, creator: users(:david))
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Pin every Room and Membership callback's observable contract (action, target, payload) before touching the model — 12 new tests added, mutation-verified to catch regressions during extraction.
- Move Room callbacks into three new concerns: `Room::Sortable` (sortable_name lifecycle + RoomListChannel rename broadcast), `Room::Announceable` (room_created / room_renamed / member-change system messages), `Room::Restorable` (sidebar reactivation broadcast).
- Move Membership callbacks into three new concerns and extend one existing: `Membership::Cacheable` (room member-count cache invalidation incl. room_id change), `Membership::Involvable` (involvement enum + UserInvolvementsChannel broadcast), `Membership::Starrable` (star validations + dual remove/append broadcast); `Membership::Connectable` absorbs `reset_user_connections*` callbacks.
- Net effect: Room drops from 412 → 350 lines (6 → 1 class-level callbacks); Membership drops from 233 → 145 lines (5 → 0 class-level callbacks). Same pattern as #80 applied to Message.

Follows the foundation refactor plan; sibling to #80.

## Test plan

- [x] `bin/rails test test/models/room_test.rb test/models/membership_test.rb` green (108 runs, 229 assertions)
- [x] `bin/rails test` green (1515 runs, 5096 assertions, 0 failures)
- [x] Mutation-verified protective tests: dropping the `thread?` guard in `announce_creation` fails G3; flipping `sidebar_list_name` to always-`:shared_rooms` fails G6 starring
- [ ] `SAAS=true bin/rails test` — not yet run in this branch