### PR TITLE
Add a follow control to chat threads and quiet forum mentions

### DIFF
--- a/app/controllers/rooms/threads/memberships_controller.rb
+++ b/app/controllers/rooms/threads/memberships_controller.rb
@@ -1,0 +1,36 @@
+# Follow (create) / Unfollow (destroy) a chat thread — the state-as-records form
+# of "notify me of replies without having replied." Access derives from the parent
+# room; this manages only the current user's own follow on the thread. Mirrors
+# Rooms::Posts::MembershipsController.
+class Rooms::Threads::MembershipsController < ApplicationController
+  before_action :set_thread
+
+  def create
+    @thread.follow!(Current.user)
+    respond_with_follow_change
+  end
+
+  def destroy
+    @thread.unfollow!(Current.user)
+    respond_with_follow_change
+  end
+
+  private
+    # Flip the Follow/Unfollow button in its frame for the actor without a reload.
+    # A thread has no gallery card (unlike a post), so only the follow control
+    # refreshes. JS off falls back to reopening the thread panel.
+    def respond_with_follow_change
+      if turbo_frame_request?
+        render turbo_stream: turbo_stream.replace(helpers.dom_id(@thread, :follow),
+          partial: "rooms/threads/follow_control", locals: { thread: @thread })
+      else
+        redirect_to rooms_thread_path(@thread)
+      end
+    end
+
+    def set_thread
+      @thread = Rooms::Thread.active.find_by(id: params[:thread_id])
+      return head :not_found unless @thread
+      head :forbidden unless @thread.viewable_by?(Current.user)
+    end
+end

--- a/app/controllers/rooms/threads_controller.rb
+++ b/app/controllers/rooms/threads_controller.rb
@@ -7,8 +7,12 @@ class Rooms::ThreadsController < RoomsController
   before_action :set_parent_message, only: %i[ create ]
 
   def create
+    # Opening a thread doesn't subscribe you — access derives from the parent room,
+    # and you follow lazily on your first reply (Message::Threadable) or explicitly
+    # via the Follow control. Creating a *new* thread still follows its creator and
+    # the parent-message author, granted by find_or_create_for. Re-subscribing here
+    # would undo an Unfollow the next time you opened the thread.
     @room = Rooms::Thread.find_or_create_for(@parent_message, creator: Current.user)
-    @room.involve_user(Current.user, unread: false)
 
     redirect_to rooms_thread_path(@room)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -294,11 +294,11 @@ class Message < ApplicationRecord
             .involved_in_everything
             .includes(eager_load)
       when :thread_reply
-        # Thread members upgraded via Room#involve_user have involvement: :mentions
-        # by default. receives_push_for?(:thread_reply) qualifies anyone
-        # !involved_in_invisible?, so the `.visible` scope already does all the
-        # filtering needed here. Pre-filtering further to :everything would drop
-        # the typical replier.
+        # Sub-room followers (chat threads and forum posts) sit at involvement
+        # :everything via Room::Followable#follow!. receives_push_for?(:thread_reply)
+        # qualifies anyone !involved_in_invisible?, so the `.visible` scope already
+        # does all the filtering needed here — and it still covers any legacy
+        # :mentions rows from before the sub-room levels were unified.
         room.memberships.visible.disconnected
             .where.not(user_id: creator_id)
             .includes(eager_load)

--- a/app/models/message/threadable.rb
+++ b/app/models/message/threadable.rb
@@ -2,8 +2,7 @@ module Message::Threadable
   extend ActiveSupport::Concern
 
   included do
-    after_create_commit :involve_creator_in_thread
-    after_create_commit :follow_post_by_creator
+    after_create_commit :follow_sub_room_by_creator
     after_create_commit :update_thread_reply_count
     after_create_commit :update_parent_message_threads
     after_create_commit :update_forum_gallery_card
@@ -13,16 +12,13 @@ module Message::Threadable
   end
 
   private
-    def involve_creator_in_thread
-      room.involve_user(creator, unread: false) if room.thread?
-    end
-
-    # A reply (or the opening message) makes its author a follower of the post,
-    # lazily — forum posts don't fan membership out to every member, so
-    # engagement is what creates the row. Mirrors Fizzy's
+    # A reply (or the opening message) makes its author a follower of the sub-room,
+    # lazily — sub-rooms don't fan membership out to every parent member, so
+    # engagement is what creates the row. A chat thread and a forum post follow
+    # alike, at "everything" (Room::Followable#follow!). Mirrors Fizzy's
     # Comment#watch_card_by_creator.
-    def follow_post_by_creator
-      room.follow!(creator) if room.post?
+    def follow_sub_room_by_creator
+      room.follow!(creator) if room.sub_room?
     end
 
     def update_thread_reply_count

--- a/app/models/room/followable.rb
+++ b/app/models/room/followable.rb
@@ -1,0 +1,34 @@
+# Follow state shared by nested sub-rooms — Rooms::Post (a forum post) and
+# Rooms::Thread (a chat thread). Access to a sub-room derives from its parent
+# (see each type's #viewable_by?), so a membership row here is pure subscription
+# state: it decides who hears about replies, not who can open the room. A member
+# becomes a follower lazily — the moment they reply (Message::Threadable) or
+# explicitly Follow — so a sub-room never fans a membership row out to every
+# parent member. Mirrors Fizzy's Watch created on comment.
+module Room::Followable
+  extend ActiveSupport::Concern
+
+  # True when the user is a follower — an active, non-invisible membership that
+  # drives reply notifications. The author and anyone who replied or explicitly
+  # Followed qualifies; a member who never engaged (access is parent-derived) does
+  # not.
+  def followed_by?(user)
+    user.present? && memberships.active.where.not(involvement: "invisible").exists?(user_id: user.id)
+  end
+
+  # A member becomes a follower the moment they reply — lazily, so a sub-room
+  # never fans a membership row out to every member. Idempotent and self-healing:
+  # it (re)activates a dropped membership and lifts an invisible one back to
+  # "everything", but never downgrades a follower who dialed themselves down.
+  def follow!(user)
+    membership = Membership.find_or_initialize_by(room_id: id, user_id: user.id)
+    membership.active = true
+    membership.involvement = "everything" if membership.new_record? || membership.involved_in_invisible?
+    membership.save! if membership.changed?
+    membership
+  end
+
+  def unfollow!(user)
+    Membership.where(room_id: id, user_id: user.id).destroy_all
+  end
+end

--- a/app/models/rooms/forum.rb
+++ b/app/models/rooms/forum.rb
@@ -115,18 +115,17 @@ class Rooms::Forum < Room
               .update_all(involvement: "invisible")
   end
 
-  # Poke the forum's sidebar unread for the members a post's activity should reach
-  # (see Message::Threadable#mark_forum_unread). The forum owns no messages, so this
+  # Poke the forum's sidebar unread for a new post — a dot, like any new room
+  # message — for the members who should see it. A forum owns no messages, so this
   # mirrors a chat room's unread behavior against the forum's own memberships. It
   # deliberately does NOT bump last_active_at — a post surfaces the forum via its
   # unread state (which sorts to the top of its group), not chat-style reordering.
+  #
+  # Mentions are deliberately NOT surfaced here: a forum mention behaves like a
+  # thread mention, reaching the named member through Activity only (see
+  # Message::Mentionee), not a sidebar dot or number badge.
   def mark_unread_from_post(message)
-    # A new post lights the whole forum unread — a dot, like any new room message.
     mark_members_unread(message) if message.room.opening_message?(message)
-
-    # A mention lights the forum unread AND bumps its notification count, so the
-    # sidebar shows a number badge, exactly like a chat-room mention.
-    notify_mentioned_members(message)
   end
 
   private
@@ -144,20 +143,6 @@ class Rooms::Forum < Room
       recipients = memberships.visible.disconnected.where.not(user_id: message.creator_id)
       recipients.read.update_all(unread_at: message.created_at, updated_at: Time.current)
       recipients.includes(:user).each { |membership| broadcast_dot(membership) }
-    end
-
-    # The named members (never the author), while they're away: each gets the dot
-    # and +1 on the notification count so the forum shows a number badge.
-    def notify_mentioned_members(message)
-      mentioned = message.mentionees.reject { |user| user.id == message.creator_id }
-      memberships.visible.disconnected.where(user: mentioned).includes(:user).each do |membership|
-        membership.update!(
-          unread_at: membership.unread_at || message.created_at,
-          unread_notifications_count: membership.unread_notifications_count + 1
-        )
-        broadcast_dot(membership)
-        UnreadNotificationsChannel.broadcast_to(membership.user, { roomId: id })
-      end
     end
 
     def broadcast_dot(membership)

--- a/app/models/rooms/post.rb
+++ b/app/models/rooms/post.rb
@@ -5,7 +5,7 @@
 # title, a permanent slug, a Solved state, and derives its access from the forum
 # rather than from a per-member membership fan-out.
 class Rooms::Post < Room
-  include Room::Participants, Room::Nested
+  include Room::Participants, Room::Nested, Room::Followable
 
   # The forum this post lives in. The real FK (rooms.parent_room_id), unlike a
   # chat thread's denormalized copy of its parent message's room.
@@ -92,31 +92,6 @@ class Rooms::Post < Room
 
   def default_involvement(user: nil)
     user.present? && user == creator ? "everything" : "invisible"
-  end
-
-  # True when the user is a follower — an active, non-invisible membership that
-  # drives reply notifications. The author and anyone who replied or explicitly
-  # Followed qualifies; a member who never engaged (access is forum-derived) does
-  # not.
-  def followed_by?(user)
-    user.present? && memberships.active.where.not(involvement: "invisible").exists?(user_id: user.id)
-  end
-
-  # A member becomes a follower of this post the moment they reply — lazily, so
-  # a forum never fans a membership row out to every member. Idempotent and
-  # self-healing: it (re)activates a dropped membership and lifts an invisible
-  # one back to "everything", but never downgrades a follower who dialed
-  # themselves down. Mirrors Fizzy's Watch created on comment.
-  def follow!(user)
-    membership = Membership.find_or_initialize_by(room_id: id, user_id: user.id)
-    membership.active = true
-    membership.involvement = "everything" if membership.new_record? || membership.involved_in_invisible?
-    membership.save! if membership.changed?
-    membership
-  end
-
-  def unfollow!(user)
-    Membership.where(room_id: id, user_id: user.id).destroy_all
   end
 
   def applicable_activity_types(message)

--- a/app/models/rooms/thread.rb
+++ b/app/models/rooms/thread.rb
@@ -4,7 +4,7 @@
 class Rooms::Thread < Room
   class NestedThreadError < StandardError; end
 
-  include Room::Participants, Room::Nested
+  include Room::Participants, Room::Nested, Room::Followable
 
   validates_presence_of :parent_message
 

--- a/app/views/rooms/threads/_follow_control.html.erb
+++ b/app/views/rooms/threads/_follow_control.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (thread:) %>
+<%# Follow/Unfollow flips in place inside this frame, so the state change is
+    visible immediately without reloading the panel. Rendered per-viewer (needs
+    Current.user), so it never rides a viewer-less broadcast. %>
+<%= turbo_frame_tag dom_id(thread, :follow) do %>
+  <% if Current.user && thread.followed_by?(Current.user) %>
+    <%= button_to rooms_thread_membership_path(thread), method: :delete, class: "btn action-btn full-width" do %>
+      <span>Unfollow</span>
+    <% end %>
+  <% elsif Current.user %>
+    <%= button_to rooms_thread_membership_path(thread), method: :post, class: "btn action-btn full-width" do %>
+      <span>Follow</span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/rooms/threads/show.html.erb
+++ b/app/views/rooms/threads/show.html.erb
@@ -7,6 +7,21 @@
       <% end %>
       <%= icon_tag "thread", class: "thread-panel__icon" %>
     </h2>
+
+    <%= tag.details class: "position-relative flex-item-no-shrink", data: {
+          controller: "popup", popup_orientation_top_class: "",
+          action: "keydown.esc->popup#close toggle->popup#toggle click@document->popup#closeOnClickOutside"
+        } do %>
+      <summary class="btn action-btn options-btn">
+        <%= icon_tag "menu-dots-horizontal" %>
+        <span class="for-screen-reader">Thread options</span>
+      </summary>
+
+      <div class="popup-menu forum-post-menu border shadow" data-popup-target="menu">
+        <%= render "rooms/threads/follow_control", thread: @room %>
+      </div>
+    <% end %>
+
     <button class="btn thread-panel__close" data-action="thread-panel#close" aria-label="Close thread">&times;</button>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,11 @@ Rails.application.routes.draw do
       end
     end
     resources :directs
-    resources :threads, only: %i[ create show edit update destroy ]
+    # The thread panel (show) plus Follow, modeled as the current user's membership
+    # on the thread: Follow = create, Unfollow = destroy (mirrors posts below).
+    resources :threads, only: %i[ create show edit update destroy ] do
+      resource :membership, only: %i[ create destroy ], module: "threads"
+    end
 
     # The in-app post panel (show) plus Follow, modeled as the current user's
     # membership on the post: Follow = create, Unfollow = destroy.

--- a/docs/brainstorms/2026-07-06-thread-forum-consistency-gaps.md
+++ b/docs/brainstorms/2026-07-06-thread-forum-consistency-gaps.md
@@ -1,0 +1,96 @@
+---
+date: 2026-07-06
+topic: thread-forum-consistency-gaps
+---
+
+# Thread ↔ forum-post: behavioral consistency gaps (to evaluate)
+
+## Summary
+
+`Rooms::Thread` (chat thread) and `Rooms::Post` (forum post) are sibling sub-rooms —
+both `Room::Participants`, both deriving access from a parent after the
+thread-fanout branch. But they diverge in several **user-facing** ways: a forum
+post behaves like a loud, controllable, room-like object; a chat thread behaves
+like a quiet, implicit side-branch with no controls. Recorded for later
+evaluation — **nothing decided, no work scheduled here.**
+
+The theme: same underlying object, opposite notification/control profiles.
+
+---
+
+## Findings
+
+### G1 — New activity lights the sidebar for forums, is silent for threads
+- New **post**: lights the whole forum unread (a dot) for every member —
+  `Message::Threadable#mark_forum_unread` → `Rooms::Forum#mark_unread_from_post`
+  → `mark_members_unread`.
+- New **thread**: no sidebar signal at all — only a reply-count bump on the parent
+  message plus a notification to the thread's followers (the reply job drops the
+  creator and also pulls in the parent room's `everything` subscribers). `threadable.rb`
+  has no room-unread call for threads.
+- **Read:** possibly a deliberate "threads = low-noise" choice. Confirm intent.
+
+### G2 — @mention is louder in a forum than in a thread
+- @mention in a **post**: Activity indicator **plus a number badge on the forum in
+  the sidebar** (`Rooms::Forum#notify_mentioned_members` bumps
+  `unread_notifications_count` + `UnreadNotificationsChannel`).
+- @mention in a **thread**: Activity indicator **only, no sidebar badge**
+  (`Message::Mentionee#create_mention_notifications` +
+  `BroadcastMentionNotificationsJob` append to the Activity stream +
+  `broadcast_activity_indicator`; `BroadcastMentioneeSidebarUpdatesJob` bails on
+  non-sidebar rooms). `CreateThreadReplyNotificationsJob` handles the separate
+  `thread_reply` fan-out and explicitly skips already-mentioned users.
+- A thread mention can slip by with no red number anywhere in the sidebar —
+  unlike a mention in a forum *or* a normal room, which both badge the sidebar.
+  Threads are the odd one out.
+
+### G3 — You can Unfollow a post, but not a thread (sharpest gap)
+- Forum posts have an explicit **Follow / Unfollow control**
+  (`app/views/rooms/forums/posts/_follow_control.html.erb`;
+  `Rooms::Post#follow!` / `#unfollow!`).
+- Chat threads have **no follow control**. You implicitly follow the moment you
+  reply, and every visible thread member is notified of *every* subsequent reply
+  (`CreateThreadReplyNotificationsJob` targets `memberships.active.visible`), with
+  no button to turn it off. Reply once to an active thread → subscribed
+  permanently.
+- **Read:** this is a missing control, not a design stance — the forum side
+  already solved it. Strongest candidate to fix.
+- **Mute plumbing already exists.** The backend can already silence a thread
+  follow — `Room#silence_thread_follows_for` flips involvement to `invisible`
+  (via `ThreadFollowCleanupJob`) — but it only fires when you *leave the parent
+  room*, never from a per-thread control. The mechanism is there; only the button
+  is missing, so a thread Unfollow could reuse it rather than build new state.
+
+### G4 — Replying sets a different follow level (internal; couples to G3)
+- Reply to a **post** → membership `everything` (`Rooms::Post#follow!`).
+- Reply to a **thread** → membership `mentions`
+  (`Room#involve_user` uses `create_with(involvement: "mentions")`).
+- No user-visible difference today (the reply-notification job notifies all
+  *visible* members regardless of level), but inconsistent — and it would surface
+  oddly the moment threads get a follow control (G3), which would read the level.
+
+### G5 — Thread auto-follows the parent-message author; no forum analog
+- Starting a thread on someone's message auto-subscribes that person
+  (`Rooms::Thread.find_or_create_for` grants `[creator, parent_message.creator]`).
+- A forum post has no equivalent — a post has no pre-existing author to subscribe.
+  Structurally justified, but it widens the "who behaves how" gap between the two.
+
+---
+
+## Differences that are intentional (NOT gaps)
+
+Recorded so we don't re-litigate them: Solved / accepted-answers (Q&A vs
+chit-chat), post titles + permalinks + gallery layout, threads being reached via
+their message vs forums being browsable/joinable from Browse, and `@everyone`
+being unavailable in both sub-rooms (consistent between them, and sensible — a
+side-conversation shouldn't page the whole community).
+
+---
+
+## Open questions for later
+
+- Is the loud/quiet split (G1, G2) intentional, or should thread activity surface
+  more like forum/room activity?
+- G3 is the clearest fix: a thread follow/mute control reusing the
+  `follow!` / `unfollow!` shape. Landing repliers at the same level as posts would
+  also close G4 for free.

--- a/docs/plans/2026-07-07-001-thread-forum-consistency-fixes-plan.md
+++ b/docs/plans/2026-07-07-001-thread-forum-consistency-fixes-plan.md
@@ -1,0 +1,183 @@
+# Plan: Close the thread ↔ forum-post consistency gaps
+
+**Status:** proposed · **Date:** 2026-07-07 · **Branch:** TBD · **Ships as:** one PR
+
+> Resolves the gaps recorded in `docs/brainstorms/2026-07-06-thread-forum-consistency-gaps.md`
+> (G1–G5), verified against code on 2026-07-07. Decisions were made interactively; this plan
+> encodes them.
+
+> **Path note.** Bare filenames are shorthand: `threadable.rb` → `app/models/message/threadable.rb`;
+> `rooms/forum.rb`, `rooms/post.rb`, `rooms/thread.rb` → `app/models/rooms/*.rb`; `room.rb` →
+> `app/models/room.rb`; `involvable.rb` → `app/models/membership/involvable.rb`; `threads_controller.rb`
+> → `app/controllers/rooms/threads_controller.rb`; `posts/memberships_controller.rb` →
+> `app/controllers/rooms/posts/memberships_controller.rb`. All other cited paths are full.
+
+## Goal
+
+`Rooms::Thread` (chat thread) and `Rooms::Post` (forum post) are sibling sub-rooms that diverge in
+user-facing notification and control behavior. This closes the divergence by making the two behave
+consistently — **leveling notification loudness *down* (quiet forums to match threads) and adding the
+missing thread control *up* (a follow/unfollow control to match posts).**
+
+## Decisions (locked)
+
+| Gap | Decision | Work |
+|---|---|---|
+| **G1** — thread activity is silent in the sidebar; forums light up | **Leave as-is.** Threads stay quiet on purpose — a thread lives inside a busy room; lighting the parent would conflate side-branch chatter with the main channel. | none |
+| **G2** — @mention badges the sidebar in a forum, not in a thread | **Quiet the forum.** A forum mention should behave like a thread mention: Activity tab only, no sidebar dot or number. Normal rooms are unchanged — the new rule is "rooms are loud, sub-room containers are quiet." | remove `notify_mentioned_members` |
+| **G3** — no Unfollow control for threads; posts have one | **Add it.** Mirror the post follow/unfollow control for threads. | new concern / route / controller / view |
+| **G4** — thread reply → `mentions`; post reply → `everything` | **Align to `everything`.** Thread followers land at `everything` like posts; the new Unfollow (G3) is the escape hatch. | shared `follow!` |
+| **G5** — thread auto-subscribes the parent-message author; no forum analog | **Keep, now opt-out-able.** The auto-subscribe (a courtesy: "someone threaded your message") stays; G3's Unfollow makes it dismissable. | none (falls out of G3) |
+
+---
+
+# Change 1 — Quiet the forum mention (G2)
+
+Small, self-contained, independent of the thread work.
+
+**`rooms/forum.rb`:**
+- In `mark_unread_from_post` (`forum.rb:123`), drop the `notify_mentioned_members(message)` line. It
+  reduces to: `mark_members_unread(message) if message.room.opening_message?(message)`.
+- Delete the `notify_mentioned_members` private method (`forum.rb:151-161`).
+- Update the `mark_unread_from_post` comment (it currently describes the mention path).
+
+**Why this is the whole change.** `notify_mentioned_members` is the *only* place a forum touches
+`unread_notifications_count` (`forum.rb:156`) or broadcasts `UnreadNotificationsChannel`. Removing it
+means forum mentions produce no sidebar dot, no number badge, and no live badge broadcast.
+
+**What is unaffected:**
+- Mention **Notifications + Activity** are created by `Message::Mentionee#create_mention_notifications`
+  — a separate path that never routed through `notify_mentioned_members`. Mentions still land in Activity.
+- **New-post dot** (`mark_members_unread`) is separate and stays — forums still signal "something new here."
+- **Normal rooms** keep their mention number badge (`Message::Unreadable#increment_unread_notifications_counters`,
+  untouched).
+
+**Side effect to note:** forum mentions will no longer contribute to the app/push badge total
+(`Push::Subscription` counts `memberships.unread.where(unread_notifications_count > 0)`). Intended —
+consistent with "quiet forums."
+
+**Tests:** a forum mention no longer bumps `unread_notifications_count` and does not broadcast the badge;
+it still creates the mention Notification / appears in Activity; a new post still lights the dot.
+
+---
+
+# Change 2 — Thread follow/unfollow control (G3 + G4 + G5)
+
+One feature. Mirrors the post model so the two sub-room types become behaviorally identical for following.
+
+## 2a. Extract the follow behavior into a shared concern
+
+`follow!`, `unfollow!`, `followed_by?` on `Rooms::Post` (`post.rb:101-120`) are generic — nothing in
+them is post-specific. Move them into a new `Room::Followable` concern.
+
+- **New `app/models/room/followable.rb`:** holds `follow!` (activate + set `everything` when the row is
+  new or `invisible`; never downgrades a follower who dialed themselves down), `unfollow!` (destroy the
+  membership rows — access is parent-derived, so the row is pure subscription state), `followed_by?`
+  (`memberships.active.where.not(involvement: :invisible).exists?`).
+- **`rooms/post.rb`:** remove the three methods; `include Room::Followable`.
+- **`rooms/thread.rb`:** `include Room::Followable`. Threads gain follow/unfollow for free at `everything`.
+
+## 2b. Unify the sub-room follow-on-reply callback (closes G4)
+
+`threadable.rb` currently has two parallel callbacks that diverge only in involvement level:
+
+```ruby
+after_create_commit :involve_creator_in_thread   # thread → involve_user → "mentions"
+after_create_commit :follow_post_by_creator       # post   → follow!      → "everything"
+```
+
+Collapse into one:
+
+```ruby
+after_create_commit :follow_sub_room_by_creator
+...
+def follow_sub_room_by_creator
+  room.follow!(creator) if room.sub_room?
+end
+```
+
+**Net behavior change:** a third-party thread replier now lands at `everything` instead of `mentions`.
+(The thread creator and parent-message author are already at `everything` via `Rooms::Thread#default_involvement`.)
+
+**Verified safe — dropping the old `unread: false`:** `follow!` never touches `unread_at`, and
+`Room#unread_memberships` already excludes the sender (`memberships.visible.disconnected.read.where.not(user: message.creator)`,
+`room.rb:383`), so a replier's own reply never marks their membership unread. No-op.
+
+## 2c. Stop subscribing on *open* — REQUIRED for Unfollow to persist
+
+`threads_controller#create` (the "open/start a thread" action) currently runs:
+
+```ruby
+@room = Rooms::Thread.find_or_create_for(@parent_message, creator: Current.user)
+@room.involve_user(Current.user, unread: false)   # ← subscribes the opener at "mentions"
+```
+
+**Remove the `involve_user` line.** This is not optional cleanup — it's load-bearing for G3. If opening a
+thread re-subscribes you, then **Unfollow never sticks**: unfollow (destroy the row), navigate away,
+re-open → `involve_user` re-creates the membership and you're followed again. Removing it makes the model
+match posts exactly:
+
+- **Create a thread** → creator + parent author followed at `everything` (via `find_or_create_for`'s
+  `auto_followers`). Unchanged.
+- **Reply** → follow at `everything` (2b). 
+- **Open/lurk** → no membership, no subscription (a lurker on a thread == a lurker on a post).
+- **Explicit Follow button** → subscribe without replying; **Unfollow** → and it persists across re-opens.
+
+`show` is unaffected — `set_membership` only *loads* the current user's membership (nil for a lurker), and
+`show.html.erb:20` already guards `turbo_stream_from @membership if @membership`.
+
+> `involve_user`'s other two callers are untouched: the thread reply path (2b replaces it with `follow!`)
+> and the bot cross-room post (`app/controllers/api/bots/messages_controller.rb:39`), which keeps its
+> `mentions` default.
+
+## 2d. Route + controller + view
+
+- **`config/routes.rb`:** nest a membership resource under threads (mirrors posts at `routes.rb:161`):
+  ```ruby
+  resources :threads, only: %i[ create show edit update destroy ] do
+    resource :membership, only: %i[ create destroy ], module: "threads"
+  end
+  ```
+- **New `app/controllers/rooms/threads/memberships_controller.rb`:** mirror
+  `Rooms::Posts::MembershipsController` — `create` → `follow!`, `destroy` → `unfollow!`, respond by
+  replacing the follow frame via turbo_stream (or redirect fallback). Simpler than the post version: a
+  thread has no gallery card, so it only flips the follow control frame. Access check: `viewable_by?`.
+- **New `app/views/rooms/threads/_follow_control.html.erb`:** mirror
+  `app/views/rooms/forums/posts/_follow_control.html.erb`, keyed on `dom_id(thread, :follow)`, using
+  `rooms_thread_membership_path(thread)` for the Follow (POST) / Unfollow (DELETE) buttons.
+- **`app/views/rooms/threads/show.html.erb`:** surface the control in `.thread-panel__header` (today it
+  holds only the title + close button, `show.html.erb:3-11`). Render `rooms/threads/follow_control`.
+  A full `⋯` options menu matching the post header (Copy link / Edit / Delete + Follow) is *optional
+  polish* — out of scope unless we want it here.
+
+## 2e. Comment fix
+
+`app/models/message.rb:296` — the `:thread_reply` push comment says thread members are at `:mentions`
+"by default." After 2b they're at `everything`. Update the comment; the logic (uses the `.visible` scope)
+is already correct for either level, so no code change. Threads now match posts, which already run repliers
+at `everything` through the same push path.
+
+## Tests (mirror `test/controllers/rooms/posts/memberships_controller_test.rb`)
+
+- Follow (POST) creates a membership at `everything`; Unfollow (DELETE) destroys it.
+- `followed_by?` transitions across follow → unfollow → re-follow.
+- A thread reply lands the replier at `everything` (not `mentions`).
+- **Unfollow persists across re-open** — the regression 2c protects: unfollow, hit `create` again for the
+  same thread, assert still not followed.
+- Unfollow stops `CreateThreadReplyNotificationsJob` reaching that user (they leave `memberships.active.visible`).
+- The parent-message author (G5 auto-subscribe) can Unfollow and it sticks.
+
+---
+
+## Out of scope
+
+- G1 (thread sidebar activity) — deliberately unchanged.
+- Forum-index per-post unread indication (per-visit watermark) — separately discussed, **parked**.
+- A full `⋯` options menu on the thread panel header — polish, not required for the control.
+
+## Blast radius
+
+- **Change 1** touches one method on `Rooms::Forum`; the only consumers of the removed behavior are the
+  forum sidebar badge (intentionally removed) and the push badge count (intentionally reduced).
+- **Change 2** is additive except 2b/2c, which alter thread involvement level (`mentions → everything`) and
+  remove subscribe-on-open. Both move threads onto the already-in-production post model — low novelty.

--- a/test/controllers/rooms/threads/memberships_controller_test.rb
+++ b/test/controllers/rooms/threads/memberships_controller_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class Rooms::Threads::MembershipsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @david = users(:david)
+    @jason = users(:jason)
+    @kevin = users(:kevin)
+    @room = rooms(:pets)
+    @parent_message = @room.messages.create!(
+      body: "Parent for follow tests", creator: @jason, client_message_id: "tm_setup_1"
+    )
+    @thread = Rooms::Thread.create_for(
+      { parent_message_id: @parent_message.id, creator: @david }, users: [ @david, @jason ]
+    )
+  end
+
+  test "a parent-room member Follows a thread by creating a membership at everything" do
+    @room.memberships.grant_to(@kevin)
+    sign_in :kevin
+    assert_not Membership.exists?(room_id: @thread.id, user_id: @kevin.id)
+
+    post rooms_thread_membership_url(@thread)
+
+    membership = Membership.find_by(room_id: @thread.id, user_id: @kevin.id)
+    assert membership.present?, "Follow creates the membership"
+    assert_equal "everything", membership.involvement, "a follower lands at everything, like a post follower"
+  end
+
+  test "Following via a turbo frame flips the button to Unfollow" do
+    @room.memberships.grant_to(@kevin)
+    sign_in :kevin
+
+    post rooms_thread_membership_url(@thread), headers: { "Turbo-Frame" => "follow" }
+
+    assert_response :success
+    assert_select "turbo-stream[action='replace'][target=?]", ActionView::RecordIdentifier.dom_id(@thread, :follow)
+    assert_select "turbo-frame button", text: /Unfollow/
+  end
+
+  test "Unfollow removes the membership" do
+    @thread.follow!(@kevin)
+    @room.memberships.grant_to(@kevin)
+    sign_in :kevin
+
+    delete rooms_thread_membership_url(@thread)
+
+    assert_not Membership.exists?(room_id: @thread.id, user_id: @kevin.id)
+  end
+
+  test "Unfollow via a turbo frame flips the button back to Follow" do
+    @thread.follow!(@kevin)
+    @room.memberships.grant_to(@kevin)
+    sign_in :kevin
+
+    delete rooms_thread_membership_url(@thread), headers: { "Turbo-Frame" => "follow" }
+
+    assert_response :success
+    assert_select "turbo-frame button", text: /Follow/
+  end
+
+  test "a non-parent-room member cannot Follow a thread" do
+    sign_in :kevin # kevin is not a member of the parent room
+
+    post rooms_thread_membership_url(@thread)
+
+    assert_response :forbidden
+    assert_not Membership.exists?(room_id: @thread.id, user_id: @kevin.id)
+  end
+
+  test "Following a nonexistent thread returns 404, not 403" do
+    sign_in :david
+
+    post rooms_thread_membership_url(999_999)
+
+    assert_response :not_found
+  end
+
+  test "the auto-subscribed parent-message author can Unfollow, and it persists across reopening" do
+    sign_in :jason
+    assert @thread.followed_by?(@jason), "the parent-message author is auto-subscribed on thread creation"
+
+    delete rooms_thread_membership_url(@thread)
+    assert_not @thread.followed_by?(@jason), "Unfollow drops the author's subscription"
+
+    # Reopening the thread must not silently re-subscribe them.
+    post rooms_threads_url, params: { parent_message_id: @parent_message.id }
+    assert_not @thread.reload.followed_by?(@jason), "Unfollow persists — reopening the thread doesn't re-subscribe"
+  end
+end

--- a/test/controllers/rooms/threads_controller_test.rb
+++ b/test/controllers/rooms/threads_controller_test.rb
@@ -66,6 +66,24 @@ class Rooms::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert thread.viewable_by?(kevin), "…but still views via derived access"
   end
 
+  test "create does not subscribe a member who merely opens an existing thread" do
+    kevin = users(:kevin)
+    @room.memberships.grant_to(kevin)
+    parent_message = @room.messages.create!(
+      body: "Parent for lurk test", creator: @jason, client_message_id: "lurk_open_1"
+    )
+    thread = Rooms::Thread.create_for(
+      { parent_message_id: parent_message.id, creator: @david }, users: [ @david, @jason ]
+    )
+
+    sign_in :kevin
+    post rooms_threads_url, params: { parent_message_id: parent_message.id }
+
+    assert_not thread.memberships.exists?(user: kevin),
+      "opening a thread doesn't subscribe you — you follow by replying or via the Follow control"
+    assert thread.viewable_by?(kevin), "…but you can still view it via derived access"
+  end
+
   test "create requires parent message to be reachable by user" do
     # Create a message in a room david is not a member of
     closed_room = Rooms::Closed.create!(name: "Secret Room", creator: @jason)

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -269,7 +269,8 @@ class RoomTest < ActiveSupport::TestCase
     parent = room.messages.create!(body: "topic", creator: users(:david))
     thread = Rooms::Thread.find_or_create_for(parent, creator: users(:david))
     Current.set(user: users(:jason)) { thread.messages.create!(body: "in", creator: users(:jason)) }
-    assert_equal "mentions", thread.memberships.find_by(user: users(:jason)).involvement
+    assert_equal "everything", thread.memberships.find_by(user: users(:jason)).involvement,
+      "replying follows the thread at everything"
 
     perform_enqueued_jobs { room.remove_member!(users(:jason), actor: users(:david)) }
 
@@ -299,7 +300,7 @@ class RoomTest < ActiveSupport::TestCase
     perform_enqueued_jobs { room.remove_member!(users(:jason), actor: users(:david)) }
 
     assert_equal "invisible", thread.memberships.find_by(user: users(:jason)).involvement
-    assert_equal "mentions", thread.memberships.find_by(user: users(:kevin)).involvement,
+    assert_equal "everything", thread.memberships.find_by(user: users(:kevin)).involvement,
       "another member's thread follow is untouched"
   end
 

--- a/test/models/rooms/forum_test.rb
+++ b/test/models/rooms/forum_test.rb
@@ -279,7 +279,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     assert_empty forum.memberships.unread, "a plain reply leaves the forum read for every member"
   end
 
-  test "a mention in a reply marks only the mentioned member's forum unread" do
+  test "a mention in a reply does not badge the forum — it surfaces in Activity only" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
     post = Current.set(user: users(:david)) { forum.post!(title: "Q", body: "b") }
     forum.memberships.update_all(unread_at: nil)
@@ -288,8 +288,10 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     Current.set(user: users(:david)) { post.messages.create!(body: "<div>#{mention} ping</div>") }
 
     kevin_membership = forum.memberships.find_by(user: users(:kevin))
-    assert kevin_membership.unread?, "the mentioned member is marked unread"
-    assert_equal 1, kevin_membership.unread_notifications_count, "a mention shows a number badge on the forum"
-    assert_equal 1, forum.memberships.unread.count, "only the mentioned member is poked by a reply mention"
+    assert kevin_membership.read?, "a forum mention no longer marks the forum sidebar unread"
+    assert_equal 0, kevin_membership.unread_notifications_count, "and no number badge on the forum — a forum mention is quiet, like a thread mention"
+    assert_empty forum.memberships.unread, "a reply mention leaves the forum read for every member"
+    assert Notification.exists?(user: users(:kevin), activity_type: "mention"),
+      "the mention still reaches the member through Activity"
   end
 end


### PR DESCRIPTION
Two changes that make chat threads and forum posts behave consistently — closing gaps where the same underlying object (a nested sub-room) had opposite notification and control profiles.

## Chat threads get a Follow/Unfollow control

Forum posts already let you follow or unfollow. Chat threads didn't — you were subscribed the moment you engaged, with no way out. The thread panel now has a ⋯ menu with Follow/Unfollow, backed by a membership resource (Follow = create, Unfollow = destroy), mirroring posts.

Thread following is brought in line with posts along the way:

- **Replying follows at `everything`** (was `mentions`) — identical to replying to a forum post, so the two sub-room types no longer diverge on involvement level.
- **Opening a thread no longer subscribes you.** You follow by replying or via the button. This is what makes Unfollow stick: previously, reopening a thread silently re-subscribed you and undid the Unfollow.
- **Starting a thread on someone's message still auto-subscribes that person** (so they hear about replies to their message) — but they can now Unfollow.

The shared `follow!` / `unfollow!` / `followed_by?` logic moves into a `Room::Followable` concern included by both `Rooms::Post` and `Rooms::Thread`.

## Forum @mentions go quiet in the sidebar

An @mention inside a forum no longer lights the forum with an unread dot and a red count badge. It now behaves like a mention in a thread — it reaches you through the Activity tab only. This drops `Rooms::Forum#notify_mentioned_members`, the only place a forum touched the sidebar notification count.

Unchanged: normal rooms still badge the sidebar on a mention, and a new forum post still lights the forum's unread dot.

## Testing

Model and controller tests cover: thread follow/unfollow (create/destroy, turbo-frame toggle, access control), replies landing at `everything`, Unfollow persisting across reopening a thread, a member opening a thread not being subscribed, and forum mentions no longer badging the sidebar while still reaching Activity. Full suite green — self-hosted and SaaS.
