### PR TITLE
Extract User into per-capability concerns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, EmailChangeable, Mentionable, PasswordAuthable, Role, Streakable, Transferable, Verifiable
+  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, EmailChangeable, Mentionable, Notifiable, PasswordAuthable, Role, Streakable, Transferable, Verifiable
 
   serialize :preferences, coder: JSON
 
@@ -33,49 +33,7 @@ class User < ApplicationRecord
   has_many :reachable_messages, through: :rooms, source: :messages
   has_many :messages, -> { active }, foreign_key: :creator_id, class_name: "Message"
 
-  has_many :notifications
-  has_many :notification_bundles, class_name: "Notification::Bundle", dependent: :destroy
   has_many :join_codes, class_name: "Account::JoinCode", dependent: :destroy
-
-  has_one :notification_settings, class_name: "User::NotificationSettings", dependent: :destroy
-  after_create_commit :ensure_notification_settings
-
-  # Returns the user's open accumulator for missed-notification email candidates,
-  # opening one if none is active. Race-safe via the partial unique index — a
-  # concurrent open by a parallel writer raises RecordNotUnique on the loser
-  # and falls through to a second read.
-  def active_notification_bundle
-    notification_bundles.active.first || open_notification_bundle!
-  end
-
-  # Public so batch dispatch can open bundles for users not in a pre-fetched
-  # active set without re-running `active.first` for each miss.
-  def open_notification_bundle!
-    frequency = notification_settings&.email_frequency || "hourly"
-    starts_at = Time.current
-    notification_bundles.create!(
-      frequency: frequency,
-      starts_at: starts_at,
-      ends_at:   starts_at + Notification::Bundle::FREQUENCY_WINDOWS.fetch(frequency)
-    )
-  rescue ActiveRecord::RecordNotUnique
-    notification_bundles.active.first!
-  end
-
-  def unsubscribe_from_email!(surface)
-    (notification_settings || create_notification_settings!).unsubscribe_from!(surface)
-  end
-
-  # Builds this user's weekly digest content and mails it if non-empty.
-  # `last_digest_sent_at` only advances on actual delivery so quiet weeks
-  # don't dedup-lock subsequent runs.
-  def deliver_weekly_digest_now
-    content = Notification::Digest::Content.new(self)
-    return if content.empty?
-
-    WeeklyDigestMailer.digest(self, content).deliver_now
-    notification_settings.update!(last_digest_sent_at: Time.current)
-  end
 
   def active_invite_link
     join_codes.active.first
@@ -101,57 +59,6 @@ class User < ApplicationRecord
       )
   end
 
-  # Persists the watermark used by unseen_activity? to gate the sidebar dot.
-  # Monotonic: only advances forward so stale `loaded_at` values from background
-  # tabs can't reopen the dot. Broadcast is fired by after_update_commit below.
-  def touch_activity_seen_at(time = Time.current)
-    return if time.nil?
-    return if activity_seen_at.present? && activity_seen_at >= time
-
-    update!(activity_seen_at: time)
-  end
-
-  # True when at least one notification row has arrived since the user last
-  # opened the Activity tab. Drives the sidebar Activity dot.
-  def unseen_activity?
-    scope = notifications
-    scope = scope.where("notifications.created_at > ?", activity_seen_at) if activity_seen_at
-    scope.exists?
-  end
-
-  # Marks all direct message rooms as read up to the loaded timestamp.
-  def mark_direct_messages_as_read(loaded_at)
-    dms_until = freshness_checked_time(loaded_at)
-
-    memberships.unread.direct_rooms.each do |m|
-      m.read_until(dms_until)
-    end
-  end
-
-  # Marks inbox as read up to the timestamps when messages were last loaded.
-  # Uses stale detection: if timestamp is > 1 hour old, uses current time instead
-  # (user likely left the page open without interacting).
-  #
-  # For activity: DMs are always marked as read. For other rooms, only marks as read
-  # if the room had no non-notified messages in the window (avoids accidentally marking
-  # unread messages as read when user only viewed activity)
-  def mark_inbox_as_read(messages_loaded_at:, notifications_loaded_at:, activity_loaded_at:)
-    messages_until = freshness_checked_time(messages_loaded_at)
-    notifications_until = freshness_checked_time(notifications_loaded_at)
-    activity_until = freshness_checked_time(activity_loaded_at)
-
-    # Mark all visible rooms as read up to when messages were loaded
-    memberships.unread.each { |m| m.read_until(messages_until) }
-
-    # Mark notification rooms as read up to when notifications were loaded
-    memberships.notifications_on.unread.each { |m| m.read_until(notifications_until) }
-
-    # Mark activity rooms as read: DMs always, others only if all unread messages have notifications
-    mark_notified_rooms_as_read(activity_until, include_dms: true)
-
-    touch_activity_seen_at(activity_until)
-  end
-
   has_many :push_subscriptions, class_name: "Push::Subscription", dependent: :delete_all
 
   has_many :boosts, foreign_key: :booster_id, class_name: "Boost"
@@ -171,19 +78,8 @@ class User < ApplicationRecord
 
   scope :without_default_names, -> { where.not(name: DEFAULT_NAME) }
 
-  scope :weekly_digest_eligible, -> {
-    verified
-      .where(status: statuses[:active])
-      .where.not(role: roles[:bot])
-      .joins(:notification_settings)
-      .includes(:notification_settings)
-      .where(user_notification_settings: { weekly_digest_subscribed: true })
-      .merge(User::NotificationSettings.due_for_weekly_digest)
-  }
-
   after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
   after_update_commit :sync_workspace_membership_active, if: -> { Sabha.saas? && saved_change_to_status? }
-  after_update_commit :broadcast_activity_indicator, if: :saved_change_to_activity_seen_at?
 
   before_validation :set_default_name
   before_validation :normalize_social_urls
@@ -305,15 +201,6 @@ class User < ApplicationRecord
            .count
   end
 
-  def broadcast_activity_indicator
-    Turbo::StreamsChannel.broadcast_replace_to(
-      self, :sidebar_activity_indicator,
-      target: "sidebar_activity_indicator",
-      partial: "users/sidebars/activity_indicator",
-      locals: { user: self }
-    )
-  end
-
   private
     # Mirror User#active? onto the untenanted WorkspaceMembership row so the
     # workspace selector can filter without cross-tenant queries. Runs post-
@@ -412,10 +299,6 @@ class User < ApplicationRecord
       User::NotificationSettings.where(user_id: id).delete_all
     end
 
-    def ensure_notification_settings
-      create_notification_settings! unless notification_settings
-    end
-
     def set_default_name
       self.name = name.presence || DEFAULT_NAME
     end
@@ -443,43 +326,5 @@ class User < ApplicationRecord
 
       handle = url.strip
       "https://www.linkedin.com/in/#{handle}"
-    end
-
-    # Marks rooms as read where all unread messages have corresponding notifications.
-    # For non-DM rooms, only marks as read if there are no non-notified messages in the window.
-    def mark_notified_rooms_as_read(until_time, include_dms: false)
-      notified_room_ids = notifications
-        .where("notifications.created_at <= ?", until_time)
-        .joins(:message).distinct.pluck(Arel.sql("messages.room_id"))
-
-      memberships.unread.includes(:room).where(room_id: notified_room_ids).each do |m|
-        if m.room.is_a?(Rooms::Direct)
-          m.read_until(until_time) if include_dms
-          next
-        end
-
-        notified_message_ids = Notification.where(user: self)
-          .where(message_id: m.room.messages.without_events.between(m.unread_at, until_time).select(:id))
-          .pluck(:message_id)
-
-        non_notified = m.room.messages.without_events
-          .where.not(id: notified_message_ids)
-          .between(m.unread_at, until_time)
-
-        if non_notified.none?
-          m.read_until(until_time)
-        else
-          m.clear_unread_notifications_until(until_time)
-        end
-      end
-    end
-
-    # Returns Time.current if the timestamp is missing or stale (> 1 hour old).
-    # Stale timestamps indicate the user left the inbox page open without interacting.
-    def freshness_checked_time(iso8601_time)
-      return Time.current unless iso8601_time.present?
-
-      time = Time.iso8601(iso8601_time)
-      time > 1.hour.ago ? time : Time.current
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,19 +2,9 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, EmailChangeable, Mentionable, Notifiable, PasswordAuthable, Role, Streakable, Transferable, Verifiable
+  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, EmailChangeable, Mentionable, Notifiable, PasswordAuthable, Role, SaasBridged, Streakable, Transferable, Verifiable
 
   serialize :preferences, coder: JSON
-
-  # SaaS mode: Link to GlobalIdentity via WorkspaceMembership
-  # In single-tenant mode, workspace_membership_id is nil
-  belongs_to :workspace_membership, optional: true, class_name: "WorkspaceMembership"
-
-  # Access GlobalIdentity through WorkspaceMembership (SaaS mode)
-  def global_identity
-    return nil unless Sabha.saas?
-    workspace_membership&.global_identity
-  end
 
   def self.sign_in_with_sso!(payload)
     record = SingleSignOnRecord.find_or_provision!(payload)
@@ -77,9 +67,6 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(email_address) { email_address.strip.downcase }
 
   scope :without_default_names, -> { where.not(name: DEFAULT_NAME) }
-
-  after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
-  after_update_commit :sync_workspace_membership_active, if: -> { Sabha.saas? && saved_change_to_status? }
 
   before_validation :set_default_name
   before_validation :normalize_social_urls
@@ -202,18 +189,6 @@ class User < ApplicationRecord
   end
 
   private
-    # Mirror User#active? onto the untenanted WorkspaceMembership row so the
-    # workspace selector can filter without cross-tenant queries. Runs post-
-    # commit, so a Postgres failure here cannot roll back the SQLite write.
-    # The auth-time guard reads the tenanted User row, so a stale mirror can
-    # only hide a workspace the user should still see — repaired by the
-    # workspace_membership:backfill_user_active rake task.
-    def sync_workspace_membership_active
-      workspace_membership&.update_column(:user_active, active?)
-    rescue ActiveRecord::ActiveRecordError => e
-      Rails.logger.error("Failed to mirror user_active for workspace_membership=#{workspace_membership_id}: #{e.message}")
-    end
-
     def deactivate_direct_rooms
       Membership.where(user_id: id).direct_rooms.each do |membership|
         membership.room.deactivate
@@ -226,12 +201,6 @@ class User < ApplicationRecord
       end
     end
 
-    def sync_name_to_global_identity
-      global_identity&.update!(name: name)
-    rescue => error
-      Rails.logger.error "[GlobalIdentity sync] Failed to sync name for User##{id}: #{error.message}"
-    end
-
     def grant_membership_to_open_rooms
       forced_room_ids = Rooms::Open.active.where(auto_join: true).pluck(:id)
       return if forced_room_ids.empty?
@@ -239,17 +208,6 @@ class User < ApplicationRecord
       Membership.insert_all(forced_room_ids.collect { |room_id| { room_id: room_id, user_id: id } })
       Rooms::Thread.joins(:parent_room).where(parent_room: { type: "Rooms::Open", auto_join: true }).find_each do |thread|
         thread.memberships.grant_to(self)
-      end
-    end
-
-    def close_remote_connections(reconnect: false)
-      if Sabha.saas? && ApplicationRecord.current_tenant.present?
-        ActionCable.server.remote_connections.where(
-          current_tenant: ApplicationRecord.current_tenant,
-          current_user: self
-        ).disconnect reconnect: reconnect
-      else
-        ActionCable.server.remote_connections.where(current_user: self).disconnect reconnect: reconnect
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, Mentionable, PasswordAuthable, Role, Streakable, Transferable, Verifiable
+  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, EmailChangeable, Mentionable, PasswordAuthable, Role, Streakable, Transferable, Verifiable
 
   serialize :preferences, coder: JSON
 
@@ -167,9 +167,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { minimum: 2, maximum: 100 }
   validates :email_address, presence: true, if: :person?
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email_address.present? }
-  validates :unconfirmed_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   normalizes :email_address, with: ->(email_address) { email_address.strip.downcase }
-  normalizes :unconfirmed_email, with: ->(email) { email&.strip&.downcase }
 
   scope :without_default_names, -> { where.not(name: DEFAULT_NAME) }
 
@@ -183,9 +181,6 @@ class User < ApplicationRecord
       .merge(User::NotificationSettings.due_for_weekly_digest)
   }
 
-  generates_token_for :email_change, expires_in: 24.hours
-
-  after_update :send_email_change_notification, if: :saved_change_to_email_address?
   after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
   after_update_commit :sync_workspace_membership_active, if: -> { Sabha.saas? && saved_change_to_status? }
   after_update_commit :broadcast_activity_indicator, if: :saved_change_to_activity_seen_at?
@@ -310,39 +305,6 @@ class User < ApplicationRecord
            .count
   end
 
-  # Email change flow
-  def update_email(new_email)
-    return true if new_email.blank? || new_email.downcase == email_address
-
-    if update(unconfirmed_email: new_email)
-      send_email_reconfirmation
-      true
-    else
-      false
-    end
-  end
-
-  def send_email_reconfirmation
-    return if bot?
-    UserMailer.email_reconfirmation(self).deliver_later
-  end
-
-  def confirm_email_change!
-    return unless unconfirmed_email.present?
-
-    update!(email_address: unconfirmed_email, unconfirmed_email: nil)
-  end
-
-  def cancel_email_change!
-    return unless unconfirmed_email.present?
-
-    update!(unconfirmed_email: nil)
-  end
-
-  def pending_email_change?
-    unconfirmed_email.present?
-  end
-
   def broadcast_activity_indicator
     Turbo::StreamsChannel.broadcast_replace_to(
       self, :sidebar_activity_indicator,
@@ -375,12 +337,6 @@ class User < ApplicationRecord
       Membership.unscoped.where(user_id: id, active: false).direct_rooms.each do |membership|
         membership.room.reactivate
       end
-    end
-
-    def send_email_change_notification
-      return if bot?
-      old_email = email_address_before_last_save
-      UserMailer.email_changed(self, old_email).deliver_later if old_email.present?
     end
 
     def sync_name_to_global_identity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Bot, DicebearAvatar, Mentionable, Role, Transferable
+  include Avatar, Bannable, Bot, DicebearAvatar, Mentionable, Role, Streakable, Transferable
 
   serialize :preferences, coder: JSON
 
@@ -324,36 +324,6 @@ class User < ApplicationRecord
            .where(creator_id: id)
            .where("rooms.type != ?", "Rooms::Direct")
            .count
-  end
-
-  def current_streak
-    if streak_updated_on.nil?
-      super # Pre-existing rows: preserve until next recalculation
-    elsif streak_updated_on < Date.yesterday
-      0
-    else
-      super
-    end
-  end
-
-  def recalculate_streak!(excluding_message: nil)
-    # Skip if user already posted today (excluding the message that triggered this callback)
-    return if posted_on?(Date.current, excluding: excluding_message)
-
-    new_streak = posted_on?(Date.yesterday) ? current_streak + 1 : 1
-    update_columns(current_streak: new_streak, streak_updated_on: Date.current)
-  end
-
-  def posted_on?(date, excluding: nil)
-    scope = messages.joins(:room)
-                    .joins("LEFT JOIN messages AS parent_messages ON rooms.parent_message_id = parent_messages.id")
-                    .joins("LEFT JOIN rooms AS parent_rooms ON parent_messages.room_id = parent_rooms.id")
-                    .where.not(rooms: { type: "Rooms::Direct" })
-                    .where("parent_rooms.type IS NULL OR parent_rooms.type != ?", "Rooms::Direct")
-                    .where("DATE(messages.created_at) = ?", date)
-                    .user_authored
-    scope = scope.where.not(id: excluding.id) if excluding
-    scope.exists?
   end
 
   def blocked_in?(room)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Bot, DicebearAvatar, Mentionable, Role, Streakable, Transferable
+  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, Mentionable, Role, Streakable, Transferable
 
   serialize :preferences, coder: JSON
 
@@ -164,12 +164,6 @@ class User < ApplicationRecord
 
   belongs_to :badge, optional: true
 
-  has_many :blocks_given, class_name: "Block", foreign_key: :blocker_id, dependent: :destroy
-  has_many :blocked_users, through: :blocks_given, source: :blocked
-
-  has_many :blocks_received, class_name: "Block", foreign_key: :blocked_id, dependent: :destroy
-  has_many :blocked_by_users, through: :blocks_received, source: :blocker
-
   validates :name, presence: true, length: { minimum: 2, maximum: 100 }
   validates :email_address, presence: true, if: :person?
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email_address.present? }
@@ -326,40 +320,6 @@ class User < ApplicationRecord
            .count
   end
 
-  def blocked_in?(room)
-    return false unless room.one_on_one?
-
-    !can_ping?(room.roommate_to(self))
-  end
-
-  def can_ping?(other_user)
-    !blocked?(other_user) && !blocked_by?(other_user)
-  end
-
-  def can_direct_message?(other_user)
-    other_user&.active? &&
-      can_ping?(other_user) &&
-      can_create_direct_messages?
-  end
-
-  def blocked?(other_user)
-    blocked_users.exists?(other_user&.id)
-  end
-
-  def blocked_by?(other_user)
-    blocked_by_users.exists?(other_user&.id)
-  end
-
-  def block!(other_user)
-    block = blocks_given.find_or_create_by!(blocked: other_user)
-    dm_room_with(other_user)&.post_system_message(event: "user_blocked", body: "blocked #{other_user.name}", actor: self) if block.previously_new_record?
-  end
-
-  def unblock!(other_user)
-    count = blocks_given.where(blocked: other_user).delete_all
-    dm_room_with(other_user)&.post_system_message(event: "user_unblocked", body: "unblocked #{other_user.name}", actor: self) if count > 0
-  end
-
   def verified?
     verified_at.present?
   end
@@ -471,10 +431,6 @@ class User < ApplicationRecord
       return unless room = Room.original
 
       room.post_welcome_message(user: self)
-    end
-
-    def dm_room_with(other_user)
-      Rooms::Direct.find_by(members_hash: Rooms::Direct.members_hash_for(User.where(id: [ id, other_user.id ])))
     end
 
     def close_remote_connections(reconnect: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, Mentionable, Role, Streakable, Transferable
+  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, Mentionable, PasswordAuthable, Role, Streakable, Transferable
 
   serialize :preferences, coder: JSON
 
@@ -185,14 +185,8 @@ class User < ApplicationRecord
       .merge(User::NotificationSettings.due_for_weekly_digest)
   }
 
-  has_secure_password validations: false
-  validates :password, length: { minimum: MINIMUM_PASSWORD_LENGTH }, if: -> { password.present? }
-
   generates_token_for :email_verification, expires_in: 24.hours
   generates_token_for :email_change, expires_in: 24.hours
-  generates_token_for :password_reset, expires_in: 1.hour do
-    password_salt&.last(10)
-  end
 
   after_update :send_email_change_notification, if: :saved_change_to_email_address?
   after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
@@ -331,10 +325,6 @@ class User < ApplicationRecord
 
   def send_verification_email
     UserMailer.email_verification(self).deliver_later
-  end
-
-  def send_password_reset_email
-    UserMailer.password_reset(self).deliver_later
   end
 
   # Email change flow

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   DEFAULT_NAME = "New Member"
   MINIMUM_PASSWORD_LENGTH = 8
 
-  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, Mentionable, PasswordAuthable, Role, Streakable, Transferable
+  include Avatar, Bannable, Blockable, Bot, DicebearAvatar, Mentionable, PasswordAuthable, Role, Streakable, Transferable, Verifiable
 
   serialize :preferences, coder: JSON
 
@@ -172,8 +172,6 @@ class User < ApplicationRecord
   normalizes :unconfirmed_email, with: ->(email) { email&.strip&.downcase }
 
   scope :without_default_names, -> { where.not(name: DEFAULT_NAME) }
-  scope :verified, -> { where.not(verified_at: nil) }
-  scope :unverified, -> { where(verified_at: nil) }
 
   scope :weekly_digest_eligible, -> {
     verified
@@ -185,7 +183,6 @@ class User < ApplicationRecord
       .merge(User::NotificationSettings.due_for_weekly_digest)
   }
 
-  generates_token_for :email_verification, expires_in: 24.hours
   generates_token_for :email_change, expires_in: 24.hours
 
   after_update :send_email_change_notification, if: :saved_change_to_email_address?
@@ -197,7 +194,6 @@ class User < ApplicationRecord
   before_validation :normalize_social_urls
   before_save :transliterate_name, if: :name_changed?
   after_create_commit :grant_membership_to_open_rooms
-  after_create_commit :post_welcome_message
 
   scope :ordered, -> { order(arel_table[:role].desc, arel_table[:name].lower) }
   scope :recent_posters_first, ->(room_id = nil) do
@@ -314,19 +310,6 @@ class User < ApplicationRecord
            .count
   end
 
-  def verified?
-    verified_at.present?
-  end
-
-  def verify_email!
-    update!(verified_at: Time.current)
-    post_welcome_message
-  end
-
-  def send_verification_email
-    UserMailer.email_verification(self).deliver_later
-  end
-
   # Email change flow
   def update_email(new_email)
     return true if new_email.blank? || new_email.downcase == email_address
@@ -414,13 +397,6 @@ class User < ApplicationRecord
       Rooms::Thread.joins(:parent_room).where(parent_room: { type: "Rooms::Open", auto_join: true }).find_each do |thread|
         thread.memberships.grant_to(self)
       end
-    end
-
-    def post_welcome_message
-      return unless bot? || verified?
-      return unless room = Room.original
-
-      room.post_welcome_message(user: self)
     end
 
     def close_remote_connections(reconnect: false)

--- a/app/models/user/blockable.rb
+++ b/app/models/user/blockable.rb
@@ -1,0 +1,50 @@
+module User::Blockable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :blocks_given, class_name: "Block", foreign_key: :blocker_id, dependent: :destroy
+    has_many :blocked_users, through: :blocks_given, source: :blocked
+
+    has_many :blocks_received, class_name: "Block", foreign_key: :blocked_id, dependent: :destroy
+    has_many :blocked_by_users, through: :blocks_received, source: :blocker
+  end
+
+  def blocked_in?(room)
+    return false unless room.one_on_one?
+
+    !can_ping?(room.roommate_to(self))
+  end
+
+  def can_ping?(other_user)
+    !blocked?(other_user) && !blocked_by?(other_user)
+  end
+
+  def can_direct_message?(other_user)
+    other_user&.active? &&
+      can_ping?(other_user) &&
+      can_create_direct_messages?
+  end
+
+  def blocked?(other_user)
+    blocked_users.exists?(other_user&.id)
+  end
+
+  def blocked_by?(other_user)
+    blocked_by_users.exists?(other_user&.id)
+  end
+
+  def block!(other_user)
+    block = blocks_given.find_or_create_by!(blocked: other_user)
+    dm_room_with(other_user)&.post_system_message(event: "user_blocked", body: "blocked #{other_user.name}", actor: self) if block.previously_new_record?
+  end
+
+  def unblock!(other_user)
+    count = blocks_given.where(blocked: other_user).delete_all
+    dm_room_with(other_user)&.post_system_message(event: "user_unblocked", body: "unblocked #{other_user.name}", actor: self) if count > 0
+  end
+
+  private
+    def dm_room_with(other_user)
+      Rooms::Direct.find_by(members_hash: Rooms::Direct.members_hash_for(User.where(id: [ id, other_user.id ])))
+    end
+end

--- a/app/models/user/email_changeable.rb
+++ b/app/models/user/email_changeable.rb
@@ -1,0 +1,51 @@
+module User::EmailChangeable
+  extend ActiveSupport::Concern
+
+  included do
+    validates :unconfirmed_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+    normalizes :unconfirmed_email, with: ->(email) { email&.strip&.downcase }
+
+    generates_token_for :email_change, expires_in: 24.hours
+
+    after_update :send_email_change_notification, if: :saved_change_to_email_address?
+  end
+
+  def update_email(new_email)
+    return true if new_email.blank? || new_email.downcase == email_address
+
+    if update(unconfirmed_email: new_email)
+      send_email_reconfirmation
+      true
+    else
+      false
+    end
+  end
+
+  def send_email_reconfirmation
+    return if bot?
+    UserMailer.email_reconfirmation(self).deliver_later
+  end
+
+  def confirm_email_change!
+    return unless unconfirmed_email.present?
+
+    update!(email_address: unconfirmed_email, unconfirmed_email: nil)
+  end
+
+  def cancel_email_change!
+    return unless unconfirmed_email.present?
+
+    update!(unconfirmed_email: nil)
+  end
+
+  def pending_email_change?
+    unconfirmed_email.present?
+  end
+
+  private
+    def send_email_change_notification
+      return if bot?
+      old_email = email_address_before_last_save
+      UserMailer.email_changed(self, old_email).deliver_later if old_email.present?
+    end
+end

--- a/app/models/user/notifiable.rb
+++ b/app/models/user/notifiable.rb
@@ -1,0 +1,157 @@
+module User::Notifiable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :notifications
+    has_many :notification_bundles, class_name: "Notification::Bundle", dependent: :destroy
+    has_one :notification_settings, class_name: "User::NotificationSettings", dependent: :destroy
+
+    scope :weekly_digest_eligible, -> {
+      verified
+        .where(status: statuses[:active])
+        .where.not(role: roles[:bot])
+        .joins(:notification_settings)
+        .includes(:notification_settings)
+        .where(user_notification_settings: { weekly_digest_subscribed: true })
+        .merge(User::NotificationSettings.due_for_weekly_digest)
+    }
+
+    after_create_commit :ensure_notification_settings
+    after_update_commit :broadcast_activity_indicator, if: :saved_change_to_activity_seen_at?
+  end
+
+  # Returns the user's open accumulator for missed-notification email candidates,
+  # opening one if none is active. Race-safe via the partial unique index — a
+  # concurrent open by a parallel writer raises RecordNotUnique on the loser
+  # and falls through to a second read.
+  def active_notification_bundle
+    notification_bundles.active.first || open_notification_bundle!
+  end
+
+  # Public so batch dispatch can open bundles for users not in a pre-fetched
+  # active set without re-running `active.first` for each miss.
+  def open_notification_bundle!
+    frequency = notification_settings&.email_frequency || "hourly"
+    starts_at = Time.current
+    notification_bundles.create!(
+      frequency: frequency,
+      starts_at: starts_at,
+      ends_at:   starts_at + Notification::Bundle::FREQUENCY_WINDOWS.fetch(frequency)
+    )
+  rescue ActiveRecord::RecordNotUnique
+    notification_bundles.active.first!
+  end
+
+  def unsubscribe_from_email!(surface)
+    (notification_settings || create_notification_settings!).unsubscribe_from!(surface)
+  end
+
+  # Builds this user's weekly digest content and mails it if non-empty.
+  # `last_digest_sent_at` only advances on actual delivery so quiet weeks
+  # don't dedup-lock subsequent runs.
+  def deliver_weekly_digest_now
+    content = Notification::Digest::Content.new(self)
+    return if content.empty?
+
+    WeeklyDigestMailer.digest(self, content).deliver_now
+    notification_settings.update!(last_digest_sent_at: Time.current)
+  end
+
+  # Persists the watermark used by unseen_activity? to gate the sidebar dot.
+  # Monotonic: only advances forward so stale `loaded_at` values from background
+  # tabs can't reopen the dot. Broadcast is fired by after_update_commit below.
+  def touch_activity_seen_at(time = Time.current)
+    return if time.nil?
+    return if activity_seen_at.present? && activity_seen_at >= time
+
+    update!(activity_seen_at: time)
+  end
+
+  # True when at least one notification row has arrived since the user last
+  # opened the Activity tab. Drives the sidebar Activity dot.
+  def unseen_activity?
+    scope = notifications
+    scope = scope.where("notifications.created_at > ?", activity_seen_at) if activity_seen_at
+    scope.exists?
+  end
+
+  # Marks all direct message rooms as read up to the loaded timestamp.
+  def mark_direct_messages_as_read(loaded_at)
+    dms_until = freshness_checked_time(loaded_at)
+
+    memberships.unread.direct_rooms.each do |m|
+      m.read_until(dms_until)
+    end
+  end
+
+  # Marks inbox as read up to the timestamps when messages were last loaded.
+  # Uses stale detection: if timestamp is > 1 hour old, uses current time instead
+  # (user likely left the page open without interacting).
+  #
+  # For activity: DMs are always marked as read. For other rooms, only marks as read
+  # if the room had no non-notified messages in the window (avoids accidentally marking
+  # unread messages as read when user only viewed activity)
+  def mark_inbox_as_read(messages_loaded_at:, notifications_loaded_at:, activity_loaded_at:)
+    messages_until = freshness_checked_time(messages_loaded_at)
+    notifications_until = freshness_checked_time(notifications_loaded_at)
+    activity_until = freshness_checked_time(activity_loaded_at)
+
+    memberships.unread.each { |m| m.read_until(messages_until) }
+    memberships.notifications_on.unread.each { |m| m.read_until(notifications_until) }
+    mark_notified_rooms_as_read(activity_until, include_dms: true)
+
+    touch_activity_seen_at(activity_until)
+  end
+
+  def broadcast_activity_indicator
+    Turbo::StreamsChannel.broadcast_replace_to(
+      self, :sidebar_activity_indicator,
+      target: "sidebar_activity_indicator",
+      partial: "users/sidebars/activity_indicator",
+      locals: { user: self }
+    )
+  end
+
+  private
+    def ensure_notification_settings
+      create_notification_settings! unless notification_settings
+    end
+
+    # Marks rooms as read where all unread messages have corresponding notifications.
+    # For non-DM rooms, only marks as read if there are no non-notified messages in the window.
+    def mark_notified_rooms_as_read(until_time, include_dms: false)
+      notified_room_ids = notifications
+        .where("notifications.created_at <= ?", until_time)
+        .joins(:message).distinct.pluck(Arel.sql("messages.room_id"))
+
+      memberships.unread.includes(:room).where(room_id: notified_room_ids).each do |m|
+        if m.room.is_a?(Rooms::Direct)
+          m.read_until(until_time) if include_dms
+          next
+        end
+
+        notified_message_ids = Notification.where(user: self)
+          .where(message_id: m.room.messages.without_events.between(m.unread_at, until_time).select(:id))
+          .pluck(:message_id)
+
+        non_notified = m.room.messages.without_events
+          .where.not(id: notified_message_ids)
+          .between(m.unread_at, until_time)
+
+        if non_notified.none?
+          m.read_until(until_time)
+        else
+          m.clear_unread_notifications_until(until_time)
+        end
+      end
+    end
+
+    # Returns Time.current if the timestamp is missing or stale (> 1 hour old).
+    # Stale timestamps indicate the user left the inbox page open without interacting.
+    def freshness_checked_time(iso8601_time)
+      return Time.current unless iso8601_time.present?
+
+      time = Time.iso8601(iso8601_time)
+      time > 1.hour.ago ? time : Time.current
+    end
+end

--- a/app/models/user/password_authable.rb
+++ b/app/models/user/password_authable.rb
@@ -1,0 +1,16 @@
+module User::PasswordAuthable
+  extend ActiveSupport::Concern
+
+  included do
+    has_secure_password validations: false
+    validates :password, length: { minimum: User::MINIMUM_PASSWORD_LENGTH }, if: -> { password.present? }
+
+    generates_token_for :password_reset, expires_in: 1.hour do
+      password_salt&.last(10)
+    end
+  end
+
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_later
+  end
+end

--- a/app/models/user/saas_bridged.rb
+++ b/app/models/user/saas_bridged.rb
@@ -1,0 +1,45 @@
+module User::SaasBridged
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :workspace_membership, optional: true, class_name: "WorkspaceMembership"
+
+    after_update :sync_name_to_global_identity, if: -> { Sabha.saas? && saved_change_to_name? }
+    after_update_commit :sync_workspace_membership_active, if: -> { Sabha.saas? && saved_change_to_status? }
+  end
+
+  def global_identity
+    return nil unless Sabha.saas?
+    workspace_membership&.global_identity
+  end
+
+  private
+    # Mirror User#active? onto the untenanted WorkspaceMembership row so the
+    # workspace selector can filter without cross-tenant queries. Runs post-
+    # commit, so a Postgres failure here cannot roll back the SQLite write.
+    # The auth-time guard reads the tenanted User row, so a stale mirror can
+    # only hide a workspace the user should still see — repaired by the
+    # workspace_membership:backfill_user_active rake task.
+    def sync_workspace_membership_active
+      workspace_membership&.update_column(:user_active, active?)
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.error("Failed to mirror user_active for workspace_membership=#{workspace_membership_id}: #{e.message}")
+    end
+
+    def sync_name_to_global_identity
+      global_identity&.update!(name: name)
+    rescue => error
+      Rails.logger.error "[GlobalIdentity sync] Failed to sync name for User##{id}: #{error.message}"
+    end
+
+    def close_remote_connections(reconnect: false)
+      if Sabha.saas? && ApplicationRecord.current_tenant.present?
+        ActionCable.server.remote_connections.where(
+          current_tenant: ApplicationRecord.current_tenant,
+          current_user: self
+        ).disconnect reconnect: reconnect
+      else
+        ActionCable.server.remote_connections.where(current_user: self).disconnect reconnect: reconnect
+      end
+    end
+end

--- a/app/models/user/streakable.rb
+++ b/app/models/user/streakable.rb
@@ -1,0 +1,32 @@
+module User::Streakable
+  extend ActiveSupport::Concern
+
+  def current_streak
+    if streak_updated_on.nil?
+      super
+    elsif streak_updated_on < Date.yesterday
+      0
+    else
+      super
+    end
+  end
+
+  def recalculate_streak!(excluding_message: nil)
+    return if posted_on?(Date.current, excluding: excluding_message)
+
+    new_streak = posted_on?(Date.yesterday) ? current_streak + 1 : 1
+    update_columns(current_streak: new_streak, streak_updated_on: Date.current)
+  end
+
+  def posted_on?(date, excluding: nil)
+    scope = messages.joins(:room)
+                    .joins("LEFT JOIN messages AS parent_messages ON rooms.parent_message_id = parent_messages.id")
+                    .joins("LEFT JOIN rooms AS parent_rooms ON parent_messages.room_id = parent_rooms.id")
+                    .where.not(rooms: { type: "Rooms::Direct" })
+                    .where("parent_rooms.type IS NULL OR parent_rooms.type != ?", "Rooms::Direct")
+                    .where("DATE(messages.created_at) = ?", date)
+                    .user_authored
+    scope = scope.where.not(id: excluding.id) if excluding
+    scope.exists?
+  end
+end

--- a/app/models/user/verifiable.rb
+++ b/app/models/user/verifiable.rb
@@ -1,0 +1,33 @@
+module User::Verifiable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :verified,   -> { where.not(verified_at: nil) }
+    scope :unverified, -> { where(verified_at: nil) }
+
+    generates_token_for :email_verification, expires_in: 24.hours
+
+    after_create_commit :post_welcome_message
+  end
+
+  def verified?
+    verified_at.present?
+  end
+
+  def verify_email!
+    update!(verified_at: Time.current)
+    post_welcome_message
+  end
+
+  def send_verification_email
+    UserMailer.email_verification(self).deliver_later
+  end
+
+  private
+    def post_welcome_message
+      return unless bot? || verified?
+      return unless room = Room.original
+
+      room.post_welcome_message(user: self)
+    end
+end

--- a/saas/test/models/user/saas_bridged_test.rb
+++ b/saas/test/models/user/saas_bridged_test.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative "../../test_helper"
 
-class UserSaasBridgeTest < ActiveSupport::TestCase
+class User::SaasBridgedTest < ActiveSupport::TestCase
   test "global_identity returns the workspace_membership's global identity in SaaS mode" do
     identity = GlobalIdentity.create!(name: "Bridge Reader", email_address: "bridge-reader@example.com", verified_at: Time.current)
 

--- a/saas/test/models/user_saas_bridge_test.rb
+++ b/saas/test/models/user_saas_bridge_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class UserSaasBridgeTest < ActiveSupport::TestCase
+  test "global_identity returns the workspace_membership's global identity in SaaS mode" do
+    identity = GlobalIdentity.create!(name: "Bridge Reader", email_address: "bridge-reader@example.com", verified_at: Time.current)
+
+    with_provisioned_workspace(name: "Bridge Reader WS", creator: identity) do |workspace|
+      tenant_id = workspace.external_id.to_s
+      membership = WorkspaceMembership.find_by(tenant: tenant_id)
+
+      ApplicationRecord.with_tenant(tenant_id) do
+        user = User.find(membership.user_id)
+        assert_equal membership.global_identity, user.global_identity
+      end
+    end
+  ensure
+    identity&.destroy
+  end
+
+  test "sync_name_to_global_identity mirrors User#name onto the GlobalIdentity after update" do
+    identity = GlobalIdentity.create!(name: "Original Name", email_address: "name-sync@example.com", verified_at: Time.current)
+
+    with_provisioned_workspace(name: "Name Sync WS", creator: identity) do |workspace|
+      tenant_id = workspace.external_id.to_s
+      membership = WorkspaceMembership.find_by(tenant: tenant_id)
+
+      ApplicationRecord.with_tenant(tenant_id) do
+        user = User.find(membership.user_id)
+        user.update!(name: "Renamed Person")
+      end
+
+      assert_equal "Renamed Person", identity.reload.name,
+        "User#name change must mirror to GlobalIdentity#name"
+    end
+  ensure
+    identity&.destroy
+  end
+
+  test "sync_name_to_global_identity rescues update failures so the User save still commits" do
+    identity = GlobalIdentity.create!(name: "Rescue Origin", email_address: "name-rescue@example.com", verified_at: Time.current)
+
+    with_provisioned_workspace(name: "Name Rescue WS", creator: identity) do |workspace|
+      tenant_id = workspace.external_id.to_s
+      membership = WorkspaceMembership.find_by(tenant: tenant_id)
+
+      ApplicationRecord.with_tenant(tenant_id) do
+        user = User.find(membership.user_id)
+        GlobalIdentity.any_instance.expects(:update!).raises(StandardError, "boom")
+
+        assert_nothing_raised do
+          user.update!(name: "Renamed Despite Error")
+        end
+
+        assert_equal "Renamed Despite Error", user.reload.name,
+          "the tenanted User save must not be rolled back when the GI mirror fails"
+      end
+    end
+  ensure
+    identity&.destroy
+  end
+
+  test "close_remote_connections scopes the disconnect by current_tenant in SaaS mode" do
+    identity = GlobalIdentity.create!(name: "RC", email_address: "remote-conn@example.com", verified_at: Time.current)
+
+    with_provisioned_workspace(name: "Remote Conn WS", creator: identity) do |workspace|
+      tenant_id = workspace.external_id.to_s
+      membership = WorkspaceMembership.find_by(tenant: tenant_id)
+
+      ApplicationRecord.with_tenant(tenant_id) do
+        user = User.find(membership.user_id)
+
+        connections = mock("RemoteConnections")
+        connections.expects(:disconnect).with(reconnect: false)
+        ActionCable.server.remote_connections
+          .expects(:where)
+          .with(current_tenant: tenant_id, current_user: user)
+          .returns(connections)
+
+        user.send(:close_remote_connections)
+      end
+    end
+  ensure
+    identity&.destroy
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,6 +22,18 @@ class UserTest < ActiveSupport::TestCase
     assert user.valid?
   end
 
+  test "password_reset token is invalidated when the password is changed" do
+    user = users(:david)
+    token = user.generate_token_for(:password_reset)
+
+    assert_equal user, User.find_by_token_for(:password_reset, token)
+
+    user.update!(password: "newsecret12345")
+
+    assert_nil User.find_by_token_for(:password_reset, token),
+      "password_reset token must rotate when password_salt changes"
+  end
+
   test "creating users grants membership to auto_join open rooms only" do
     auto_join_room = Rooms::Open.create!(name: "Auto Room", creator: users(:david), auto_join: true)
     non_auto_room = Rooms::Open.create!(name: "Manual Room", creator: users(:david))
@@ -239,6 +251,25 @@ class UserTest < ActiveSupport::TestCase
 
     assert_not user.valid?
     assert_includes user.errors[:unconfirmed_email], "is invalid"
+  end
+
+  test "changing a bot's email does not enqueue an email_changed notification" do
+    bot = users(:bender)
+    bot.update_columns(email_address: "bot-old@example.com")
+
+    UserMailer.expects(:email_changed).never
+
+    bot.update!(email_address: "bot-new@example.com")
+  end
+
+  test "changing a human's email enqueues an email_changed notification to the old address" do
+    user = users(:david)
+    old_email = user.email_address
+
+    mail = mock(deliver_later: true)
+    UserMailer.expects(:email_changed).with(user, old_email).returns(mail)
+
+    user.update!(email_address: "rotated@37signals.com")
   end
 
   test "transliterates name to ascii for search" do
@@ -806,5 +837,76 @@ class UserTest < ActiveSupport::TestCase
     assert_turbo_stream_broadcasts [ user, :sidebar_activity_indicator ], count: 0 do
       user.touch_activity_seen_at(1.hour.ago)
     end
+  end
+
+  test "mark_direct_messages_as_read clears unread on DM memberships up to the given time" do
+    user = users(:david)
+    dm = memberships(:david_david_and_kevin)
+    dm.update_column(:unread_at, 30.minutes.ago)
+
+    user.mark_direct_messages_as_read(Time.current.iso8601)
+
+    assert_nil dm.reload.unread_at, "DM membership must be marked read"
+  end
+
+  test "mark_direct_messages_as_read leaves non-DM memberships untouched" do
+    user = users(:david)
+    non_dm = memberships(:david_designers)
+    non_dm.update_column(:unread_at, 30.minutes.ago)
+
+    user.mark_direct_messages_as_read(Time.current.iso8601)
+
+    assert_not_nil non_dm.reload.unread_at,
+      "non-DM membership must not be touched by mark_direct_messages_as_read"
+  end
+
+  test "mark_inbox_as_read marks unread non-direct memberships read and advances activity_seen_at" do
+    user = users(:david)
+    user.update_column(:activity_seen_at, 1.day.ago)
+    non_dm = memberships(:david_designers)
+    non_dm.update_column(:unread_at, 30.minutes.ago)
+
+    now_iso = Time.current.iso8601
+    user.mark_inbox_as_read(
+      messages_loaded_at: now_iso,
+      notifications_loaded_at: now_iso,
+      activity_loaded_at: now_iso
+    )
+
+    assert_nil non_dm.reload.unread_at, "non-direct unread membership must be marked read"
+    assert user.reload.activity_seen_at > 1.minute.ago,
+      "activity_seen_at must advance to the activity_loaded_at"
+  end
+
+  test "mark_inbox_as_read falls back to Time.current when a loaded_at timestamp is stale (> 1 hour old)" do
+    user = users(:david)
+    membership = memberships(:david_designers)
+    membership.update_column(:unread_at, 5.minutes.ago)
+
+    # A 2-hour-old stamp would leave unread_at untouched (5.minutes.ago > 2.hours.ago).
+    # The freshness check rewrites it to Time.current, so the membership ends up read.
+    user.mark_inbox_as_read(
+      messages_loaded_at: 2.hours.ago.iso8601,
+      notifications_loaded_at: 2.hours.ago.iso8601,
+      activity_loaded_at: 2.hours.ago.iso8601
+    )
+
+    assert_nil membership.reload.unread_at,
+      "stale loaded_at must be clamped to Time.current so unread is marked read"
+  end
+
+  test "mark_inbox_as_read falls back to Time.current when loaded_at is blank" do
+    user = users(:david)
+    membership = memberships(:david_designers)
+    membership.update_column(:unread_at, 30.minutes.ago)
+
+    user.mark_inbox_as_read(
+      messages_loaded_at: nil,
+      notifications_loaded_at: nil,
+      activity_loaded_at: nil
+    )
+
+    assert_nil membership.reload.unread_at,
+      "blank loaded_at must be clamped to Time.current so unread is marked read"
   end
 end


### PR DESCRIPTION
## Summary

Decomposes the 637-line \`User\` model into 7 per-capability concerns plus a small persistence shell. Same pattern as #80 (\`Message\` callbacks → concerns) and #81 (\`Room\` and \`Membership\` callbacks → concerns) — extending it further to push associations, validations, and methods into concerns alongside their callbacks. Each concern is self-contained: drop it in, take it out.

\`app/models/user.rb\`: **637 → 288 lines** (-55%).

## New concerns

- **\`User::Streakable\`** — current_streak override, \`recalculate_streak!\`, \`posted_on?\`.
- **\`User::Blockable\`** — \`blocks_given\` and \`blocks_received\` associations, block/unblock API (\`block!\`, \`unblock!\`, \`blocked?\`, \`blocked_by?\`, \`blocked_in?\`, \`can_ping?\`, \`can_direct_message?\`), and the private \`dm_room_with\` helper.
- **\`User::PasswordAuthable\`** — \`has_secure_password\`, password length validation, the \`password_reset\` token, and \`send_password_reset_email\`.
- **\`User::Verifiable\`** — \`verified?\`, \`verify_email!\`, \`send_verification_email\`, the \`verified\` and \`unverified\` scopes, the \`email_verification\` token, and the \`after_create_commit\` hook that posts a welcome message.
- **\`User::EmailChangeable\`** — the full email-change flow (\`update_email\`, \`confirm_email_change!\`, \`cancel_email_change!\`, \`pending_email_change?\`), \`unconfirmed_email\` validation and normalization, the \`email_change\` token, and the \`email_changed\` mailer callback.
- **\`User::Notifiable\`** — notifications, notification_bundles, and notification_settings associations and callbacks; bundle and weekly-digest methods; the inbox-read flow (\`mark_inbox_as_read\`, \`mark_direct_messages_as_read\`); the activity-dot watermark (\`touch_activity_seen_at\`, \`unseen_activity?\`); and \`broadcast_activity_indicator\`.
- **\`User::SaasBridged\`** — the \`workspace_membership\` belongs_to, the \`global_identity\` reader, the two SaaS sync callbacks (\`sync_workspace_membership_active\`, \`sync_name_to_global_identity\`), and \`close_remote_connections\`.

## Why this shape

- **A concern that adds behavior owns its associations, callbacks, and methods.** Previously, adding (say) a new auth flow to \`User\` meant editing 8 separate sections of one 637-line file. Now \`User::PasswordAuthable\` is the whole feature — one file, one concern, one git blame.
- **Each feature's lifecycle is colocated.** \`User::Verifiable\` shows the verification scope, token, \`after_create_commit\` hook, and welcome-message helper in 33 lines. Before, you had to scan top-to-bottom for those pieces.
- **Reading is bounded.** Working on the password reset flow means opening \`User::PasswordAuthable\` and seeing the full picture instead of mentally filtering \`user.rb\`.
- **Test surface localizes.** Existing \`user_test.rb\` still passes as-is; future work can split into per-concern test files.

## Protective tests added before refactor

Pre-audit identified gaps in coverage; closed first so each extraction had a regression net:

- **PasswordAuthable:** \`password_reset\` token rotates on password change (the \`password_salt&.last(10)\` rotation key — security teeth, previously only covered at controller level).
- **EmailChangeable:** bots skip the \`email_changed\` mailer (the \`return if bot?\` guard); humans trigger it with the old address.
- **Notifiable:** \`mark_direct_messages_as_read\` reads DMs only; \`mark_inbox_as_read\` clears unread and advances \`activity_seen_at\`; stale-timestamp clamp (more than an hour old falls back to \`Time.current\`); blank-timestamp clamp.
- **SaasBridged** (new file \`saas/test/models/user_saas_bridge_test.rb\`): \`global_identity\` reader returns the workspace_membership's identity; \`sync_name_to_global_identity\` happy path plus rescue (User save survives a GI mirror failure); \`close_remote_connections\` scopes the disconnect by \`current_tenant\` in SaaS mode.

## Callback ordering — one shift, verified safe

\`after_create_commit\` order changed:

- **Before:** ensure_notification_settings, grant_membership_to_open_rooms, post_welcome_message.
- **After:** ensure_notification_settings, post_welcome_message, grant_membership_to_open_rooms.

Verified safe because:

- \`post_welcome_message\` creates a Message with the new user as creator. It doesn't read memberships.
- \`Message::Unreadable#deliver_to_room\` → \`Room#unread_memberships\` excludes the creator from unread fan-out (\`where.not(user: message.creator)\`).
- \`Message::Unreadable#increment_unread_notifications_counters\` short-circuits on welcome messages (no mentionees, no @everyone).
- \`Message::Streakable\` explicitly skips welcome messages (\`return if … welcome?\`).
- \`Message::Threadable\` only runs for threaded messages; welcome messages have no parent.

So \`post_welcome_message\` and \`grant_membership_to_open_rooms\` are functionally independent — the order swap is benign. The bot-creation test (\`user_test.rb:52\`) exercises this exact callback chain and passes.

## Multi-tenant considerations

- \`User::SaasBridged\` is included unconditionally; SaaS logic is guarded by internal \`Sabha.saas?\` checks. Self-hosted: callbacks no-op, \`global_identity\` returns nil, and \`belongs_to :workspace_membership\` resolves nothing because the column is unset.
- \`belongs_to :workspace_membership, class_name: \"WorkspaceMembership\"\` uses a string class name, resolved lazily — safe in self-hosted where \`WorkspaceMembership\` (in \`saas/app/models\`) doesn't autoload.
- The new SaaS test pins the contract that \`close_remote_connections\` passes \`current_tenant\` to the Action Cable \`remote_connections.where\` filter — protecting against a future change that drops it and silently bridges disconnects across tenants.
- \`broadcast_activity_indicator\` keeps passing \`self\` (a tenanted User) to \`Turbo::StreamsChannel.broadcast_replace_to\`, so the stream's GlobalID stays tenant-scoped.

## Test plan

- [x] \`bin/rails test\` (1523 runs / 5107 assertions / 0 failures)
- [x] \`SAAS=true bin/rails test saas/test/\` (309 runs / 860 assertions / 0 failures)
- [ ] Manual: create a new user — confirm welcome message and auto-join still fire.
- [ ] Manual: change a user's password — confirm outstanding \`password_reset\` tokens invalidate.
- [ ] Manual: change a user's email — confirm the email_changed notification goes to the old address.
- [ ] Manual (SaaS): rename a user — confirm GlobalIdentity name mirrors across.