### PR TITLE
Default workspace invite links to 30 days and show usage to admins

### DIFF
--- a/app/models/account/join_code.rb
+++ b/app/models/account/join_code.rb
@@ -66,6 +66,15 @@ class Account::JoinCode < ApplicationRecord
     unlimited? ? count_phrase : "#{count_phrase} of #{usage_limit}"
   end
 
+  def expiry_display
+    return nil unless expires_at
+
+    days = ((expires_at - Time.current) / 1.day).ceil
+    return nil if days <= 0
+
+    "Expires in #{days} #{"day".pluralize(days)}"
+  end
+
   private
     def generate_code
       self.code = generate_new_code

--- a/app/models/account/join_code.rb
+++ b/app/models/account/join_code.rb
@@ -15,7 +15,7 @@ class Account::JoinCode < ApplicationRecord
   scope :personal, -> { where.not(user_id: nil) }
 
   before_validation :generate_code, on: :create, if: -> { code.blank? }
-  before_validation :set_default_expiration, on: :create
+  before_validation :set_default_expiration, on: :create, unless: :bot?
   before_validation :set_default_account, on: :create, if: -> { account_id.blank? }
   before_validation :set_bot_defaults, on: :create, if: :bot?
 

--- a/app/models/account/join_code.rb
+++ b/app/models/account/join_code.rb
@@ -1,6 +1,7 @@
 class Account::JoinCode < ApplicationRecord
   CODE_LENGTH = 12
   DEFAULT_EXPIRATION = 7.days
+  DEFAULT_GLOBAL_EXPIRATION = 30.days
 
   enum :kind, human: "human", bot: "bot"
 
@@ -14,7 +15,7 @@ class Account::JoinCode < ApplicationRecord
   scope :personal, -> { where.not(user_id: nil) }
 
   before_validation :generate_code, on: :create, if: -> { code.blank? }
-  before_validation :set_default_expiration, on: :create, if: :personal?
+  before_validation :set_default_expiration, on: :create
   before_validation :set_default_account, on: :create, if: -> { account_id.blank? }
   before_validation :set_bot_defaults, on: :create, if: :bot?
 
@@ -51,7 +52,7 @@ class Account::JoinCode < ApplicationRecord
   end
 
   def regenerate_code
-    update!(code: generate_new_code, usage_count: 0)
+    update!(code: generate_new_code, usage_count: 0, expires_at: default_lifetime.from_now)
   end
 
   def unlimited?
@@ -59,7 +60,10 @@ class Account::JoinCode < ApplicationRecord
   end
 
   def usage_display
-    unlimited? ? "#{usage_count} uses" : "#{usage_count}/#{usage_limit} uses"
+    return "Never used" if usage_count.zero?
+
+    count_phrase = "#{usage_count} #{"use".pluralize(usage_count)}"
+    unlimited? ? count_phrase : "#{count_phrase} of #{usage_limit}"
   end
 
   private
@@ -75,7 +79,11 @@ class Account::JoinCode < ApplicationRecord
     end
 
     def set_default_expiration
-      self.expires_at ||= DEFAULT_EXPIRATION.from_now
+      self.expires_at ||= default_lifetime.from_now
+    end
+
+    def default_lifetime
+      global? ? DEFAULT_GLOBAL_EXPIRATION : DEFAULT_EXPIRATION
     end
 
     def set_default_account

--- a/app/models/account/joinable.rb
+++ b/app/models/account/joinable.rb
@@ -8,7 +8,9 @@ module Account::Joinable
   end
 
   def join_code
-    join_codes.global.first
+    join_codes.global.first.tap do |code|
+      code.regenerate_code if code&.expired?
+    end
   end
 
   def reset_join_code

--- a/app/views/accounts/_invite.html.erb
+++ b/app/views/accounts/_invite.html.erb
@@ -38,8 +38,8 @@
   <% if show_regenerate && Current.user.can_administer? %>
     <div class="txt-small txt-de-emph txt-align-center">
       <%= join_code.usage_display %>
-      <% if join_code.expires_at %>
-        · Expires in <%= distance_of_time_in_words_to_now(join_code.expires_at) %>
+      <% if join_code.expiry_display %>
+        · <%= join_code.expiry_display %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/accounts/_invite.html.erb
+++ b/app/views/accounts/_invite.html.erb
@@ -1,6 +1,7 @@
 <%# locals: (show_regenerate: true) %>
 <div class="flex flex-column align-center gap">
-  <% url = join_url(Current.account.join_code.code) %>
+  <% join_code = Current.account.join_code %>
+  <% url = join_url(join_code.code) %>
 
   <label class="flex flex-column gap full-width" style="--row-gap: 0.5em">
     <strong id="invite_label" class="invite-label">Share to invite more people</strong>
@@ -33,4 +34,13 @@
       <% end %>
     <% end %>
   </div>
+
+  <% if show_regenerate && Current.user.can_administer? %>
+    <div class="txt-small txt-de-emph txt-align-center">
+      <%= join_code.usage_display %>
+      <% if join_code.expires_at %>
+        · Expires in <%= distance_of_time_in_words_to_now(join_code.expires_at) %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/users/profiles/_invite_link.html.erb
+++ b/app/views/users/profiles/_invite_link.html.erb
@@ -26,7 +26,7 @@
       </div>
 
       <div class="txt-small txt-de-emph txt-align-center">
-        Expires in <%= distance_of_time_in_words_to_now(invite_link.expires_at) %>
+        <%= invite_link.expiry_display %>
       </div>
     </div>
   <% else %>

--- a/test/models/account/join_code_test.rb
+++ b/test/models/account/join_code_test.rb
@@ -140,6 +140,11 @@ class Account::JoinCodeTest < ActiveSupport::TestCase
     assert join_code.expires_at <= Account::JoinCode::DEFAULT_EXPIRATION.from_now + 1.second
   end
 
+  test "bot invites do not get a default expiration (active until consumed or replaced)" do
+    join_code = Account::JoinCode.create!(account: accounts(:signal), kind: :bot)
+    assert_nil join_code.expires_at
+  end
+
   test "global invite gets the longer default expiration on create" do
     join_code = Account::JoinCode.create!(account: accounts(:signal))
     assert join_code.expires_at.present?

--- a/test/models/account/join_code_test.rb
+++ b/test/models/account/join_code_test.rb
@@ -68,13 +68,7 @@ class Account::JoinCodeTest < ActiveSupport::TestCase
     assert_equal "Never used", join_code.usage_display
   end
 
-  test "usage_display singularizes 'use' when usage_count is one" do
-    join_code = account_join_codes(:signal)
-    join_code.update!(usage_limit: nil, usage_count: 1)
-    assert_equal "1 use", join_code.usage_display
-  end
-
-  test "usage_display shows count for unlimited above one" do
+  test "usage_display shows count for unlimited" do
     join_code = account_join_codes(:signal)
     join_code.update!(usage_limit: nil, usage_count: 42)
     assert_equal "42 uses", join_code.usage_display
@@ -86,10 +80,24 @@ class Account::JoinCodeTest < ActiveSupport::TestCase
     assert_equal "42 uses of 100", join_code.usage_display
   end
 
-  test "usage_display says 'Never used' even when a limit is set" do
+  test "expiry_display rounds remaining time up to whole days" do
     join_code = account_join_codes(:signal)
-    join_code.update!(usage_limit: 100, usage_count: 0)
-    assert_equal "Never used", join_code.usage_display
+
+    join_code.update!(expires_at: 30.days.from_now)
+    assert_equal "Expires in 30 days", join_code.expiry_display
+
+    join_code.update!(expires_at: 1.hour.from_now)
+    assert_equal "Expires in 1 day", join_code.expiry_display
+  end
+
+  test "expiry_display is nil when there is nothing to show" do
+    join_code = account_join_codes(:signal)
+
+    join_code.update!(expires_at: nil)
+    assert_nil join_code.expiry_display
+
+    join_code.update!(expires_at: 1.hour.ago)
+    assert_nil join_code.expiry_display
   end
 
   test "global? returns true when user_id is nil" do
@@ -138,12 +146,6 @@ class Account::JoinCodeTest < ActiveSupport::TestCase
     assert join_code.expires_at > Account::JoinCode::DEFAULT_EXPIRATION.from_now,
       "global code should outlive the personal default"
     assert join_code.expires_at <= Account::JoinCode::DEFAULT_GLOBAL_EXPIRATION.from_now + 1.second
-  end
-
-  test "explicit expires_at is preserved over the default" do
-    target = 2.hours.from_now
-    join_code = Account::JoinCode.create!(account: accounts(:signal), expires_at: target)
-    assert_in_delta target, join_code.expires_at, 1.second
   end
 
   test "regenerate_code resets expires_at to a fresh default lifetime" do

--- a/test/models/account/join_code_test.rb
+++ b/test/models/account/join_code_test.rb
@@ -62,16 +62,34 @@ class Account::JoinCodeTest < ActiveSupport::TestCase
     assert_equal 0, join_code.usage_count
   end
 
-  test "usage_display shows count for unlimited" do
+  test "usage_display says 'Never used' when usage_count is zero" do
+    join_code = account_join_codes(:signal)
+    join_code.update!(usage_limit: nil, usage_count: 0)
+    assert_equal "Never used", join_code.usage_display
+  end
+
+  test "usage_display singularizes 'use' when usage_count is one" do
+    join_code = account_join_codes(:signal)
+    join_code.update!(usage_limit: nil, usage_count: 1)
+    assert_equal "1 use", join_code.usage_display
+  end
+
+  test "usage_display shows count for unlimited above one" do
     join_code = account_join_codes(:signal)
     join_code.update!(usage_limit: nil, usage_count: 42)
     assert_equal "42 uses", join_code.usage_display
   end
 
-  test "usage_display shows count/limit for limited" do
+  test "usage_display shows count and limit for limited" do
     join_code = account_join_codes(:signal)
     join_code.update!(usage_limit: 100, usage_count: 42)
-    assert_equal "42/100 uses", join_code.usage_display
+    assert_equal "42 uses of 100", join_code.usage_display
+  end
+
+  test "usage_display says 'Never used' even when a limit is set" do
+    join_code = account_join_codes(:signal)
+    join_code.update!(usage_limit: 100, usage_count: 0)
+    assert_equal "Never used", join_code.usage_display
   end
 
   test "global? returns true when user_id is nil" do
@@ -114,9 +132,40 @@ class Account::JoinCodeTest < ActiveSupport::TestCase
     assert join_code.expires_at <= Account::JoinCode::DEFAULT_EXPIRATION.from_now + 1.second
   end
 
-  test "global invite does not set default expiration" do
+  test "global invite gets the longer default expiration on create" do
     join_code = Account::JoinCode.create!(account: accounts(:signal))
-    assert_nil join_code.expires_at
+    assert join_code.expires_at.present?
+    assert join_code.expires_at > Account::JoinCode::DEFAULT_EXPIRATION.from_now,
+      "global code should outlive the personal default"
+    assert join_code.expires_at <= Account::JoinCode::DEFAULT_GLOBAL_EXPIRATION.from_now + 1.second
+  end
+
+  test "explicit expires_at is preserved over the default" do
+    target = 2.hours.from_now
+    join_code = Account::JoinCode.create!(account: accounts(:signal), expires_at: target)
+    assert_in_delta target, join_code.expires_at, 1.second
+  end
+
+  test "regenerate_code resets expires_at to a fresh default lifetime" do
+    join_code = account_join_codes(:signal)
+    join_code.update!(expires_at: 1.minute.from_now)
+
+    join_code.regenerate_code
+
+    assert join_code.expires_at > Account::JoinCode::DEFAULT_EXPIRATION.from_now,
+      "regenerate must restore a global code's lifetime"
+    assert join_code.expires_at <= Account::JoinCode::DEFAULT_GLOBAL_EXPIRATION.from_now + 1.second
+  end
+
+  test "regenerate_code on a personal code resets expires_at to the personal default" do
+    join_code = account_join_codes(:signal_personal)
+    join_code.update!(expires_at: 1.minute.from_now)
+
+    join_code.regenerate_code
+
+    assert join_code.expires_at > Time.current
+    assert join_code.expires_at <= Account::JoinCode::DEFAULT_EXPIRATION.from_now + 1.second,
+      "personal regenerate must not stretch to the longer global lifetime"
   end
 
   test "redeem! raises InactiveCodeError when exhausted" do

--- a/test/models/account/joinable_test.rb
+++ b/test/models/account/joinable_test.rb
@@ -12,4 +12,17 @@ class Account::JoinableTest < ActiveSupport::TestCase
       accounts(:signal).reset_join_code
     end
   end
+
+  test "join_code lazily regenerates an expired global code" do
+    account = accounts(:signal)
+    stale = account.join_code
+    stale.update!(expires_at: 1.hour.ago, usage_count: 5)
+    old_code = stale.code
+
+    fresh = account.join_code
+
+    assert_not_equal old_code, fresh.code
+    assert fresh.expires_at > Time.current
+    assert_equal 0, fresh.usage_count
+  end
 end


### PR DESCRIPTION
## Summary

- Workspace-wide invite links no longer live forever. Global codes now get a 30-day default expiration on create (personal codes stay at 7 days). `regenerate_code` also resets `expires_at` to a fresh lifetime, so the rotate button is a real reset, not just a string swap.
- `Account#join_code` lazily regenerates the global code if it's already expired when read. Admins viewing settings always see a usable link — they never have to click regenerate to "unstick" an expired one. Joiners are unaffected: they look up by code string, so anyone holding an expired URL still gets `"This invite link is no longer valid"`.
- The invite partial now shows admins the code's usage and expiry: `Never used` / `1 use` / `42 uses` / `42 uses of 100`, with `· Expires in N days` (rounded up to whole days). Non-admins see no change.
- Pre-existing global codes with `expires_at IS NULL` keep working; the next admin page load triggers lazy regen and they pick up the new default. No backfill migration ships with this PR.

## Why

Workspace join links were never-expiring and unlimited-uses by default. The only kill switch was regenerate, and admins had no visibility into whether the current code was active, stale, or being hammered. This brings the global code in line with the personal-code defaults, gives admins the signal they need to decide when to rotate, and keeps the share link self-healing so an expired code never blocks them from inviting someone new.

## Test plan

- [ ] As an admin, open Settings → invite. Confirm the footer shows "Never used · Expires in 30 days" for a freshly regenerated code.
- [ ] Use the link to join as a new user, return to Settings, confirm "1 use · Expires in 30 days".
- [ ] As a non-admin, confirm the footer does not render.
- [ ] Click regenerate, confirm the URL changes, usage resets to "Never used", and expiry resets to 30 days.
- [ ] In console: set the global code's `expires_at` to `1.hour.ago`. Reload Settings as an admin — confirm the URL has rotated to a new value and the footer shows "Never used · Expires in 30 days".
- [ ] With that same originally-expired URL (captured before the lazy regen), attempt to join in an incognito tab — receives "This invite link is no longer valid".