### PR TITLE
Operator-branded OpenGraph share cards

### DIFF
--- a/app/controllers/accounts/og_images_controller.rb
+++ b/app/controllers/accounts/og_images_controller.rb
@@ -1,0 +1,10 @@
+class Accounts::OgImagesController < ApplicationController
+  allow_unauthenticated_access only: :show
+
+  def show
+    if stale?(etag: Current.account)
+      expires_in 1.hour, public: true, stale_while_revalidate: 1.week
+      send_data Account::OgImage.new(Current.account).png, type: "image/png", disposition: :inline
+    end
+  end
+end

--- a/app/models/account/og_image.rb
+++ b/app/models/account/og_image.rb
@@ -64,8 +64,10 @@ class Account::OgImage
 
     # libvips renders text as a single-band coverage mask; colorize it by using
     # the mask as the alpha channel over a solid fill, so it composites cleanly.
+    # The string is escaped first because libvips parses it as Pango markup, so a
+    # raw "&" or "<" in an account name would otherwise raise an invalid-markup error.
     def text(string, font, color)
-      mask = Vips::Image.text(string, font: font, width: WIDTH - 160, align: :centre)
+      mask = Vips::Image.text(CGI.escapeHTML(string), font: font, width: WIDTH - 160, align: :centre)
       mask.new_from_image(color).bandjoin(mask).copy(interpretation: "srgb")
     end
 

--- a/app/models/account/og_image.rb
+++ b/app/models/account/og_image.rb
@@ -46,15 +46,33 @@ class Account::OgImage
       canvas.flatten(background: BACKGROUND)
     end
 
-    # The operator's uploaded logo when present (fitted into the mark box,
-    # aspect preserved), otherwise the stock Sabha mark.
+    # The operator's uploaded logo when present, otherwise the stock Sabha mark,
+    # always centered inside a fixed square so the card's layout stays put.
     def mark
-      if @account&.logo&.attached?
-        Vips::Image.thumbnail_buffer(@account.logo.download, MARK_SIZE, height: MARK_SIZE, size: :down)
-                   .copy(interpretation: "srgb")
-      else
-        Vips::Image.thumbnail(MARK.to_s, MARK_SIZE)
-      end
+      frame(logo_mark || stock_mark)
+    end
+
+    # A corrupt or empty logo blob must degrade to the stock mark rather than
+    # 500 the public card endpoint, so swallow vips' decode failures here.
+    def logo_mark
+      return unless @account&.logo&.attached?
+      Vips::Image.thumbnail_buffer(@account.logo.download, MARK_SIZE, height: MARK_SIZE, size: :down)
+    rescue Vips::Error, FFI::NullPointerError
+      nil
+    end
+
+    def stock_mark
+      Vips::Image.thumbnail(MARK.to_s, MARK_SIZE)
+    end
+
+    # Aspect-preserving thumbnails aren't square, so center the mark inside a
+    # MARK_SIZE box with transparent padding — otherwise a wide or tall logo
+    # shifts the whole composition off-center.
+    def frame(image)
+      image = image.bandjoin(255) if image.bands < 4
+      image.embed((MARK_SIZE - image.width) / 2, (MARK_SIZE - image.height) / 2,
+                  MARK_SIZE, MARK_SIZE, extend: :background, background: [ 0, 0, 0, 0 ])
+           .copy(interpretation: "srgb")
     end
 
     def background

--- a/app/models/account/og_image.rb
+++ b/app/models/account/og_image.rb
@@ -1,0 +1,75 @@
+# Renders the social-share (OpenGraph) card for an account as a 1200x630 PNG.
+#
+# Rather than advertising Sabha on every shared link, the card shows the
+# operator's own community: their uploaded logo (or the Sabha mark when none is
+# set) above the account name, on a clean brand background with a small "powered
+# by sabha" footer.
+class Account::OgImage
+  WIDTH = 1200
+  HEIGHT = 630
+
+  BACKGROUND = [ 255, 255, 255 ]  # white
+  INK = [ 32, 33, 36 ]            # #202124
+  MUTED = [ 142, 142, 147 ]       # #8e8e93
+
+  MARK_SIZE = 112
+  MARK = Rails.root.join("app/assets/images/logos/app-icon.png")
+
+  def initialize(account)
+    @account = account
+  end
+
+  def png
+    compose.write_to_buffer(".png")
+  end
+
+  private
+    def compose
+      title = text(display_name, "sans bold 72", INK)
+      footer = text("powered by sabha", "sans 28", MUTED)
+
+      stack = [
+        [ mark, 48 ],
+        [ title, 20 ],
+        [ footer, 0 ]
+      ]
+
+      total = stack.sum { |image, gap| image.height + gap }
+      top = (HEIGHT - total) / 2
+
+      canvas = background
+      stack.each do |image, gap|
+        canvas = canvas.composite2(image, :over, x: (WIDTH - image.width) / 2, y: top)
+        top += image.height + gap
+      end
+
+      canvas.flatten(background: BACKGROUND)
+    end
+
+    # The operator's uploaded logo when present (fitted into the mark box,
+    # aspect preserved), otherwise the stock Sabha mark.
+    def mark
+      if @account&.logo&.attached?
+        Vips::Image.thumbnail_buffer(@account.logo.download, MARK_SIZE, height: MARK_SIZE, size: :down)
+                   .copy(interpretation: "srgb")
+      else
+        Vips::Image.thumbnail(MARK.to_s, MARK_SIZE)
+      end
+    end
+
+    def background
+      white = (Vips::Image.black(WIDTH, HEIGHT) + BACKGROUND).cast("uchar")
+      white.bandjoin(255).copy(interpretation: "srgb")
+    end
+
+    # libvips renders text as a single-band coverage mask; colorize it by using
+    # the mask as the alpha channel over a solid fill, so it composites cleanly.
+    def text(string, font, color)
+      mask = Vips::Image.text(string, font: font, width: WIDTH - 160, align: :centre)
+      mask.new_from_image(color).bandjoin(mask).copy(interpretation: "srgb")
+    end
+
+    def display_name
+      @account&.name.presence || Branding.app_name
+    end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,8 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="<%= page_title %>">
     <meta property="og:description" content="<%= Branding.app_description %>">
-    <meta property="og:image" content="<%= request.base_url %>/sabha-og.jpg">
-    <meta property="og:logo" content="<%= request.base_url %>/icon.png">
+    <meta property="og:image" content="<%= fresh_account_og_image_url %>">
+    <meta property="og:logo" content="<%= fresh_account_logo_url %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= Sabha.saas? ? tenanted_action_cable_meta_tag : action_cable_meta_tag %>

--- a/app/views/layouts/session.html.erb
+++ b/app/views/layouts/session.html.erb
@@ -13,8 +13,8 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="<%= [content_for(:title), Branding.contextual_app_name].compact.uniq.join(" | ") %>">
     <meta property="og:description" content="<%= Branding.app_description %>">
-    <meta property="og:image" content="<%= request.base_url %>/sabha-og.jpg">
-    <meta property="og:logo" content="<%= request.base_url %>/icon.png">
+    <meta property="og:image" content="<%= fresh_account_og_image_url %>">
+    <meta property="og:logo" content="<%= fresh_account_logo_url %>">
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,12 +88,17 @@ Rails.application.routes.draw do
 
       resource :join_code, only: %i[ create update ]
       resource :logo, only: %i[ show destroy ]
+      resource :og_image, only: :show
       resource :custom_styles, only: %i[ edit update ]
     end
   end
 
   direct :fresh_account_logo do |options|
     route_for :account_logo, v: Current.account&.updated_at&.to_fs(:number), size: options[:size]
+  end
+
+  direct :fresh_account_og_image do
+    route_for :account_og_image, v: Current.account&.updated_at&.to_fs(:number)
   end
 
   resources :qr_code, only: :show

--- a/saas/app/views/layouts/saas.html.erb
+++ b/saas/app/views/layouts/saas.html.erb
@@ -13,7 +13,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="<%= [content_for(:title), Branding.app_name].compact.uniq.join(" | ") %>">
     <meta property="og:description" content="<%= Branding.app_description %>">
-    <meta property="og:image" content="<%= request.base_url %>/icon.png">
+    <meta property="og:image" content="<%= fresh_account_og_image_url %>">
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/test/controllers/accounts/og_images_controller_test.rb
+++ b/test/controllers/accounts/og_images_controller_test.rb
@@ -21,6 +21,18 @@ class Accounts::OgImagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 630, image.height
   end
 
+  test "composites an uploaded logo end to end without raising" do
+    accounts(:signal).update! logo: fixture_file_upload("moon.jpg", "image/jpeg")
+
+    get account_og_image_url
+
+    assert_equal "image/png", @response.headers["content-type"]
+
+    image = ::Vips::Image.new_from_buffer(@response.body, "")
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
   test "is publicly cacheable" do
     get account_og_image_url
 

--- a/test/controllers/accounts/og_images_controller_test.rb
+++ b/test/controllers/accounts/og_images_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+begin
+  require "vips"
+rescue LoadError
+  Vips = nil
+end
+
+class Accounts::OgImagesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    skip "libvips is not available" unless defined?(::Vips)
+  end
+
+  test "renders a 1200x630 png card without authentication" do
+    get account_og_image_url
+
+    assert_equal "image/png", @response.headers["content-type"]
+
+    image = ::Vips::Image.new_from_buffer(@response.body, "")
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
+  test "is publicly cacheable" do
+    get account_og_image_url
+
+    assert_match "public", @response.headers["cache-control"]
+  end
+
+  test "returns 304 when the account is unchanged" do
+    get account_og_image_url
+    etag = @response.headers["etag"]
+
+    get account_og_image_url, headers: { "If-None-Match" => etag }
+
+    assert_response :not_modified
+  end
+end

--- a/test/integration/og_image_test.rb
+++ b/test/integration/og_image_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class OgImageTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in :david
+  end
+
+  test "og:image points at the rendered account card with an absolute url" do
+    get room_url(rooms(:watercooler))
+
+    assert_select "meta[property='og:image']" do |tags|
+      assert_match %r{\Ahttps?://.+#{Regexp.escape(account_og_image_path)}}, tags.first["content"]
+    end
+  end
+
+  test "still uses the card endpoint once a logo is uploaded" do
+    accounts(:signal).update! logo: fixture_file_upload("moon.jpg", "image/jpeg")
+
+    get room_url(rooms(:watercooler))
+
+    assert_select "meta[property='og:image']" do |tags|
+      assert_includes tags.first["content"], account_og_image_path
+    end
+  end
+end

--- a/test/models/account/og_image_test.rb
+++ b/test/models/account/og_image_test.rb
@@ -28,6 +28,15 @@ class Account::OgImageTest < ActiveSupport::TestCase
     assert_equal 630, image.height
   end
 
+  test "renders names containing pango markup characters without raising" do
+    accounts(:signal).update!(name: "ACME & Co <chat>")
+
+    image = render(accounts(:signal))
+
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
   test "falls back to the app name when the account name is blank" do
     account = accounts(:signal)
 

--- a/test/models/account/og_image_test.rb
+++ b/test/models/account/og_image_test.rb
@@ -28,6 +28,27 @@ class Account::OgImageTest < ActiveSupport::TestCase
     assert_equal 630, image.height
   end
 
+  test "degrades to the stock mark when the logo blob is unreadable" do
+    accounts(:signal).logo.attach(
+      io: StringIO.new("this is not an image"), filename: "broken.png", content_type: "image/png")
+
+    image = render(accounts(:signal))
+
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
+  test "frames a non-square logo without raising or resizing the card" do
+    wide = (::Vips::Image.black(400, 100) + [ 60, 90, 200 ]).cast("uchar")
+    accounts(:signal).logo.attach(
+      io: StringIO.new(wide.write_to_buffer(".png")), filename: "wide.png", content_type: "image/png")
+
+    image = render(accounts(:signal))
+
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
   test "renders names containing pango markup characters without raising" do
     accounts(:signal).update!(name: "ACME & Co <chat>")
 

--- a/test/models/account/og_image_test.rb
+++ b/test/models/account/og_image_test.rb
@@ -29,9 +29,15 @@ class Account::OgImageTest < ActiveSupport::TestCase
   end
 
   test "falls back to the app name when the account name is blank" do
-    accounts(:signal).update_column(:name, "")
+    account = accounts(:signal)
 
-    assert_nothing_raised { render(accounts(:signal)) }
+    account.update_column(:name, "")
+    blank = Account::OgImage.new(account).png
+
+    account.update_column(:name, Branding.app_name)
+    named = Account::OgImage.new(account).png
+
+    assert_equal named, blank
   end
 
   private

--- a/test/models/account/og_image_test.rb
+++ b/test/models/account/og_image_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+begin
+  require "vips"
+rescue LoadError
+  Vips = nil
+end
+
+class Account::OgImageTest < ActiveSupport::TestCase
+  setup do
+    skip "libvips is not available" unless defined?(::Vips)
+  end
+
+  test "renders a 1200x630 card from the stock mark and account name" do
+    image = render(accounts(:signal))
+
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
+  test "composites the uploaded logo into the card" do
+    accounts(:signal).logo.attach(
+      io: File.open(file_fixture("moon.jpg")), filename: "moon.jpg", content_type: "image/jpeg")
+
+    image = render(accounts(:signal))
+
+    assert_equal 1200, image.width
+    assert_equal 630, image.height
+  end
+
+  test "falls back to the app name when the account name is blank" do
+    accounts(:signal).update_column(:name, "")
+
+    assert_nothing_raised { render(accounts(:signal)) }
+  end
+
+  private
+    def render(account)
+      ::Vips::Image.new_from_buffer(Account::OgImage.new(account).png, "")
+    end
+end


### PR DESCRIPTION
## What

Shared links to a Sabha instance now unfurl with the operator's own identity instead of a Sabha marketing image. When someone pastes their community's link into Slack, Discord, or iMessage, the preview card shows the operator's uploaded logo (or the Sabha mark as a fallback) above their account name, on a clean brand background with a small "powered by sabha" footer.

## Why

The `og:image` tag previously hardcoded a sabha.co marketing image on every self-hosted and in-app surface. A self-hoster who had set their own app name, theme, and logo still saw a literal sabha.co ad on the one surface that matters most — the share card a prospective member sees first. The card is now rendered per-instance so it reflects whoever owns the surface.

## How it works

- `og:image` points at a new account-scoped endpoint that renders a 1200×630 PNG on the fly via libvips (the same image stack already used for logo variants — no ImageMagick dependency).
- `Current.account` resolves the right identity automatically: the singleton account when self-hosted, the workspace account when running multi-tenant. The same code path therefore produces the operator's name on self-hosted and the workspace name inside a SaaS workspace.
- The card is publicly cacheable with an ETag and a `updated_at`-based cache-buster, mirroring the existing logo endpoint.
- The public sabha.co marketing layout is intentionally left untouched — it keeps its hand-made card.

## Testing

- Model, controller, and integration coverage for the rendered card, the logo-vs-stock-mark branches, the blank-name fallback, public caching, and 304 revalidation.
- Full single-tenant and multi-tenant suites pass; the card was also rendered live inside a real workspace tenant to confirm it picks up the workspace name.
