### PR TITLE
Modernize auth scopes, honor iOS safe areas, preprocess thumbnails

### DIFF
--- a/app/assets/stylesheets/application/layout.css
+++ b/app/assets/stylesheets/application/layout.css
@@ -38,6 +38,7 @@ body.library-collapsed #sidebar {
   inset: 0;
   position: fixed;
   inline-size: 100vw; /* mobile default: full width */
+  padding-block: env(safe-area-inset-top) env(safe-area-inset-bottom);
   transform: translate(100%);
 
   @media (min-width: 120ch) {
@@ -134,6 +135,7 @@ body.library-collapsed:has(#sidebar.open) {
     @media (max-width: 120ch) {
       inset: 0;
       position: fixed;
+      padding-block: env(safe-area-inset-top) env(safe-area-inset-bottom);
       transform: translate(100%);
     }
   }

--- a/app/assets/stylesheets/application/nav.css
+++ b/app/assets/stylesheets/application/nav.css
@@ -4,8 +4,8 @@
   display: flex;
   inset: 0 0 auto 0;
   inset-inline-end: var(--sidebar-width);
-  padding-block: var(--block-space);
-  padding-inline: calc(var(--inline-space) * 1.5) var(--inline-space-double);
+  padding-block: calc(var(--block-space) + env(safe-area-inset-top)) var(--block-space);
+  padding-inline: calc(var(--inline-space) * 1.5) calc(var(--inline-space-double) + env(safe-area-inset-right));
   pointer-events: none;
   position: fixed;
   row-gap: var(--block-space);

--- a/app/javascript/entrypoints/application.css
+++ b/app/javascript/entrypoints/application.css
@@ -341,20 +341,7 @@ main#main-content:focus {
 
 /* Text size and color utilities are defined in utilities.css (vanilla CSS).
    They load after this Tailwind layer so those definitions always win.
-   Do not duplicate .txt-* classes here. */
-
-/* Spacing utilities */
-.pad {
-  @apply px-[var(--spacing-inline)] py-[var(--spacing-block)];
-}
-
-.margin-block {
-  @apply my-[var(--spacing-block)];
-}
-
-.gap {
-  @apply gap-x-[var(--spacing-inline)] gap-y-[var(--spacing-block)];
-}
+   Do not duplicate .txt-* or spacing classes (.pad/.gap/.margin-block) here. */
 
 /* Input component classes - migrated from inputs.css */
 /* Base input styling maintained in CSS file for complex pseudo-classes and nested selectors */

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -16,7 +16,7 @@ class AuthToken < ApplicationRecord
 
   before_validation :generate_code
 
-  scope :valid, -> { where(used_at: nil).where("expires_at > ?", Time.current) }
+  scope :valid, -> { where(used_at: nil, expires_at: Time.current..) }
 
   def deliver_later
     AuthTokenMailer.otp(self).deliver_later

--- a/app/models/message/attachment.rb
+++ b/app/models/message/attachment.rb
@@ -17,7 +17,7 @@ module Message::Attachment
 
   included do
     has_one_attached :attachment do |attachable|
-      attachable.variant :thumb, resize_to_limit: [ THUMBNAIL_MAX_WIDTH, THUMBNAIL_MAX_HEIGHT ]
+      attachable.variant :thumb, resize_to_limit: [ THUMBNAIL_MAX_WIDTH, THUMBNAIL_MAX_HEIGHT ], process: :later
     end
 
     validate :acceptable_attachment, if: :attachment?

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -9,7 +9,7 @@ class Session < ApplicationRecord
   before_create :set_defaults
   after_create_commit :update_user_last_authenticated_at
 
-  scope :active, -> { where("expires_at IS NULL OR expires_at > ?", Time.current) }
+  scope :active, -> { where(expires_at: nil).or(where(expires_at: Time.current..)) }
 
   def self.start!(user_agent:, ip_address:)
     create! user_agent: user_agent, ip_address: ip_address

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 
     <%= page_title_tag %>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
     <meta name="view-transition" content="same-origin">
     <meta name="theme-color" content="<%= Branding.theme_color %>">
     <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/layouts/session.html.erb
+++ b/app/views/layouts/session.html.erb
@@ -5,7 +5,7 @@
 
     <title><%= [content_for(:title), Branding.contextual_app_name].compact.uniq.join(" | ") %></title>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="<%= Branding.theme_color %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/saas/app/models/auth_code.rb
+++ b/saas/app/models/auth_code.rb
@@ -20,7 +20,7 @@ class AuthCode < UntenantedRecord
   validates :code, presence: true, uniqueness: true
   validates :purpose, presence: true
 
-  scope :active, -> { where("expires_at > ?", Time.current) }
+  scope :active, -> { where(expires_at: Time.current..) }
 
   before_validation :generate_code, on: :create
   before_validation :set_expiration, on: :create

--- a/saas/app/models/global_session.rb
+++ b/saas/app/models/global_session.rb
@@ -12,7 +12,7 @@ class GlobalSession < UntenantedRecord
 
   validates :token, presence: true, uniqueness: true
 
-  scope :active, -> { where("expires_at IS NULL OR expires_at > ?", Time.current) }
+  scope :active, -> { where(expires_at: nil).or(where(expires_at: Time.current..)) }
 
   before_create :set_expiration
 


### PR DESCRIPTION
## Summary

Three quality-of-life cleanups bundled together. Auth scopes drop their raw SQL fragments for Active Record range syntax, the layout honors iPhone safe-area insets, and message thumbnails arrive pre-generated instead of lazy.

### Auth scope queries

Four scopes — `Session.active`, `AuthToken.valid`, `AuthCode.active`, `GlobalSession.active` — moved to Active Record's endless-range form. One subtle semantic shift to flag: `where(expires_at: Time.current..)` generates `>= ?` where the old SQL was `> ?`. A session expiring at the exact microsecond is now treated as active rather than expired. Negligible in practice and arguably more correct.

### iOS safe areas

Added `viewport-fit=cover` to both layout viewports and `env(safe-area-inset-*)` padding to the fixed `#nav` and mobile `#sidebar` overlay. Used MDN's additive `calc(static + env(...))` pattern so notched devices keep the design's intentional padding *plus* the safe-area buffer, instead of letting the inset swallow the static value. Non-notched devices are unchanged (env() resolves to 0). Also deleted three dead Tailwind `@apply` blocks (`.pad`, `.gap`, `.margin-block`) — identically-named vanilla classes already won the cascade.

### Message thumbnail preprocessing

Added `process: :later` to the `:thumb` variant declaration in `Message::Attachment` — Rails 8.2's `process:` option replaces the now-deprecated `preprocessed: true`. On upload, Active Storage enqueues `CreateVariantsJob` → `TransformJob` to generate the thumbnail in a background job. First display becomes an instant cache hit instead of an on-demand transformation.

## Verification

- Variant preprocessing confirmed in dev logs: `TransformJob` performs in ~5ms immediately after upload, and the subsequent `Blobs::RedirectController#show` reads the `VariantRecord` from cache rather than transforming on demand.
- Auth scope tests (`Session`, `AuthCode`, `GlobalSession`) cover both nil and expired branches; all green.
- Mobile safe-area work still needs iOS device validation before merge. The CSS is additive (zero effect on non-notched devices), but the notched-device visual should be eyeballed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude_Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)