### PR TITLE
Open SSO handshake during auto-bootstrap regardless of AUTH_METHOD

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -31,7 +31,8 @@ class Account < ApplicationRecord
     end
 
     def sso_configured?
-      sso_auth? && sso_provider_url.present? && sso_secret.present?
+      (sso_auth? || FirstRun.should_auto_bootstrap?) &&
+        sso_provider_url.present? && sso_secret.present?
     end
 
     def sso_provider_url

--- a/test/controllers/sso_controller_test.rb
+++ b/test/controllers/sso_controller_test.rb
@@ -305,12 +305,37 @@ class SsoFlowTest < ActionDispatch::IntegrationTest
     assert_response :service_unavailable
   end
 
-  test "configured sso endpoint fails closed when sso auth is disabled" do
+  test "configured sso endpoint fails closed when sso auth is disabled and not bootstrapping" do
     ENV["AUTH_METHOD"] = "password"
 
     get sso_handshake_url
 
     assert_response :service_unavailable
+  end
+
+  test "sso callback accepts bootstrap traffic and provisions admin when auth_method != sso" do
+    ENV["AUTH_METHOD"] = "password"
+    ENV["AUTO_BOOTSTRAP"] = "true"
+
+    ActiveRecord::Base.connection.disable_referential_integrity do
+      Account.destroy_all
+      Room.destroy_all
+      User.destroy_all
+    end
+
+    get sso_handshake_url
+    nonce = provider_request_payload["nonce"]
+    sso, sig = Sso::Payload.encode(callback_payload(nonce:, email: "boot@example.com", external_id: "boot-1", name: "Boot"), ENV["SSO_SECRET"])
+
+    assert_difference -> { Account.count }, +1 do
+      assert_difference -> { User.count }, +1 do
+        get sso_callback_url, params: { sso:, sig: }
+      end
+    end
+
+    assert User.find_by(email_address: "boot@example.com").administrator?
+  ensure
+    ENV.delete("AUTO_BOOTSTRAP")
   end
 
   private


### PR DESCRIPTION
## Summary

`Account.sso_configured?` required `auth_method == "sso"`, but sabha_cloud-managed droplets ship with the customer's chosen `AUTH_METHOD` (`password` or `otp`) plus `AUTO_BOOTSTRAP=true`. Result: every fresh managed droplet hits a redirect loop and 503s on `/session/sso` with "Single sign-on is not configured.", locking out the first admin.

This widens the gate so the handshake/callback also accept traffic when `FirstRun.should_auto_bootstrap?` is true — matching the boot-time validator in `config/initializers/00_boot_mode.rb` which already requires `SSO_PROVIDER_URL`/`SSO_SECRET` whenever `AUTO_BOOTSTRAP=true`, and matching PR #110's stated design that "after bootstrap the droplet runs under whatever AUTH_METHOD the customer configured."

## Change

```diff
 def sso_configured?
-  sso_auth? && sso_provider_url.present? && sso_secret.present?
+  (sso_auth? || FirstRun.should_auto_bootstrap?) &&
+    sso_provider_url.present? && sso_secret.present?
 end
```

Provider URL + secret are still required either way, so the "secret missing → 503" path is unchanged.

## Tests

- Renamed the existing `"fails closed when sso auth is disabled"` test to make its precondition explicit (`"…and not bootstrapping"`).
- Added a callback test that exercises the full bootstrap flow with `AUTH_METHOD=password`: handshake → callback → Account + admin User provisioned.

## Test plan

- [ ] CI green
- [ ] Deploy and bootstrap a fresh managed droplet with `AUTH_METHOD=password`; confirm first admin can sign in via SSO
- [ ] Post-bootstrap, confirm subsequent logins honour the configured `AUTH_METHOD` (no further SSO required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)