### PR TITLE
Drop orphan accepted_terms_at column from users schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -337,7 +337,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_061320) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "accepted_terms_at"
     t.datetime "activity_seen_at"
     t.string "ascii_name"
     t.integer "avatar_seed"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -1288,16 +1288,6 @@ columns:
   users:
   - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
-    name: accepted_terms_at
-    cast_type: *1
-    sql_type_metadata: *2
-    'null': true
-    default:
-    default_function:
-    collation:
-    comment:
-  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
-    auto_increment:
     name: activity_seen_at
     cast_type: *1
     sql_type_metadata: *2


### PR DESCRIPTION
## Summary

\`db/schema.rb\` declared \`users.accepted_terms_at\` even though no migration ever creates that column on the \`users\` table. The actual SQLite \`users\` table doesn't have it (confirmed via \`PRAGMA table_info\`).

Rails trusts \`schema.rb\` / \`schema_cache.yml\` to know what columns exist, so \`User.create!\` builds an INSERT including \`accepted_terms_at\` → SQLite rejects → 500 on self-hosted signup.

## How it got there

#73 ("Light up the Activity sidebar dot…") accidentally introduced \`t.datetime \"accepted_terms_at\"\` into the \`users\` block in \`db/schema.rb\`. Probably a stray copy-paste from a schema dump taken while SaaS was active — the column legitimately exists on the SaaS-only \`global_identities\` table (\`saas/db/untenanted_schema.rb:30\`, backed by \`saas/db/untenanted_migrate/20260503000001_add_accepted_terms_at_to_global_identities.rb\`).

No application code references \`User#accepted_terms_at\` — only \`GlobalIdentity#accepted_terms_at\`. So the column was never wired into anything; it just sat in the schema declaration mismatched against the DB.

## Why it stayed latent until now

Fixtures bypass Rails attribute-aware INSERTs and write raw SQL with only the columns that exist. So the test suite never tripped on it. The first time \`User#save\` runs against the live dev DB is when somebody hits self-hosted signup (\`/join/<code>\` POST) — which is when I hit the 500.

## Fix

Two deletions, both mechanical:

1. \`db/schema.rb\`: drop \`t.datetime \"accepted_terms_at\"\` from the \`users\` table block.
2. \`db/schema_cache.yml\`: regenerated via \`bin/rails db:schema:cache:dump\` after the schema edit.

## Verification

- \`bin/rails runner 'User.new(name: \"S\", email_address: \"s@example.com\", password: \"secret123456\").save!'\` — succeeds (previously crashed with SQLite3::SQLException).
- Self-hosted test suite: 1515 runs / 5096 assertions / 0 failures / 2 skips.
- Audit script comparing every column in \`schema.rb\` against the actual SQLite DB confirms **no other orphan columns** exist after this fix.

## Test plan

- [x] \`bin/rails test\` passes
- [ ] Manual: hit \`/join/<code>\` POST in self-hosted dev — signup completes, user lands logged in