### PR TITLE
Show the viewer as online on the members list, and label the account tool by role

### DIFF
--- a/app/controllers/accounts/users_controller.rb
+++ b/app/controllers/accounts/users_controller.rb
@@ -128,6 +128,7 @@ class Accounts::UsersController < ApplicationController
 
     def preload_activity(users)
       @activity_statuses = Membership.activity_statuses_for(users.map(&:id))
+      @activity_statuses[Current.user.id] = :active # You're viewing the page, so you're online
     end
 
     def sort_by_activity(users)

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -6,7 +6,8 @@ module AccountsHelper
   end
 
   def online_users_count
-    Membership.online_user_count
+    count = Membership.online_user_count
+    Membership.online?(Current.user) ? count : count + 1 # You're viewing the page, so you're online
   end
 
   STATUS_CSS_CLASSES = { active: "status--active", away: "status--away", offline: "status--offline" }.freeze

--- a/app/models/membership/connectable.rb
+++ b/app/models/membership/connectable.rb
@@ -46,6 +46,10 @@ module Membership::Connectable
       where(connected_at: since.ago..).select(:user_id).distinct.count
     end
 
+    def online?(user, since: ACTIVITY_TIERS[:active])
+      where(user_id: user.id, connected_at: since.ago..).exists?
+    end
+
     # Email-only presence check: a user is away when no membership in this
     # tenant has been connected within the away tier (1 hour). Distinct from
     # `connected?` (60s) which gates push — email asks "has the user been gone

--- a/app/views/users/sidebars/show.html.erb
+++ b/app/views/users/sidebars/show.html.erb
@@ -115,10 +115,11 @@
         <span class="sidebar__tool-label">Bookmarks</span>
       <% end %>
 
+      <% account_tool_label = Current.user&.staff? ? "Settings" : "About" %>
       <%= link_to account_path, class: "btn sidebar__tool" do %>
         <%= icon_tag Current.user&.staff? ? "crown" : "world" %>
-        <span class="for-screen-reader">About</span>
-        <span class="sidebar__tool-label">About</span>
+        <span class="for-screen-reader"><%= account_tool_label %></span>
+        <span class="sidebar__tool-label"><%= account_tool_label %></span>
       <% end %>
       
       <%= render "users/sidebars/bell" %>

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -146,6 +146,19 @@ class MembershipTest < ActiveSupport::TestCase
     assert_equal :away, Membership.activity_status(result[jason.id])
   end
 
+  test "online? is true only when the user has a membership connected within the active tier" do
+    david = users(:david)
+    Membership.unscoped.where(user_id: david.id).update_all(connected_at: nil)
+
+    refute Membership.online?(david)
+
+    memberships(:david_watercooler).update_column(:connected_at, 1.minute.ago)
+    assert Membership.online?(david)
+
+    memberships(:david_watercooler).update_column(:connected_at, 30.minutes.ago)
+    refute Membership.online?(david)
+  end
+
   # Starred tests
 
   test "starred scope returns starred memberships" do


### PR DESCRIPTION
Two small fixes to the members/account surface.

**Members list shows you as offline.** On `/account/users` the admin viewing the page always rendered with a gray status dot and "0 members online", despite actively using the app. Presence is room-scoped — the `presence` controller only runs inside a room's message area, and leaving a room nils the membership's `connected_at` — so on any non-room page the viewer reads as stale. This asserts the one thing we know for certain: the person rendering the page is online. Their own dot now shows active and the online count includes them.

This is a deliberate, viewer-only stopgap; other users sitting on non-room pages still read offline. The durable fix (don't nil `connected_at`, or app-wide presence) belongs with the eventual AnyCable broker-presence migration and is documented separately.

A new `Membership.online?(user)` predicate carries the "is this user online" question, leaving `online_user_count` a single `COUNT(DISTINCT)` and keeping the "viewer is online" assertion at the presentation layer next to the controller's status override.

**Sidebar account tool label.** The sidebar entry linking to the account page already switched its icon between a crown (staff) and a globe (everyone else), but always read "About". It now reads "Settings" for staff and "About" otherwise, matching the icon. The label is computed once so the visible text and the accessible name stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
