### PR TITLE
Tighten Active Storage hygiene across attachments and webhooks

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,11 +11,11 @@ class AccountsController < ApplicationController
   end
 
   def update
-    @account.attach_logo(account_params[:logo]) if account_params[:logo].present?
-    @account.update!(merged_account_params.except(:logo))
-    redirect_to edit_account_url, notice: "✓"
-  rescue Account::InvalidLogoType
-    redirect_to edit_account_url, alert: "Logo must be a JPEG, PNG, GIF, or WebP image"
+    if @account.update(merged_account_params)
+      redirect_to edit_account_url, notice: "✓"
+    else
+      redirect_to edit_account_url, alert: @account.errors.full_messages.to_sentence
+    end
   end
 
   private

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -3,14 +3,16 @@ class Account < ApplicationRecord
 
   VALID_AUTH_METHODS = %w[password otp sso].freeze
   ALLOWED_LOGO_CONTENT_TYPES = %w[ image/jpeg image/png image/gif image/webp ].freeze
+  MAX_LOGO_SIZE = 5.megabytes
 
-  InvalidLogoType = Class.new(StandardError)
-
-  has_one_attached :logo
+  has_one_attached :logo, dependent: :purge_later
   has_json :settings, restrict_room_creation_to_administrators: false, restrict_direct_messages_to_administrators: false, allow_users_to_create_invite_links: true
+
+  validate :acceptable_logo, if: :logo_attached?
 
   after_save :invalidate_personal_invite_links, if: :invite_links_disabled?
   after_commit :sync_name_to_workspace, if: :saved_change_to_name?
+  after_save_commit :sync_logo_to_workspace
 
   # Auth config is ENV-driven and shared across all accounts on a deploy.
   class << self
@@ -44,22 +46,27 @@ class Account < ApplicationRecord
     end
   end
 
-  def attach_logo(attachable)
-    content_type = attachable.try(:content_type) || attachable[:content_type]
-    raise InvalidLogoType unless content_type.in?(ALLOWED_LOGO_CONTENT_TYPES)
-
-    logo.attach(attachable)
-    touch
-    sync_logo_to_workspace
-  end
-
   def purge_logo
     logo.purge
-    touch
     sync_logo_to_workspace
   end
 
   private
+    def logo_attached?
+      logo.attached?
+    end
+
+    def acceptable_logo
+      unless ALLOWED_LOGO_CONTENT_TYPES.include?(logo.content_type)
+        errors.add(:logo, "must be a JPEG, PNG, GIF, or WebP image")
+        return
+      end
+
+      if logo.byte_size > MAX_LOGO_SIZE
+        errors.add(:logo, "is too large (max #{MAX_LOGO_SIZE / 1.megabyte}MB)")
+      end
+    end
+
     def invite_links_disabled?
       saved_change_to_settings? && !settings.allow_users_to_create_invite_links?
     end

--- a/app/models/message/attachment.rb
+++ b/app/models/message/attachment.rb
@@ -16,7 +16,7 @@ module Message::Attachment
   MAX_ATTACHMENT_SIZE = 50.megabytes
 
   included do
-    has_one_attached :attachment do |attachable|
+    has_one_attached :attachment, dependent: :purge_later do |attachable|
       attachable.variant :thumb, resize_to_limit: [ THUMBNAIL_MAX_WIDTH, THUMBNAIL_MAX_HEIGHT ], process: :later
     end
 

--- a/app/models/user/avatar.rb
+++ b/app/models/user/avatar.rb
@@ -2,11 +2,12 @@ module User::Avatar
   extend ActiveSupport::Concern
 
   ALLOWED_AVATAR_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+  MAX_AVATAR_SIZE = 5.megabytes
 
   included do
-    has_one_attached :avatar
+    has_one_attached :avatar, dependent: :purge_later
 
-    validate :avatar_content_type_allowed, if: :avatar_attached?
+    validate :acceptable_avatar, if: :avatar_attached?
   end
 
   class_methods do
@@ -24,9 +25,14 @@ module User::Avatar
       avatar.attached?
     end
 
-    def avatar_content_type_allowed
+    def acceptable_avatar
       unless ALLOWED_AVATAR_CONTENT_TYPES.include?(avatar.content_type)
         errors.add(:avatar, "must be a JPEG, PNG, GIF, or WebP image")
+        return
+      end
+
+      if avatar.byte_size > MAX_AVATAR_SIZE
+        errors.add(:avatar, "is too large (max #{MAX_AVATAR_SIZE / 1.megabyte}MB)")
       end
     end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -3,6 +3,21 @@ require "uri"
 
 class Webhook < ApplicationRecord
   ENDPOINT_TIMEOUT = 300.seconds
+  MAX_REPLY_BODY_SIZE = 10.megabytes
+  ALLOWED_REPLY_CONTENT_TYPES = %w[
+    image/jpeg image/png image/gif image/webp
+    video/mp4 video/quicktime video/webm
+    audio/mpeg audio/mp4 audio/ogg audio/webm
+    application/pdf
+  ].freeze
+
+  ResponseTooLarge = Class.new(StandardError)
+
+  Response = Struct.new(:code, :message, :content_type, :body, keyword_init: true) do
+    def success?
+      code.to_i.between?(200, 299)
+    end
+  end
 
   belongs_to :user
 
@@ -54,17 +69,34 @@ class Webhook < ApplicationRecord
       end
     rescue Net::OpenTimeout, Net::ReadTimeout
       receive_text_reply_to room, text: "Failed to respond within #{ENDPOINT_TIMEOUT} seconds"
+    rescue ResponseTooLarge
+      receive_text_reply_to room, text: "Bot reply exceeded #{MAX_REPLY_BODY_SIZE / 1.megabyte}MB limit"
     end
 
     def deliver_without_reply(event_name, payload)
       post(event_name, payload).tap do |response|
-        raise "Failed to deliver webhook to #{url}, response: #{response.code} #{response.message}" unless response.is_a?(Net::HTTPSuccess)
+        raise "Failed to deliver webhook to #{url}, response: #{response.code} #{response.message}" unless response.success?
       end
     end
 
     def post(event_name, payload)
       headers = { "Content-Type" => "application/json" }.merge(signature_headers(event_name, payload))
-      http.request Net::HTTP::Post.new(uri, headers).tap { |request| request.body = payload }
+      request = Net::HTTP::Post.new(uri, headers).tap { |r| r.body = payload }
+
+      body = String.new
+      net_response = http.request(request) do |response|
+        response.read_body do |chunk|
+          body << chunk
+          raise ResponseTooLarge if body.bytesize > MAX_REPLY_BODY_SIZE
+        end
+      end
+
+      Response.new(
+        code: net_response.code,
+        message: net_response.message,
+        content_type: net_response.content_type,
+        body: body
+      )
     end
 
     def signature_headers(event_name, payload)
@@ -99,10 +131,13 @@ class Webhook < ApplicationRecord
     end
 
     def extract_attachment_from(response)
-      if response.content_type && mime_type = Mime::Type.lookup(response.content_type)
-        ActiveStorage::Blob.create_and_upload! \
-          io: StringIO.new(response.body), filename: "attachment.#{mime_type.symbol}", content_type: mime_type.to_s
-      end
+      return unless response.content_type && ALLOWED_REPLY_CONTENT_TYPES.include?(response.content_type)
+
+      mime_type = Mime::Type.lookup(response.content_type)
+      return unless mime_type
+
+      ActiveStorage::Blob.create_and_upload! \
+        io: StringIO.new(response.body), filename: "attachment.#{mime_type.symbol}", content_type: mime_type.to_s
     end
 
     def receive_attachment_reply_to(room, attachment:)

--- a/saas/test/models/account_test.rb
+++ b/saas/test/models/account_test.rb
@@ -17,4 +17,22 @@ class SaasAccountTest < ActiveSupport::TestCase
   ensure
     identity&.destroy
   end
+
+  test "attaching and purging logo syncs has_logo flag on workspace" do
+    identity = GlobalIdentity.create!(name: "Logo Sync", email_address: "logosync@example.com", verified_at: Time.current)
+
+    with_provisioned_workspace(name: "Logo Test", creator: identity) do |workspace|
+      ApplicationRecord.with_tenant(workspace.external_id.to_s) do
+        account = Account.first
+
+        account.update!(logo: { io: StringIO.new("fake png"), filename: "logo.png", content_type: "image/png" })
+        assert workspace.reload.has_logo?, "expected has_logo to flip true after attach"
+
+        account.purge_logo
+        assert_not workspace.reload.has_logo?, "expected has_logo to flip false after purge"
+      end
+    end
+  ensure
+    identity&.destroy
+  end
 end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -94,10 +94,17 @@ class AccountTest < ActiveSupport::TestCase
   end
 
   test "rejects SVG logo uploads" do
-    assert_raises(Account::InvalidLogoType) do
-      @account.attach_logo({ io: file_fixture("logo.svg").open, filename: "logo.svg", content_type: "image/svg+xml" })
-    end
-    assert_not @account.logo.attached?
+    @account.logo.attach(io: file_fixture("logo.svg").open, filename: "logo.svg", content_type: "image/svg+xml")
+
+    assert_not @account.valid?
+    assert_includes @account.errors[:logo], "must be a JPEG, PNG, GIF, or WebP image"
+  end
+
+  test "rejects oversize logo uploads" do
+    @account.logo.attach(io: StringIO.new("x" * (Account::MAX_LOGO_SIZE + 1)), filename: "huge.png", content_type: "image/png")
+
+    assert_not @account.valid?
+    assert_includes @account.errors[:logo], "is too large (max #{Account::MAX_LOGO_SIZE / 1.megabyte}MB)"
   end
 
   test "disabling invite links destroys all personal invite links" do

--- a/test/models/user/avatar_test.rb
+++ b/test/models/user/avatar_test.rb
@@ -19,4 +19,14 @@ class User::AvatarTest < ActiveSupport::TestCase
     assert_not user.valid?
     assert_includes user.errors[:avatar], "must be a JPEG, PNG, GIF, or WebP image"
   end
+
+  test "oversize avatar is invalid" do
+    user = users(:david)
+    user.avatar.attach(
+      io: StringIO.new("x" * (User::Avatar::MAX_AVATAR_SIZE + 1)), filename: "huge.png", content_type: "image/png"
+    )
+
+    assert_not user.valid?
+    assert_includes user.errors[:avatar], "is too large (max #{User::Avatar::MAX_AVATAR_SIZE / 1.megabyte}MB)"
+  end
 end

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -49,6 +49,28 @@ class WebhookTest < ActiveSupport::TestCase
     end
   end
 
+  test "delivery with reply posts size-limit message when body exceeds cap" do
+    oversize = "x" * (Webhook::MAX_REPLY_BODY_SIZE + 1)
+    WebMock.stub_request(:post, webhooks(:betty).url).to_return(status: 200, body: oversize, headers: { "Content-Type" => "text/plain" })
+
+    webhooks(:betty).deliver_now(messages(:first), :created, reply: true)
+
+    reply_message = Message.last
+    assert_equal "Bot reply exceeded #{Webhook::MAX_REPLY_BODY_SIZE / 1.megabyte}MB limit", reply_message.body.to_plain_text
+  end
+
+  test "size cap fires before attachment blob is created for oversize image reply" do
+    oversize_image = "x" * (Webhook::MAX_REPLY_BODY_SIZE + 1)
+    WebMock.stub_request(:post, webhooks(:betty).url).to_return(status: 200, body: oversize_image, headers: { "Content-Type" => "image/png" })
+
+    assert_no_difference -> { ActiveStorage::Blob.count } do
+      webhooks(:betty).deliver_now(messages(:first), :created, reply: true)
+    end
+
+    reply_message = Message.last
+    assert_equal "Bot reply exceeded #{Webhook::MAX_REPLY_BODY_SIZE / 1.megabyte}MB limit", reply_message.body.to_plain_text
+  end
+
   test "delivery with reply posts timeout message" do
     Webhook.any_instance.stubs(:post).raises(Net::OpenTimeout)
     response = webhooks(:betty).deliver_now(messages(:first), :created, reply: true)


### PR DESCRIPTION
## Summary

Three Active Storage surfaces in Sabha had real or potential blob-leak / DoS exposure. This branch tightens all of them.

- **Parent destroy now purges blobs.** Avatars, logos, and message attachments declare `dependent: :purge_later` so a destroyed parent doesn't orphan its blob.
- **Size caps on avatar and logo uploads** (5 MB each). Both were unbounded — an authenticated user could upload a 500 MB "avatar" today.
- **Streaming webhook reply bodies with a 10 MB cap.** Webhook reply bodies were read into memory unbounded, then optionally promoted to a blob. A malicious bot endpoint could exhaust a worker's memory or fill storage. The body is now streamed via `Net::HTTP` block form and `ResponseTooLarge` is raised the moment cumulative bytes cross the cap. Same defensive shape as fizzy's `Webhook::Delivery#stream_body_with_limit`.

`Account#logo` also got a Rails-idiomatic refactor along the way: the homemade `attach_logo` + `InvalidLogoType` / `InvalidLogoSize` exception scheme is gone, replaced with a `validate :acceptable_logo` mirroring `User::Avatar`. The controller becomes the standard `if @account.update(...) ... else ... end`. Workspace `has_logo` sync moved to `after_save_commit` for the attach path; `purge_logo` kept as a one-line method because AS's `purge` doesn't fire parent save callbacks (verified against the gem source — would have left \`workspace.has_logo\` stuck at \`true\` after deletion otherwise).

## Test plan

- [ ] Upload a logo via account settings — happy path still works
- [ ] Try to upload a >5 MB logo — alert flash, attachment rejected
- [ ] Try to upload a >5 MB avatar — same
- [ ] Bot webhook returning a small text or image reply still works end-to-end
- [ ] Self-hosted: \`bin/rails test\` (1468 runs, 0 failures locally)
- [ ] SaaS: \`SAAS=true bin/rails test saas/test/models/account_test.rb\` (covers the \`Workspace#has_logo\` sync regression)