### PR TITLE
Close a sub-room access leak in RoomScoped controllers

### DIFF
--- a/app/controllers/api/bots/base_controller.rb
+++ b/app/controllers/api/bots/base_controller.rb
@@ -13,7 +13,7 @@ class API::Bots::BaseController < ApplicationController
     # keep granting it. Raises (→ 404) when unreachable, like `rooms.find` did.
     def reachable_bot_room(id)
       room = Current.user.rooms.find(id)
-      raise ActiveRecord::RecordNotFound if room.sub_room? && !room.viewable_by?(Current.user)
+      raise ActiveRecord::RecordNotFound if room.stale_sub_room_for?(Current.user)
       room
     end
 

--- a/app/controllers/concerns/room_scoped.rb
+++ b/app/controllers/concerns/room_scoped.rb
@@ -9,21 +9,20 @@ module RoomScoped
     def set_room
       @membership = Current.user.memberships.find_by!(room_id: params[:room_id])
       @room = @membership.room
-      enforce_sub_room_access!
+      ensure_sub_room_access
     end
 
     def set_room_if_found
       @membership = Current.user.memberships.find_by(room_id: params[:room_id])
       @room = @membership&.room
-      enforce_sub_room_access!
+      ensure_sub_room_access
     end
 
-    # A sub-room membership row never grants access on its own — access derives
-    # from the parent room. Removal only silences a follow (the row stays active),
-    # so a stale row still resolves above; re-check derived access the same way
-    # SubRoomAccessible and User#reachable_room do, and deny when it's gone.
-    def enforce_sub_room_access!
-      raise ActiveRecord::RecordNotFound if @room&.sub_room? && !@room.viewable_by?(Current.user)
+    # A sub-room follow row can outlive the parent access that justified it, so
+    # deny one the user can no longer reach — the same re-check SubRoomAccessible
+    # and User#reachable_room apply.
+    def ensure_sub_room_access
+      raise ActiveRecord::RecordNotFound if @room&.stale_sub_room_for?(Current.user)
     end
 
     def ensure_can_administer

--- a/app/controllers/concerns/room_scoped.rb
+++ b/app/controllers/concerns/room_scoped.rb
@@ -9,11 +9,21 @@ module RoomScoped
     def set_room
       @membership = Current.user.memberships.find_by!(room_id: params[:room_id])
       @room = @membership.room
+      enforce_sub_room_access!
     end
 
     def set_room_if_found
       @membership = Current.user.memberships.find_by(room_id: params[:room_id])
       @room = @membership&.room
+      enforce_sub_room_access!
+    end
+
+    # A sub-room membership row never grants access on its own — access derives
+    # from the parent room. Removal only silences a follow (the row stays active),
+    # so a stale row still resolves above; re-check derived access the same way
+    # SubRoomAccessible and User#reachable_room do, and deny when it's gone.
+    def enforce_sub_room_access!
+      raise ActiveRecord::RecordNotFound if @room&.sub_room? && !@room.viewable_by?(Current.user)
     end
 
     def ensure_can_administer

--- a/app/controllers/concerns/sub_room_accessible.rb
+++ b/app/controllers/concerns/sub_room_accessible.rb
@@ -17,6 +17,6 @@ module SubRoomAccessible
     # a member removed from the parent loses it immediately rather than riding an
     # orphaned row. A non-sub-room (a normal sidebar room) passes through untouched.
     def deny_stale_sub_room(room)
-      room unless room&.sub_room? && !room.viewable_by?(Current.user)
+      room unless room&.stale_sub_room_for?(Current.user)
     end
 end

--- a/app/controllers/rooms/stars_controller.rb
+++ b/app/controllers/rooms/stars_controller.rb
@@ -24,6 +24,6 @@ class Rooms::StarsController < ApplicationController
   private
 
   def ensure_starrable
-    head :unprocessable_entity if @room.direct? || @room.thread? || @room.post? || @membership.involved_in_invisible?
+    head :unprocessable_entity if @room.direct? || @room.sub_room? || @membership.involved_in_invisible?
   end
 end

--- a/app/models/bot/event_payload.rb
+++ b/app/models/bot/event_payload.rb
@@ -77,7 +77,7 @@ module Bot::EventPayload
 
     private
       def thread_to_api(message)
-        return nil unless message.room.thread? || message.room.post?
+        return nil unless message.room.sub_room?
         { id: message.room.id, parent_message_id: message.room.parent_message_id }
       end
 

--- a/app/models/message/threadable.rb
+++ b/app/models/message/threadable.rb
@@ -26,7 +26,7 @@ module Message::Threadable
     end
 
     def update_thread_reply_count
-      return unless room.thread? || room.post?
+      return unless room.sub_room?
 
       # A chat thread's messages are all replies; a post's exclude the OP.
       count = room.post? ? room.replies_count : room.messages_count

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -324,7 +324,7 @@ class Room < ApplicationRecord
       .where(user_id: bot_ids)
       .includes(user: :webhook)
 
-    if direct? || thread? || post?
+    if direct? || sub_room?
       eligible.to_a
     elsif item.is_a?(Message) && event == :created
       eligible.to_a.select { |m| item.mentionees.include?(m.user) || item.mentions_everyone? }

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -164,6 +164,15 @@ class Room < ApplicationRecord
     user.present? && memberships.active.exists?(user_id: user.id)
   end
 
+  # A sub-room reached only through a membership row that outlived its access:
+  # removal silences a follow but leaves the row active, so it still resolves even
+  # though the parent-derived access is gone. Non-sub-rooms are never stale — for
+  # them the membership row IS the access. Callers that resolve a room from a
+  # membership (RoomScoped, SubRoomAccessible, User#reachable_room) deny on this.
+  def stale_sub_room_for?(user)
+    sub_room? && !viewable_by?(user)
+  end
+
   def default_involvement(user: nil)
     "mentions"
   end

--- a/app/models/room/announceable.rb
+++ b/app/models/room/announceable.rb
@@ -20,7 +20,7 @@ module Room::Announceable
 
   private
     def announce_creation
-      return if direct? || thread? || post?
+      return if direct? || sub_room?
       return unless User.active.where.not(id: creator_id).exists? # No audience on fresh setup
       post_system_message(event: "room_created", body: "created the room", actor: creator)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,7 @@ class User < ApplicationRecord
   # backs the controllers that resolve a room from params.
   def reachable_room(id)
     room = rooms.find_by(id:) || Room.active.sub_rooms.find_by(id:)
-    room unless room&.sub_room? && !room.viewable_by?(self)
+    room unless room&.stale_sub_room_for?(self)
   end
 
   def active_invite_link

--- a/app/views/messages/_actions.html.erb
+++ b/app/views/messages/_actions.html.erb
@@ -1,7 +1,7 @@
 <%# Be sure to check/update messages/_template.html.erb when changing this file %>
 <%# locals: (message:, current_room: nil) -%>
 
-<% show_thread_actions = !message.room.direct? && !current_room&.thread? && !message.room.thread? && !message.room.post? %>
+<% show_thread_actions = !message.room.direct? && !current_room&.thread? && !message.room.sub_room? %>
 <% existing_thread = message.threads.find { |t| t.active? } if show_thread_actions %>
 
 <div class="message__actions" data-controller="soft-keyboard">

--- a/test/integration/thread_access_characterization_test.rb
+++ b/test/integration/thread_access_characterization_test.rb
@@ -212,11 +212,7 @@ class ThreadAccessCharacterizationTest < ActionDispatch::IntegrationTest
   # a room the member can no longer open — a message-content / roster leak.
 
   test "a removed member cannot read new thread messages via the RoomScoped refresh endpoint" do
-    closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
-    closed.memberships.grant_to([ @creator, @member ])
-    parent = closed.messages.create!(body: "topic", creator: @creator)
-    thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
-    Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+    closed, thread = engaged_thread_in_closed_room
 
     closed.remove_member!(@member, actor: @creator)
     ThreadFollowCleanupJob.perform_now(room: closed, user: @member)
@@ -229,11 +225,7 @@ class ThreadAccessCharacterizationTest < ActionDispatch::IntegrationTest
   end
 
   test "a removed member cannot read the members roster of a thread they lost access to" do
-    closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
-    closed.memberships.grant_to([ @creator, @member ])
-    parent = closed.messages.create!(body: "topic", creator: @creator)
-    thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
-    Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+    closed, thread = engaged_thread_in_closed_room
 
     closed.remove_member!(@member, actor: @creator)
     ThreadFollowCleanupJob.perform_now(room: closed, user: @member)
@@ -245,14 +237,22 @@ class ThreadAccessCharacterizationTest < ActionDispatch::IntegrationTest
   end
 
   test "a current member who follows a thread still reaches it through RoomScoped" do
-    closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
-    closed.memberships.grant_to([ @creator, @member ])
-    parent = closed.messages.create!(body: "topic", creator: @creator)
-    thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
-    Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+    closed, thread = engaged_thread_in_closed_room
 
     sign_in :jason
     get room_refresh_url(thread, format: :turbo_stream), params: { since: 10.minutes.ago.to_fs(:epoch) }
     assert_response :success, "a current parent member keeps access — no regression from the gate"
   end
+
+  private
+    # A private room with a chat thread the member has engaged in (so a follow row
+    # exists) — the arrange every RoomScoped-gate test starts from.
+    def engaged_thread_in_closed_room
+      closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
+      closed.memberships.grant_to([ @creator, @member ])
+      parent = closed.messages.create!(body: "topic", creator: @creator)
+      thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
+      Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+      [ closed, thread ]
+    end
 end

--- a/test/integration/thread_access_characterization_test.rb
+++ b/test/integration/thread_access_characterization_test.rb
@@ -204,4 +204,55 @@ class ThreadAccessCharacterizationTest < ActionDispatch::IntegrationTest
     assert_equal before, @member.reload.memberships.unread.count,
       "thread activity must not raise an unread badge for a passive parent member"
   end
+
+  # ---- RoomScoped gate: derived access re-checked at the controller --------
+  # RoomScoped resolves @room straight from Current.user.memberships. A removed
+  # member's sub-room follow stays active (only silenced), so without a
+  # viewable_by? re-check the RoomScoped endpoints (refresh, members, ...) serve
+  # a room the member can no longer open — a message-content / roster leak.
+
+  test "a removed member cannot read new thread messages via the RoomScoped refresh endpoint" do
+    closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
+    closed.memberships.grant_to([ @creator, @member ])
+    parent = closed.messages.create!(body: "topic", creator: @creator)
+    thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
+    Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+
+    closed.remove_member!(@member, actor: @creator)
+    ThreadFollowCleanupJob.perform_now(room: closed, user: @member)
+    Current.set(user: @creator) { thread.messages.create!(body: "after you left", creator: @creator) }
+
+    sign_in :jason
+    assert_raises ActiveRecord::RecordNotFound, "the silenced-but-active follow row grants no access" do
+      get room_refresh_url(thread, format: :turbo_stream), params: { since: 10.minutes.ago.to_fs(:epoch) }
+    end
+  end
+
+  test "a removed member cannot read the members roster of a thread they lost access to" do
+    closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
+    closed.memberships.grant_to([ @creator, @member ])
+    parent = closed.messages.create!(body: "topic", creator: @creator)
+    thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
+    Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+
+    closed.remove_member!(@member, actor: @creator)
+    ThreadFollowCleanupJob.perform_now(room: closed, user: @member)
+
+    sign_in :jason
+    assert_raises ActiveRecord::RecordNotFound do
+      get room_members_url(thread)
+    end
+  end
+
+  test "a current member who follows a thread still reaches it through RoomScoped" do
+    closed = Rooms::Closed.create!(name: "War Room", creator: @creator)
+    closed.memberships.grant_to([ @creator, @member ])
+    parent = closed.messages.create!(body: "topic", creator: @creator)
+    thread = Rooms::Thread.find_or_create_for(parent, creator: @creator)
+    Current.set(user: @member) { thread.messages.create!(body: "engaged", creator: @member) }
+
+    sign_in :jason
+    get room_refresh_url(thread, format: :turbo_stream), params: { since: 10.minutes.ago.to_fs(:epoch) }
+    assert_response :success, "a current parent member keeps access — no regression from the gate"
+  end
 end

--- a/test/models/rooms/post_test.rb
+++ b/test/models/rooms/post_test.rb
@@ -115,7 +115,7 @@ class Rooms::PostTest < ActiveSupport::TestCase
     @forum.memberships.grant_to(member)
     post = create_post(title: "Members only")
 
-    Membership.create!(room: post, user: outsider, involvement: "everything", active: true)
+    Membership.create!(room: post, user: outsider, involvement: "everything")
 
     assert_not post.viewable_by?(outsider), "a follow row on the post does not confer access"
     assert post.viewable_by?(member), "a forum member views the post via derived access"

--- a/test/models/rooms/post_test.rb
+++ b/test/models/rooms/post_test.rb
@@ -107,6 +107,21 @@ class Rooms::PostTest < ActiveSupport::TestCase
     assert_not post.viewable_by?(nil)
   end
 
+  # A post membership row is a follow, never access — viewable_by? delegates to the
+  # forum and never consults the post's own memberships.
+  test "a post follow row grants no access — access derives from the forum" do
+    member = users(:jason)
+    outsider = users(:kevin) # not a member of help_desk
+    @forum.memberships.grant_to(member)
+    post = create_post(title: "Members only")
+
+    Membership.create!(room: post, user: outsider, involvement: "everything", active: true)
+
+    assert_not post.viewable_by?(outsider), "a follow row on the post does not confer access"
+    assert post.viewable_by?(member), "a forum member views the post via derived access"
+    assert_not Membership.exists?(room_id: post.id, user_id: member.id), "the forum member holds no post row"
+  end
+
   test "default involvement is everything for the author, invisible for others" do
     author = users(:david)
     post = create_post(title: "Mine", author: author)

--- a/test/models/rooms/thread_test.rb
+++ b/test/models/rooms/thread_test.rb
@@ -43,7 +43,7 @@ class Rooms::ThreadTest < ActiveSupport::TestCase
     thread = Rooms::Thread.find_or_create_for(parent_message, creator: users(:david))
 
     outsider = users(:kevin) # not a member of `parent`
-    Membership.create!(room: thread, user: outsider, involvement: "everything", active: true)
+    Membership.create!(room: thread, user: outsider, involvement: "everything")
 
     assert_not thread.viewable_by?(outsider), "a follow row on the thread does not confer access"
     assert thread.viewable_by?(users(:jason)), "a parent member views the thread via derived access"

--- a/test/models/rooms/thread_test.rb
+++ b/test/models/rooms/thread_test.rb
@@ -33,6 +33,23 @@ class Rooms::ThreadTest < ActiveSupport::TestCase
     assert_not thread.memberships.exists?(user_id: users(:david).id)
   end
 
+  # A thread membership row is a follow, never access — viewable_by? delegates to
+  # the parent room and never consults the thread's own memberships. Build a fresh
+  # parent so we control who is a member (the setup's rooms(:hq) has every user).
+  test "a thread follow row grants no access — access derives from the parent room" do
+    parent = Rooms::Closed.create!(name: "Fresh room", creator: users(:david))
+    parent.memberships.grant_to(users(:jason))
+    parent_message = parent.messages.create!(body: "topic", creator: users(:david))
+    thread = Rooms::Thread.find_or_create_for(parent_message, creator: users(:david))
+
+    outsider = users(:kevin) # not a member of `parent`
+    Membership.create!(room: thread, user: outsider, involvement: "everything", active: true)
+
+    assert_not thread.viewable_by?(outsider), "a follow row on the thread does not confer access"
+    assert thread.viewable_by?(users(:jason)), "a parent member views the thread via derived access"
+    assert_not thread.viewable_by?(nil)
+  end
+
   test "default involvement for thread creator is everything" do
     thread = Rooms::Thread.create!(parent_message: @parent_message, creator: users(:david))
     assert_equal "everything", thread.default_involvement(user: users(:david))


### PR DESCRIPTION
A member removed from a private room could keep reading that room's thread and forum-post messages — and its member roster — because the `RoomScoped` controllers (refresh, members, involvements, stars, memberships, access) resolved the room straight from the requester's own membership rows without re-checking derived access. Removal only *silences* a sub-room follow (involvement → invisible); the row stays active, so it kept resolving. In practice a removed member's open tab keeps polling `/refresh` and receiving new messages until reload, and a former member who knows the id can hit the endpoint directly.

The other sub-room entry points — message reachability, the sub-room show controllers, and the bots API — already re-check `viewable_by?`. `RoomScoped` was the one that didn't. It now denies the same way, raising `RecordNotFound` when a resolved sub-room isn't currently viewable, which also closes the equivalent message-show vector `RoomScoped` feeds in the messages controller. Legitimate access is unaffected: a current parent member always passes the check.

Also included:

- Integration tests driving the refresh and members endpoints for a removed-but-silenced member (they fail without the fix), plus a no-regression test for a current member who still follows the thread.
- Model tests stating the underlying invariant directly: a sub-room membership row is a follow, never access — access derives from the parent room/forum.
- A small readability pass adopting the existing `Room#sub_room?` predicate at the last open-coded `thread? || post?` sites (no behavior change).

Verified: full self-hosted and SaaS test suites green.
