### PR TITLE
Fix stale load-test fixtures and add WebSocket capacity benchmark harness

### DIFF
--- a/docs/performance/load-testing.md
+++ b/docs/performance/load-testing.md
@@ -1,0 +1,234 @@
+# Load testing & capacity
+
+How a self-hosted Sabha instance behaves under concurrent WebSocket load, how to
+reproduce the test, and what the numbers mean for sizing a deployment.
+
+The harness lives in [`test/performance/`](../../test/performance/) (a [k6](https://k6.io)
+script plus fixtures). See [`test/performance/README.md`](../../test/performance/README.md)
+for the script-level details; this doc covers methodology, results, and recommendations.
+
+---
+
+## TL;DR
+
+On a **1 vCPU / 2 GB** VPS running Sabha v1.10.0:
+
+| WebSocket layer | Comfortable | Practical ceiling | Failure mode |
+|---|---|---|---|
+| **In-process ActionCable** (default) | ~600 concurrent | **~1,000 concurrent** | Hard crash + restart at ~1,500 |
+| **AnyCable** (anycable-go) | ~2,000 concurrent | **~3,000+ concurrent** | Graceful — slow connect, no crash |
+
+- **The bottleneck is always the single CPU core, never RAM** (memory stayed under ~950 MB of 1.9 GB at every level).
+- With **in-process ActionCable**, WebSockets share the Ruby core with the web app; holding ~1,000 idle connections already costs ~80% CPU just for keepalive.
+- **AnyCable** moves connection-holding into a Go process (~25% CPU / ~85 MB to hold 3,400 connections), roughly **2–3× the ceiling on the same box** with no crashes. The bottleneck shifts to Rails RPC throughput for *connection establishment*.
+- A **connection storm** (many clients connecting at once, e.g. after a deploy/restart) is a sharper limit than steady-state concurrency: ~167 conns/sec crashed the in-process setup even at 500 total.
+
+---
+
+## Test setup
+
+- **Target:** 1 vCPU / 2 GB / Ubuntu 24.04 VPS (DigitalOcean), the smallest spec in
+  [DEPLOYMENT.md](../DEPLOYMENT.md)'s requirements table.
+- **Image:** `ghcr.io/sabha-co/sabha:1.10.0`, run in `RAILS_ENV=performance`.
+- **Generator:** k6 on a separate machine (laptop) over the public internet, so the
+  load generator never steals CPU from the target.
+- **Seed:** `config/environments/performance.rb` auto-seeds **10,000 users + sessions,
+  201 rooms, ~11,000 memberships** on first boot. Room 1 contains *every* user.
+- **Auth:** the test authenticates as seeded users with pre-signed `session_token`
+  cookies (`SECRET_KEY_BASE=dummy`); WebSocket origin checks are disabled in the
+  performance env.
+
+Each virtual user opens a WebSocket and subscribes to the same channels a real
+room page does: `PresenceChannel`, `UserUnreadRoomsChannel`, `HeartbeatChannel`,
+and three signed `Turbo::StreamsChannel` streams.
+
+### Reproducing it
+
+```bash
+# On the target VPS — in-process ActionCable (default self-host)
+docker compose up -d            # see compose snippets below
+
+# On the generator
+ruby test/performance/create_dummy_cookies.rb > test/performance/cookies.txt
+cd test/performance
+HOST=<target-ip> PORT=3000 USERS=1000 RATE=20 HOLD=50 DURATION=80s k6 run chatter.js
+```
+
+Two non-obvious things are required to run the image in the performance env (both
+because `performance` inherits `production` but isn't `Rails.env.production?`):
+
+1. **Prepare the DB yourself.** `bin/boot` only runs `db:prepare` when
+   `RAILS_ENV=production`. Use `command: sh -c "./bin/rails db:prepare && exec ./bin/boot"`.
+2. **`SKIP_THRUSTER=1`** to expose Puma directly on `:3000` (no TLS/Thruster in front).
+
+<details>
+<summary>In-process ActionCable compose</summary>
+
+```yaml
+services:
+  web:
+    image: ghcr.io/sabha-co/sabha:1.10.0
+    command: sh -c "./bin/rails db:prepare && exec ./bin/boot"
+    environment:
+      RAILS_ENV: performance
+      SECRET_KEY_BASE: dummy
+      SKIP_THRUSTER: "1"
+      ANYCABLE_ENABLED: "false"
+      APP_HOST: <target-ip>
+    ports: ["3000:3000"]
+    volumes: ["sabha_storage:/rails/storage"]
+volumes: { sabha_storage: }
+```
+</details>
+
+<details>
+<summary>AnyCable compose</summary>
+
+```yaml
+services:
+  web:
+    image: ghcr.io/sabha-co/sabha:1.10.0
+    command: sh -c "./bin/rails db:prepare && exec ./bin/boot"
+    environment:
+      RAILS_ENV: performance
+      SECRET_KEY_BASE: dummy
+      SKIP_THRUSTER: "1"
+      ANYCABLE_ENABLED: "true"
+      CABLE_ADAPTER: any_cable      # REQUIRED — see "Gotchas" below
+      APP_HOST: <target-ip>
+    ports: ["3000:3000"]
+    volumes: ["sabha_storage:/rails/storage"]
+  anycable:
+    image: anycable/anycable-go:1.6
+    command: >
+      --host=0.0.0.0 --port=8080 --http_broadcast_port=8080
+      --rpc_host=http://web:3000/_anycable --broadcast_adapter=http
+      --secret=test-secret --streams_whisper
+    ports: ["8080:8080"]
+    depends_on: [web]
+volumes: { sabha_storage: }
+```
+
+With AnyCable, k6 connects WS to `:8080` but posts HTTP to `:3000`
+(`WS_PORT=8080 PORT=3000`).
+</details>
+
+---
+
+## Results — in-process ActionCable (default)
+
+Connections established *gently* (~15–20/sec) and held open:
+
+| Concurrent | WS errors | Handshake (p95) | Steady CPU | Verdict |
+|---:|---:|---:|---:|---|
+| 200 | 0 | ~0.3 s | ~5% | Trivial |
+| 600 | 0 | 0.28 s | ~45% | Healthy |
+| 1,000 | 0 | 0.61 s | **~80%** (peaks 98%) | At the edge |
+| 1,500 | **674** | **22.7 s** | 100% | **Crash + restart** |
+
+- **Holding connections isn't free.** ActionCable keepalive pings + presence
+  refreshes across N sockets run on the single Ruby core: ~1,000 idle connections
+  already consume ~80% CPU, leaving no headroom for messages or new connections.
+- **At ~1,500 the process died and was restarted** by Docker (`restart: unless-stopped`)
+  — handshakes blew out to 20–30 s and ~674 connections errored. The box has **no
+  swap**, so CPU saturation tips into an abrupt OOM-style process kill rather than
+  graceful slowdown.
+
+### Connection storms are a separate, sharper limit
+
+The same 1,000 connections that held fine at 20/sec **crashed the box when
+established at 167/sec** (1,000+ errors, 10 s handshakes). Real users don't connect
+that fast — but they do all reconnect at once after a deploy or restart. A 1 vCPU
+in-process self-host tolerates roughly **≤ 25 new connections/sec**.
+
+---
+
+## Results — AnyCable
+
+Same box, WebSockets offloaded to anycable-go:
+
+| Concurrent | Handshake (median / p95) | web CPU | anycable-go CPU / RAM | Verdict |
+|---:|---|---:|---|---|
+| 2,000 | 19 ms / 21 s | ~65% | **~20% / ~90 MB** | Clean, no crash |
+| ~3,400 | 5 s / 30 s (timeout) | ~65% | **~25% / ~85 MB** | Held, no crash; establishment-bound |
+
+- **anycable-go holds thousands of connections for almost nothing** — ~85 MB of RAM
+  and ~25% CPU at 3,400 connections. Connection-holding is no longer the limit.
+- **No crashes** at any level (vs ActionCable crashing at 1,500).
+- The new bottleneck is **Rails RPC for connection *establishment***: every connect +
+  subscribe is an HTTP RPC call back to Rails, and Puma's default 5 threads (plus
+  SQLite write contention on presence/subscribe) cap establishment throughput. Note
+  web CPU was only ~65% even when handshakes timed out — it's thread/IO-bound on RPC,
+  not CPU-bound. Raising `RAILS_MAX_THREADS` would push the establishment ceiling higher.
+
+### CPU split tells the story
+
+At ~2,000 concurrent: **anycable-go ~20% CPU** (holding sockets) vs **web ~65%**
+(RPC auth/subscribe + jobs). AnyCable did exactly what it's for — it took persistent
+connections out of the Ruby process.
+
+---
+
+## Message throughput (both modes)
+
+Posting a message is dominated by **room membership size**, not the cable layer.
+Room 1 in the seed has all 10,000 users, so each post fans out unread/notification
+work to every member: it **pegs the Ruby core at 100% for ~2.5–4 s per message**.
+A normal 50–200-member room is far cheaper. This is a separate scaling axis from
+connection count — large rooms are expensive to post into regardless of ActionCable
+vs AnyCable.
+
+---
+
+## Gotchas discovered
+
+These tripped up the test and are worth knowing (or fixing):
+
+- **`performance` cable.yml ignores `ANYCABLE_ENABLED`.** Unlike `production`, the
+  `performance:` block resolves the adapter from `ENV.fetch("CABLE_ADAPTER", "redis")`.
+  So `ANYCABLE_ENABLED=true` alone leaves ActionCable on the **redis** adapter and
+  Turbo broadcasts go to Redis (which anycable-go never reads) — connections work but
+  **no messages are delivered**. You must also set `CABLE_ADAPTER=any_cable`.
+  *Consider mirroring production's `ANYCABLE_ENABLED` check in the performance block.*
+- **anycable-go must bind `--host=0.0.0.0`** in Docker, or it listens on localhost
+  inside the container and docker-proxy can't reach it.
+- **Disabling broadcast batching floods anycable-go.** With `broadcast_batching: true`
+  (the default), per-member broadcasts for a large room are aggregated into one POST;
+  with it off, each becomes a separate HTTP POST and delivery degrades under load.
+
+The load-test fixtures themselves were also stale and were corrected: the signed
+Turbo stream names referenced the pre-fork `gid://campfire/...` app name, and the
+dummy cookie generator derived keys with SHA1 instead of the SHA256 that
+`load_defaults 8.2` uses (so no cookie would authenticate). See
+[`test/performance/README.md`](../../test/performance/README.md).
+
+---
+
+## Recommendations
+
+For a self-hosted Sabha instance:
+
+1. **Enable AnyCable once you expect more than a few hundred concurrent users.** On a
+   1 vCPU box it roughly tripled the connection ceiling and removed the crash cliff.
+   The Kamal deployment ([DEPLOYMENT.md](../DEPLOYMENT.md)) wires this up by default.
+2. **Add 1–2 GB of swap.** With none, CPU saturation kills and restarts the app
+   process instead of degrading gracefully.
+3. **Size for reconnect storms, not just steady state.** The worst load is everyone
+   reconnecting after a restart. AnyCable's `restore_from_cache` helps; staggering
+   client reconnects helps more.
+4. **With AnyCable, raise `RAILS_MAX_THREADS`** (and watch SQLite contention) to lift
+   the RPC establishment ceiling — that, not connection-holding, becomes the limit.
+5. **Watch room sizes.** Posting into rooms with thousands of members is CPU-heavy
+   regardless of the cable layer (per-member unread fan-out).
+
+### Rough sizing guide
+
+| Concurrent users | Suggested setup |
+|---|---|
+| < 300 | 1 vCPU / 2 GB, in-process ActionCable |
+| 300–1,000 | 2 vCPU / 4 GB, in-process ActionCable (or AnyCable) |
+| 1,000–5,000 | AnyCable, 2–4 vCPU / 4–8 GB, tuned Puma threads |
+| 5,000+ | AnyCable on dedicated nodes; revisit SQLite vs scaling story |
+
+*Numbers measured on Sabha v1.10.0, single 1 vCPU / 2 GB VPS, June 2026. Treat as
+order-of-magnitude guidance, not guarantees — re-measure for your own workload.*

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,0 +1,163 @@
+# Performance / load testing
+
+A [k6](https://k6.io) load test (`chatter.js`) that simulates many users idling on
+ActionCable WebSockets while one user posts messages, exercising the real-time
+broadcast fan-out.
+
+## How it works
+
+Two generated fixtures feed the test, k6 drives two scenarios against the target,
+and the loop is closed by measuring whether broadcasts come back:
+
+```
+  FIXTURES (generated once)
+    create_dummy_cookies.rb ─▶ cookies.txt   10k signed session_token cookies
+    signed_stream_names.rb  ─▶ chatter.js    signed Turbo::StreamsChannel names
+                                   │
+                                   ▼
+  ┌─────────────────────────────────────────────────────────────┐
+  │  k6  (chatter.js)  — load generator, runs OFF the target box │
+  │                                                             │
+  │   sockets scenario                 messages scenario        │
+  │   open + hold N WebSockets         1 user posts messages    │
+  │   (RATE/sec, HELD for HOLDs)       (starts at 30s)          │
+  └───────┬─────────────────────────────────────┬───────────────┘
+          │ ① ws://HOST:WS_PORT/cable            │ ② POST http://HOST:PORT
+          │    Cookie: session_token=<dummy>     │    /rooms/1/messages
+          ▼                                      ▼
+  ┌─────────────────────────────────────────────────────────────┐
+  │  SABHA TARGET   RAILS_ENV=performance, SECRET_KEY_BASE=dummy │
+  │                                                             │
+  │  WebSocket layer (pick one):                                │
+  │    • in-process ActionCable ── Puma :3000 /cable            │
+  │    • AnyCable ── anycable-go :8080 ──RPC──▶ Rails /_anycable │
+  │                                                             │
+  │  ① connect  → verify signed cookie → Session → Current.user │
+  │     subscribe→ PresenceChannel, UserUnreadRoomsChannel,     │
+  │                HeartbeatChannel, 3× Turbo::StreamsChannel    │
+  │                                                             │
+  │  ② create Message → broadcast_append_to room, :messages     │
+  │                          (stream gid://sabha/...:messages)  │
+  └───────────────────────────────┬─────────────────────────────┘
+                                  │ ③ fan-out to every subscriber
+                                  ▼
+   each held socket receives  <turbo-stream action="append">  …
+   k6 tallies it as the  `appends_received`  metric  ◀── closes the loop
+```
+
+The signed cookies (①) and signed stream names (②/③) only validate when the
+target boots with `SECRET_KEY_BASE=dummy` and the GlobalID app name `sabha` —
+which is why both fixtures are regenerable (see below). Run the generator on a
+**separate machine** from the target, or the two contend for CPU and the numbers
+measure contention rather than capacity.
+
+## Preconditions
+
+The test authenticates thousands of fake users against a dedicated environment
+seeded with matching data. Three things must line up:
+
+1. **`RAILS_ENV=performance`** — `config/environments/performance.rb` inherits
+   production, disables ActionCable origin checking, and (on first boot) seeds
+   10k users + sessions, 200 rooms, and memberships. Room 1 has every user as a
+   member, which is the room the load test targets.
+
+2. **`SECRET_KEY_BASE=dummy`** — both the session cookies and the signed Turbo
+   stream names are generated with this secret. The perf server must boot with
+   it, or every connection is rejected and no broadcasts are received.
+
+3. **`cookies.txt`** — k6 reads auth cookies from this file (not checked in).
+
+## Running
+
+```bash
+# 1. Generate the session cookies (one signed session_token per seeded user).
+ruby create_dummy_cookies.rb > cookies.txt
+
+# 2. Boot the app in the performance env (seeds on first run).
+SECRET_KEY_BASE=dummy RAILS_ENV=performance bin/rails server
+
+# 3. Run k6 (Docker reaches the host via host.docker.internal).
+#    USERS = concurrent WebSocket connections to open.
+docker run --rm -i \
+  -e HOST=localhost -e PORT=3000 -e USERS=1000 \
+  -v "$PWD:/scripts" -w /scripts grafana/k6 run chatter.js
+```
+
+The `sockets` scenario opens WebSocket connections, each subscribing to
+`PresenceChannel`, `UserUnreadRoomsChannel`, `HeartbeatChannel`, and the signed
+Turbo streams. After 30s the `messages` scenario POSTs messages to room 1;
+connected sockets count broadcasts via the `appends_received` metric in the k6
+summary.
+
+### Parameters (env vars)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `HOST` | — | Target host/IP (`localhost` maps to `host.docker.internal`) |
+| `PORT` | — | HTTP port for `/rooms` and `/messages` (e.g. `3000`) |
+| `WS_PORT` | `PORT` | WebSocket port — `3000` for in-process ActionCable, `8080` for anycable-go |
+| `USERS` | `500` | Size of the cookie pool to draw from |
+| `RATE` | `USERS/3` | New connections per second (establishment rate) |
+| `HOLD` | `50` | Seconds each socket stays open |
+| `VUS` | `USERS` | Max concurrent virtual users (caps the plateau) |
+| `DURATION` | `60s` | How long the sockets scenario runs |
+| `MSG_COUNT` | `100` | Messages the `messages` scenario posts (set `0` to skip) |
+
+Steady-state concurrency is roughly `RATE × HOLD` (capped by `VUS`). To probe
+*holding* capacity, establish gently (low `RATE`, high `HOLD`); to probe a
+*connection storm*, raise `RATE`. For a capacity ramp, see
+[`docs/performance/load-testing.md`](../../docs/performance/load-testing.md).
+
+## Regenerating the signed stream names
+
+`chatter.js` hardcodes signed `Turbo::StreamsChannel` names. They encode
+GlobalIDs (`gid://sabha/...`) and are signed with `SECRET_KEY_BASE`, so they
+break if either the app name or the secret changes. Regenerate and paste the
+output into `chatter.js`:
+
+```bash
+ruby signed_stream_names.rb            # defaults: SECRET_KEY_BASE=dummy, GID_APP=sabha
+```
+
+Both this and `create_dummy_cookies.rb` reproduce Rails/Turbo signing using the
+framework defaults (signed-cookie salt, 1000-iteration SHA256 key generator,
+JSON serializer). The Gemfile pins Rails to a GitHub ref, so if those internal
+defaults ever change upstream, these generators must be updated to match.
+
+## Differences from Campfire's load-test script
+
+This harness was inherited verbatim from [once-campfire](https://github.com/basecamp/once-campfire)
+(`test/performance/`). The seed, the k6 scenarios, and the overall approach are the
+same. The differences are fork-drift fixes, capability additions, and a shared
+latent bug:
+
+| | once-campfire | Sabha |
+|---|---|---|
+| **Signed stream names** | `gid://campfire/...` (correct for Campfire) | `gid://sabha/...` — updated for the renamed GlobalID app |
+| **Channel name** | `UnreadRoomsChannel` | `UserUnreadRoomsChannel` (renamed in Sabha) |
+| **Cookie key digest** | SHA1 `KeyGenerator` | **SHA256** (matches `load_defaults 8.2`) |
+| **Parameters** | hardcoded `duration: 60s`, `rate = USERS/3` | `RATE`, `HOLD`, `VUS`, `DURATION`, `MSG_COUNT` — establishment rate decoupled from concurrency |
+| **WS vs HTTP port** | single `PORT` | separate `WS_PORT` (so the same script drives ActionCable `:3000` or anycable-go `:8080`) |
+| **Delivery measurement** | `console.log` per frame | `appends_received` / `subscriptions_confirmed` metrics |
+| **Socket lifecycle** | left open until scenario stop | explicit `HOLD` then clean close |
+| **AnyCable path** | none (Campfire has no AnyCable) | added (`WS_PORT=8080`) |
+
+Two of these matter beyond cosmetics:
+
+- **The SHA256 fix is a real correction, and once-campfire still has the bug.** Both
+  repos are on `load_defaults 8.2`, which derives keys with SHA256, but the inherited
+  `create_dummy_cookies.rb` used the `KeyGenerator` SHA1 default. Under 8.2 those dummy
+  cookies never authenticate — so Campfire's committed harness is broken the same way
+  Sabha's was, just unnoticed.
+- **Decoupling rate from concurrency changed what we could measure.** Campfire's
+  `rate = USERS/3` means "500 users" is silently a 167-conn/sec *storm*; you can't tell
+  a holding-capacity limit from a connection-storm limit. The `RATE`/`HOLD`/`VUS`
+  parameters are what let the benchmark separate "~600 held fine" from "167/sec
+  crashed it."
+
+Topology also differs: Campfire's `host.docker.internal` default points at an app on
+the **same machine** (k6-in-Docker against localhost) — a co-located smoke test, where
+generator and target share CPU. The capacity benchmark in
+[`docs/performance/load-testing.md`](../../docs/performance/load-testing.md) runs the
+generator on a **separate machine** against a dedicated target, which is required to
+measure a real ceiling.

--- a/test/performance/chatter.js
+++ b/test/performance/chatter.js
@@ -2,33 +2,57 @@ import ws from 'k6/ws';
 import http from 'k6/http';
 import papaparse from 'https://jslib.k6.io/papaparse/5.1.1/index.js';
 import { SharedArray } from 'k6/data';
+import { Counter, Trend } from 'k6/metrics';
 
+// k6 load test: opens WebSockets that subscribe like a real room page, and (after
+// 30s) posts messages to exercise broadcast fan-out. Delivery is tracked via
+// metrics rather than console.log so high message rates don't flood stdout and
+// skew results. Parameterized via env (see README.md):
+//   HOST, PORT (HTTP), WS_PORT (defaults to PORT), USERS (cookie pool),
+//   RATE (new conns/sec), HOLD (sec/conn), VUS (max concurrency), DURATION, MSG_COUNT
+// Steady-state concurrency ~= RATE * HOLD (capped by VUS).
+
+const appendsReceived = new Counter('appends_received');     // real message broadcasts delivered to sockets
+const subsConfirmed   = new Counter('subscriptions_confirmed');
+const wsErrors        = new Counter('ws_errors');
+const postDuration    = new Trend('message_post_duration', true);
+
+// Signed Turbo stream names for room 1's `messages` stream and user 1's `rooms`
+// stream (gid://sabha/..., SECRET_KEY_BASE=dummy). See test/performance/README.md.
 const turboSignedStreamNames = [
   "InJvb21zIg==--54acd827f0a7db144c75316a9fc488c0a949f9635b1e47956ce1bd9d1cf2c41d",
-  "IloybGtPaTh2WTJGdGNHWnBjbVV2VW05dmJYTTZPa05zYjNObFpDOHg6bWVzc2FnZXMi--84f0f3dde5d23eb0fdb410746c2fb76813a4ddff1e2798aac4be0c3d969702ba",
-  "IloybGtPaTh2WTJGdGNHWnBjbVV2VlhObGNpOHg6cm9vbXMi--df547a679cd41f7531b53d9e48f9883c02481a4da0d862453106441d8546d084"
+  "IloybGtPaTh2YzJGaWFHRXZVbTl2YlhNNk9rTnNiM05sWkM4eDptZXNzYWdlcyI=--cb2cb75566e57c00ffee6a6c50e78ce5216e151422e03c11917e8fe4a1706fbd",
+  "IloybGtPaTh2YzJGaWFHRXZWWE5sY2k4eDpyb29tcyI=--42a94033d5823d82bcafce1d88911270a1ca74f1eb015206bb4156166613dc12"
 ];
 
-const dummyCookies = new SharedArray('another data name', function () {
-  // Load CSV file and parse it using Papa Parse
+const dummyCookies = new SharedArray('cookies', function () {
   return papaparse.parse(open('cookies.txt'), { header: false }).data;
 });
 
 const host = __ENV.HOST == "localhost" ? "host.docker.internal" : __ENV.HOST;
-const port = __ENV.PORT ? `:${__ENV.PORT}` : "";
-const users = parseInt(__ENV.USERS)
+const port = __ENV.PORT ? `:${__ENV.PORT}` : "";              // HTTP (Rails): /rooms, /messages
+const wsPort = __ENV.WS_PORT ? `:${__ENV.WS_PORT}` : port;    // WS: :3000 (ActionCable) or :8080 (anycable-go)
+const users = parseInt(__ENV.USERS || '500');           // cookie pool size to draw from
+const duration = __ENV.DURATION || '60s';
+const msgCount = parseInt(__ENV.MSG_COUNT || '100');
+const holdSeconds = parseInt(__ENV.HOLD || '50');       // how long each socket stays open
+// Establishment rate (new conns/sec) decoupled from target concurrency.
+// Steady-state concurrency ~= RATE * HOLD. VUS caps the plateau.
+const rate = parseInt(__ENV.RATE || String(Math.ceil(users / 3.0)));
+const vus = parseInt(__ENV.VUS || String(users));
 
 export const options = {
   discardResponseBodies: true,
   scenarios: {
     sockets: {
       executor: 'constant-arrival-rate',
-      duration: '60s',
-      rate: Math.ceil(users / 3.0),
+      duration: duration,
+      rate: rate,
       timeUnit: '1s',
-      preAllocatedVUs: users,
+      preAllocatedVUs: vus,
+      maxVUs: vus,
       env: { SCENARIO: 'sockets' },
-      gracefulStop: "0s"
+      gracefulStop: "2s"
     },
     messages: {
       executor: 'shared-iterations',
@@ -36,7 +60,7 @@ export const options = {
       vus: 1,
       startTime: '30s',
       env: { SCENARIO: 'messages' },
-      gracefulStop: "0s"
+      gracefulStop: "10s"
     },
   },
 };
@@ -50,15 +74,14 @@ export default function() {
 }
 
 export function sockets() {
-  const cookie = dummyCookies[Math.floor(Math.random() * parseInt(__ENV.USERS))][0];
-  const url = `ws://${host}${port}/cable`;
+  const cookie = dummyCookies[Math.floor(Math.random() * users)][0];
+  const url = `ws://${host}${wsPort}/cable`;
   const params = {
     headers: { 'Origin': `http://localhost`, 'Cookie': `session_token=${cookie}` }
   };
 
   ws.connect(url, params, function(socket) {
     socket.on('open', function open() {
-      // Subscribe to an ActionCable channel
       socket.send(JSON.stringify({ command: 'subscribe', identifier: '{"channel":"PresenceChannel", "room_id":1}' }));
       socket.send(JSON.stringify({ command: 'subscribe', identifier: '{"channel":"UserUnreadRoomsChannel"}' }));
       socket.send(JSON.stringify({ command: 'subscribe', identifier: '{"channel":"HeartbeatChannel"}' }));
@@ -66,19 +89,22 @@ export function sockets() {
         socket.send(JSON.stringify({ command: 'subscribe', identifier: `{"channel":"Turbo::StreamsChannel", "signed_stream_name":"${signedStreamName}"}` }));
       });
 
-      // Handle incoming messages
       socket.on('message', function(message) {
         if (message.includes("confirm_subscription")) {
-          console.log("Subscription confirmed");
+          subsConfirmed.add(1);
         } else if (message.includes("append")) {
-          console.log("Message received");
+          appendsReceived.add(1);
         }
       });
+
+      // Hold the connection open for the steady-state window, then close cleanly.
+      socket.setTimeout(function () { socket.close(); }, holdSeconds * 1000);
     });
 
     socket.on('error', function(e) {
       if (e.error() != 'websocket: close sent') {
-        console.log('An unexpected error occurred: ', e.error());
+        wsErrors.add(1);
+        console.log('ws error: ', e.error());
       }
     });
   });
@@ -88,20 +114,22 @@ export function messages() {
   const cookie = `session_token=${dummyCookies[0][0]}`;
 
   const response = http.get(`http://${host}${port}/rooms/1`, { headers: { "Cookie": cookie }, responseType: "text" });
-  const csrfToken = response.body.match(/<meta name="csrf-token" content="([^"]*)"/i)[1];
+  const m = response.body && response.body.match(/<meta name="csrf-token" content="([^"]*)"/i);
+  if (!m) { console.log(`messages: could not read csrf token (status ${response.status})`); return; }
+  const csrfToken = m[1];
 
   const postHeaders = {
     "Cookie": cookie,
     "Accept": "text/vnd.turbo-stream.html, text/html, application/xhtml+xml"
+  };
+
+  for (let i = 0; i < msgCount; i++) {
+    const payload = {
+      "message[body]": `Hello from k6 #${i}`,
+      "message[client_message_id]": `${i}-${Math.random().toString(36)}`,
+      "authenticity_token": csrfToken
+    };
+    const res = http.post(`http://${host}${port}/rooms/1/messages`, payload, { headers: postHeaders, responseType: "text" });
+    postDuration.add(res.timings.duration);
   }
-
-  const payload = {
-    "message[body]": "Hello from k6",
-    "message[client_message_id]": Math.random().toString(36),
-    "authenticity_token": csrfToken
-  };
-
-  for (let i = 0; i < 100; i++) {
-    http.post(`http://${host}${port}/rooms/1/messages`, payload, { headers: postHeaders, responseType: "text" });
-  };
 }

--- a/test/performance/create_dummy_cookies.rb
+++ b/test/performance/create_dummy_cookies.rb
@@ -1,6 +1,13 @@
 require "active_support/all"
 
-key_generator = ActiveSupport::KeyGenerator.new("dummy", iterations: 1000)
+# Mirrors how Rails derives and verifies the signed `session_token` cookie, so the
+# load test can authenticate as the users seeded by config/environments/performance.rb.
+# All of these track Rails defaults (load_defaults 8.2): the "signed cookie" salt, a
+# SHA256-derived key generator, a SHA1 message verifier, and the JSON-serialized,
+# purpose-scoped cookie. The token is JSON-encoded by hand (quotes) and signed with
+# the NullSerializer so the bytes match what the :json cookie serializer produces.
+secret = ENV.fetch("SECRET_KEY_BASE", "dummy")
+key_generator = ActiveSupport::KeyGenerator.new(secret, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA256)
 signed_cookie_secret = key_generator.generate_key("signed cookie")
 signed_cookie_verifier = ActiveSupport::MessageVerifier.new(signed_cookie_secret, digest: "SHA1", serializer: ActiveSupport::MessageEncryptor::NullSerializer)
 

--- a/test/performance/signed_stream_names.rb
+++ b/test/performance/signed_stream_names.rb
@@ -1,0 +1,41 @@
+require "active_support/all"
+require "json"
+require "openssl"
+require "base64"
+
+# Regenerates the signed Turbo::StreamsChannel names baked into chatter.js.
+#
+# These must match what the running app broadcasts to, which depends on two
+# things that drifted once already (the GlobalID app name flipped from
+# "campfire" to "sabha" during the fork):
+#
+#   * SECRET_KEY_BASE — the load test boots the perf env with "dummy"
+#   * the GlobalID app name — derived from the app module (Sabha => "sabha")
+#
+# Run with the same values the perf server uses, then paste the output into
+# chatter.js:
+#
+#   ruby signed_stream_names.rb
+#   SECRET_KEY_BASE=dummy GID_APP=sabha ruby signed_stream_names.rb
+#
+# Mirrors Turbo::StreamsChannel signing (turbo-rails): the verifier key is
+# derived via Rails' key generator and the name is JSON-serialized + signed.
+
+secret = ENV.fetch("SECRET_KEY_BASE", "dummy")
+gid_app = ENV.fetch("GID_APP", "sabha")
+
+key = ActiveSupport::KeyGenerator
+  .new(secret, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA256)
+  .generate_key("turbo/signed_stream_verifier_key")
+verifier = ActiveSupport::MessageVerifier.new(key, digest: "SHA256", serializer: JSON)
+
+# `to_gid_param` base64-encodes the GlobalID; streamables are joined with ":".
+gid_param = ->(model, id) { Base64.urlsafe_encode64("gid://#{gid_app}/#{model}/#{id}", padding: false) }
+stream    = ->(*parts) { verifier.generate(parts.join(":")) }
+
+# Streams a member on room 1's page subscribes to. The second one — room 1's
+# `messages` stream — is where Message#broadcast_create appends, so it's the one
+# that actually exercises message fan-out.
+puts stream.call("rooms")
+puts stream.call(gid_param.call("Rooms::Closed", 1), "messages")
+puts stream.call(gid_param.call("User", 1), "rooms")


### PR DESCRIPTION
The load-test harness under `test/performance/` was inherited from Campfire and had drifted out of sync with the app, so it silently no longer authenticated or delivered messages. This repairs it and turns it into a real capacity benchmark.

## Fixes
- **Cookie signing was broken.** `create_dummy_cookies.rb` derived signing keys with SHA1, but `load_defaults 8.2` uses SHA256 — so every dummy cookie was rejected and no connection authenticated. Now uses SHA256; verified a generated cookie authenticates `GET /rooms/1 → 200` against a live v1.10.0 instance.
- **Signed stream names were stale.** They still encoded the pre-fork `gid://campfire/...` GlobalID app, so broadcasts went to a stream nothing published to. Regenerated for `gid://sabha/...`; verified sockets now receive `append` broadcasts.

## Harness
- Parameterized establishment rate, hold time, concurrency cap, duration, and message count, with separate WebSocket/HTTP ports so the same script drives in-process ActionCable (`:3000`) or anycable-go (`:8080`).
- Replaced per-frame `console.log` with k6 metrics, and added a `signed_stream_names.rb` regenerator so the names can't silently rot again.

## Docs
- `docs/performance/load-testing.md` — methodology, ActionCable vs AnyCable capacity results on a 1 vCPU / 2 GB box, the config gotchas hit along the way, and a sizing guide.
- `test/performance/README.md` — preconditions, a flow diagram, parameter reference, and how this differs from Campfire's script.

Note: the SHA256 cookie issue also exists in once-campfire's committed harness (same `load_defaults 8.2`), so it's likely broken there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
