### PR TITLE
Match wildcard SSO return hosts for managed_sabha customer servers

### DIFF
--- a/app/models/sso/provider_client.rb
+++ b/app/models/sso/provider_client.rb
@@ -69,13 +69,20 @@ class Sso::ProviderClient
 
     uri = URI.parse(url)
 
-    unless valid_scheme?(uri) && uri.host == return_host && uri.path == return_path && uri.userinfo.blank?
+    unless valid_scheme?(uri) && host_matches?(uri.host) && uri.path == return_path && uri.userinfo.blank?
       raise InvalidReturnUrl, "Untrusted SSO return URL"
     end
 
     true
   rescue URI::InvalidURIError
     raise InvalidReturnUrl, "Invalid SSO return URL"
+  end
+
+  # True when this client's return_host is a single-label wildcard like
+  # "*.sabha.co" — matching one subdomain level (acme.sabha.co), not the bare
+  # apex (sabha.co) or deeper subdomains (evil.acme.sabha.co).
+  def wildcard?
+    return_host.to_s.start_with?("*.")
   end
 
   private
@@ -85,5 +92,28 @@ class Sso::ProviderClient
       return true if uri.is_a?(URI::HTTPS)
 
       Rails.env.development? && uri.is_a?(URI::HTTP)
+    end
+
+    def host_matches?(host)
+      return false if host.blank?
+      return host == return_host unless wildcard?
+
+      base = return_host.delete_prefix("*.")
+      return false unless host.end_with?(".#{base}")
+
+      remainder = host.delete_suffix(".#{base}")
+      return false if remainder.empty? || remainder.include?(".")
+
+      # A wildcard client must not validate a host that another configured
+      # client claims exactly — keeps managed_sabha (*.sabha.co) out of
+      # cloud.sabha.co even if cloud_sabha's secret leaks and an attacker
+      # tries to swap return URLs.
+      !claimed_exactly_by_other_client?(host)
+    end
+
+    def claimed_exactly_by_other_client?(host)
+      self.class.active.any? do |client|
+        client.name != name && !client.wildcard? && client.return_host == host
+      end
     end
 end

--- a/test/models/sso/provider_client_test.rb
+++ b/test/models/sso/provider_client_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class Sso::ProviderClientTest < ActiveSupport::TestCase
+  setup do
+    @prior_env = ENV.to_h.dup
+    ENV["SSO_PROVIDER_CLIENTS"] = "cloud_sabha,managed_sabha"
+    ENV["SSO_CLOUD_SABHA_RETURN_HOST"]   = "cloud.sabha.co"
+    ENV["SSO_CLOUD_SABHA_RETURN_PATH"]   = "/session/sso/callback"
+    ENV["SSO_CLOUD_SABHA_SECRET"]        = "cloud-secret"
+    ENV["SSO_MANAGED_SABHA_RETURN_HOST"] = "*.sabha.co"
+    ENV["SSO_MANAGED_SABHA_RETURN_PATH"] = "/session/sso/callback"
+    ENV["SSO_MANAGED_SABHA_SECRET"]      = "managed-secret"
+  end
+
+  teardown do
+    ENV.replace(@prior_env)
+  end
+
+  test "exact-match client accepts its exact return URL" do
+    assert cloud_sabha.verify_return_url!("https://cloud.sabha.co/session/sso/callback")
+  end
+
+  test "exact-match client rejects any other host" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      cloud_sabha.verify_return_url!("https://acme.sabha.co/session/sso/callback")
+    end
+  end
+
+  test "wildcard client accepts a single-label subdomain" do
+    assert managed_sabha.verify_return_url!("https://acme.sabha.co/session/sso/callback")
+  end
+
+  test "wildcard client rejects the bare base domain" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      managed_sabha.verify_return_url!("https://sabha.co/session/sso/callback")
+    end
+  end
+
+  test "wildcard client rejects multi-label subdomains" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      managed_sabha.verify_return_url!("https://evil.acme.sabha.co/session/sso/callback")
+    end
+  end
+
+  test "wildcard client rejects a different base domain" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      managed_sabha.verify_return_url!("https://acme.evil.com/session/sso/callback")
+    end
+  end
+
+  test "wildcard client refuses a host claimed exactly by another configured client" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      managed_sabha.verify_return_url!("https://cloud.sabha.co/session/sso/callback")
+    end
+  end
+
+  test "wildcard client still rejects wrong return path" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      managed_sabha.verify_return_url!("https://acme.sabha.co/admin/sso/callback")
+    end
+  end
+
+  test "wildcard client rejects URL with userinfo" do
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      managed_sabha.verify_return_url!("https://attacker@acme.sabha.co/session/sso/callback")
+    end
+  end
+
+  test "wildcard? reflects return_host" do
+    assert managed_sabha.wildcard?
+    assert_not cloud_sabha.wildcard?
+  end
+
+  test "authenticate picks the client whose secret matches and verifies its return URL" do
+    encoded, sig = Sso::Payload.encode({
+      nonce: "abc",
+      return_sso_url: "https://acme.sabha.co/session/sso/callback"
+    }, "managed-secret")
+
+    client, payload = Sso::ProviderClient.authenticate(encoded, sig)
+
+    assert_equal "managed_sabha", client.name
+    assert_equal "abc", payload["nonce"]
+  end
+
+  test "authenticate rejects a managed_sabha-signed payload trying to return to cloud.sabha.co" do
+    encoded, sig = Sso::Payload.encode({
+      nonce: "abc",
+      return_sso_url: "https://cloud.sabha.co/session/sso/callback"
+    }, "managed-secret")
+
+    assert_raises(Sso::ProviderClient::InvalidReturnUrl) do
+      Sso::ProviderClient.authenticate(encoded, sig)
+    end
+  end
+
+  private
+    def cloud_sabha
+      Sso::ProviderClient.active.find { |c| c.name == "cloud_sabha" }
+    end
+
+    def managed_sabha
+      Sso::ProviderClient.active.find { |c| c.name == "managed_sabha" }
+    end
+end


### PR DESCRIPTION
## Why

Customer Sabha servers provisioned by sabha_cloud live at `{subdomain}.sabha.co` and bootstrap their first admin via the `managed_sabha` SSO provider client. That client is configured with `SSO_MANAGED_SABHA_RETURN_HOST=*.sabha.co`, but `verify_return_url!` only did exact `uri.host == return_host` matching — so every droplet handshake was rejected as an untrusted return URL.

## What

`Sso::ProviderClient#verify_return_url!` now treats a `return_host` starting with `*.` as a single-label wildcard:

- `acme.sabha.co` matches `*.sabha.co` ✓
- `sabha.co` (apex) does not match ✗
- `evil.acme.sabha.co` (multi-label) does not match ✗
- `cloud.sabha.co` does not match `*.sabha.co` — because another active client (`cloud_sabha`) claims it exactly. This guards against a leaked `managed_sabha` secret being used to redirect into the dashboard.

Path, scheme, and userinfo checks are unchanged. The non-wildcard path (`cloud_sabha`) still uses exact host equality.

## Test plan

- [x] `bin/rails test test/models/sso/provider_client_test.rb` — 12 runs, 14 assertions, 0 failures (covers exact match, single-label/apex/multi-label/different-base/cross-client-claim/wrong-path/userinfo rejections, `wildcard?` predicate, and `authenticate` routing by secret + cross-client attack path)