### PR TITLE
Clear stale return_to so an abandoned SSO flow can't hijack a later login

### DIFF
--- a/saas/app/controllers/concerns/saas/authentication.rb
+++ b/saas/app/controllers/concerns/saas/authentication.rb
@@ -100,6 +100,14 @@ module Saas
         session[:return_to_after_authenticating] = request.fullpath if request.get? || request.head?
       end
 
+      # Capture the post-authentication redirect target from params, clearing any
+      # previously stored value when none is supplied. Clearing matters because an
+      # abandoned flow (e.g. SSO arriving with a return_to) would otherwise leave a
+      # stale, cross-origin target that hijacks the next unrelated plain login.
+      def capture_return_to
+        session[:return_to_after_authenticating] = params[:return_to].presence
+      end
+
       # URL to redirect to after successful authentication
       def after_authentication_url
         stored_url = session.delete(:return_to_after_authenticating)

--- a/saas/app/controllers/saas/auth_codes_controller.rb
+++ b/saas/app/controllers/saas/auth_codes_controller.rb
@@ -15,7 +15,9 @@ module Saas
     def show
       @auth_code_email = session.delete(:auth_code_email)
 
-      # Store return_to param for redirect after authentication
+      # Store-only (not capture_return_to): this page is reached via a paramless
+      # redirect from session/registration create, so clearing on a blank param
+      # would wipe the return_to those steps legitimately stored.
       if params[:return_to].present?
         session[:return_to_after_authenticating] = params[:return_to]
       end

--- a/saas/app/controllers/saas/registrations_controller.rb
+++ b/saas/app/controllers/saas/registrations_controller.rb
@@ -18,10 +18,7 @@ module Saas
     rescue_from RailsCloudflareTurnstile::Forbidden, with: :handle_turnstile_failure
 
     def new
-      # Store return_to param for redirect after authentication
-      if params[:return_to].present?
-        session[:return_to_after_authenticating] = params[:return_to]
-      end
+      capture_return_to
     end
 
     def create

--- a/saas/app/controllers/saas/sessions_controller.rb
+++ b/saas/app/controllers/saas/sessions_controller.rb
@@ -12,10 +12,7 @@ module Saas
     }
 
     def new
-      # Store return_to param for redirect after authentication
-      if params[:return_to].present?
-        session[:return_to_after_authenticating] = params[:return_to]
-      end
+      capture_return_to
     end
 
     def create

--- a/saas/test/controllers/saas/registrations_controller_test.rb
+++ b/saas/test/controllers/saas/registrations_controller_test.rb
@@ -11,6 +11,16 @@ module Saas
       assert_response :success
     end
 
+    test "new clears stale return_to when none is supplied" do
+      # An earlier, abandoned SSO flow stored a cross-origin return_to.
+      get new_registration_path, params: { return_to: "/session/sso?sso=abc&sig=def" }
+      assert_equal "/session/sso?sso=abc&sig=def", session[:return_to_after_authenticating]
+
+      # A later plain signup with no return_to must not inherit the stale value.
+      get new_registration_path
+      assert_nil session[:return_to_after_authenticating]
+    end
+
     test "create with blank email redirects with validation errors" do
       post registration_path, params: with_turnstile_response(name: "Test", email_address: "")
       assert_redirected_to new_registration_path

--- a/saas/test/controllers/saas/sessions_controller_test.rb
+++ b/saas/test/controllers/saas/sessions_controller_test.rb
@@ -15,6 +15,34 @@ module Saas
       assert_equal "/1000001/rooms/general", session[:return_to_after_authenticating]
     end
 
+    test "new clears stale return_to when none is supplied" do
+      # An earlier, abandoned SSO flow stored a cross-origin return_to.
+      get new_session_path, params: { return_to: "/session/sso?sso=abc&sig=def" }
+      assert_equal "/session/sso?sso=abc&sig=def", session[:return_to_after_authenticating]
+
+      # A later plain login with no return_to must not inherit the stale value,
+      # otherwise it would hijack the post-authentication redirect.
+      get new_session_path
+      assert_nil session[:return_to_after_authenticating]
+    end
+
+    test "stale SSO return_to from an abandoned flow does not hijack a later plain login" do
+      # 1. An SSO flow lands on registration/new with a cross-origin return_to,
+      #    then the user abandons it (never completes signup).
+      sso_return_to = "/session/sso?sso=bm9uY2U9YWJj&sig=deadbeef"
+      get new_registration_path, params: { return_to: sso_return_to }
+      assert_equal sso_return_to, session[:return_to_after_authenticating]
+
+      # 2. The user later does an unrelated plain login (no return_to).
+      get new_session_path
+      assert_nil session[:return_to_after_authenticating]
+
+      # 3. Completing the code entry must redirect to root, not the stale SSO URL.
+      post auth_code_path, params: { code: auth_codes(:alice_signin).code }
+      assert_redirected_to root_path
+      assert_no_match %r{/session/sso}, @response.redirect_url
+    end
+
     test "create sends auth code for existing identity" do
       identity = global_identities(:alice)
 


### PR DESCRIPTION
## Problem

In SaaS mode, `session[:return_to_after_authenticating]` was set on the login/signup entry pages but never cleared. A user who began an SSO flow (`/registration/new?return_to=<sso url>` or `/session/new?return_to=...`) and abandoned it left that `return_to` sitting in their session. A later, unrelated plain login then popped the stale value in `after_authentication_url` and redirected cross-origin after OTP entry — which Turbo silently can't follow, so the sign-in appeared to hang.

Confirmed on prod: the same SSO nonce appeared in both the abandoned attempt and the unrelated later login's post-auth redirect.

## Fix

`SessionsController#new` and `RegistrationsController#new` now clear the stored value when no `return_to` is supplied, via a shared `capture_return_to` helper in `Saas::Authentication` (which already owns this session key). Expressed idiomatically as `session[:return_to_after_authenticating] = params[:return_to].presence` — both read paths guard on `present?`, so assigning nil is equivalent to clearing.

Every legitimate SSO step threads `return_to` through its links, so the param is only absent on a genuine plain login. `AuthCodesController#show` deliberately keeps store-only behavior (it's reached via a paramless redirect, where clearing would wipe a legitimately-stored value) — documented inline.

## Tests

Unit tests on both controllers (stale value cleared on paramless `new`) plus an end-to-end regression test reproducing the original incident (abandon SSO `return_to`, complete a plain login, assert the post-auth redirect lands on root, not the stale SSO URL). Verified the tests fail without the fix.