### PR TITLE
Sync notification_bundle FK annotations with their on_delete: :cascade

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -400,10 +400,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_061320) do
   add_foreign_key "boosts", "messages"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users", column: "creator_id"
-  add_foreign_key "notification_bundle_items", "messages"
-  add_foreign_key "notification_bundle_items", "notification_bundles", column: "bundle_id"
-  add_foreign_key "notification_bundle_items", "users", column: "actor_id"
-  add_foreign_key "notification_bundles", "users"
+  add_foreign_key "notification_bundle_items", "messages", on_delete: :cascade
+  add_foreign_key "notification_bundle_items", "notification_bundles", column: "bundle_id", on_delete: :cascade
+  add_foreign_key "notification_bundle_items", "users", column: "actor_id", on_delete: :cascade
+  add_foreign_key "notification_bundles", "users", on_delete: :cascade
   add_foreign_key "notifications", "boosts"
   add_foreign_key "notifications", "messages"
   add_foreign_key "notifications", "users"


### PR DESCRIPTION
## Summary

The actual SQLite \`notification_bundles\` and \`notification_bundle_items\` tables ship cascade-delete foreign keys (defined in the original migrations \`20260509190100_create_notification_bundles.rb\` and \`20260509190101_create_notification_bundle_items.rb\`). But \`db/schema.rb\` declared those same FKs without the \`on_delete: :cascade\` option — schema drift in the silent direction.

## Why it matters

The DB is correct, so existing setups (dev, prod) keep cascading deletes. But anyone running \`db:schema:load\` from scratch — a fresh dev install, a CI sandbox, or a prod rebuild — gets FKs **without** cascade. Then destroying a \`Notification::Bundle\` raises \`SQLite3::ConstraintException: FOREIGN KEY constraint failed\` because the bundle's items still reference it.

\`User#destroy_all_associated_records\` (app/models/user.rb) explicitly tears bundle items down before the bundles to dodge this exact problem on existing setups, but it shouldn't have to — the FK is supposed to cascade.

## Fix

Regenerated \`db/schema.rb\` via \`bin/rails db:schema:dump\`. The four affected FKs now match the DB:

\`\`\`
- add_foreign_key "notification_bundle_items", "messages"
- add_foreign_key "notification_bundle_items", "notification_bundles", column: "bundle_id"
- add_foreign_key "notification_bundle_items", "users", column: "actor_id"
- add_foreign_key "notification_bundles", "users"
+ add_foreign_key "notification_bundle_items", "messages", on_delete: :cascade
+ add_foreign_key "notification_bundle_items", "notification_bundles", column: "bundle_id", on_delete: :cascade
+ add_foreign_key "notification_bundle_items", "users", column: "actor_id", on_delete: :cascade
+ add_foreign_key "notification_bundles", "users", on_delete: :cascade
\`\`\`

No code changes, no migration — just bringing the schema file in line with reality.

## Test plan

- [x] \`bin/rails test\` (passes; no behavioral change)
- [x] \`db:schema:cache:dump\` produces no diff (schema_cache.yml only tracks columns/indexes, not FK options)