### PR TITLE
Derive unread from read cursors; collapse send-path fan-out to one shared nudge

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -99,7 +99,7 @@ class RoomsController < ApplicationController
 
     def find_messages
       messages = @room.messages.for_display.with_bookmark_status_for(Current.user)
-      @first_unread_message = first_unread_from(messages)
+      @first_unread_message = first_unread
 
       anchor = target_message(messages) || @first_unread_message
       result = anchor ? messages.page_around(anchor) : messages.last_page
@@ -107,11 +107,11 @@ class RoomsController < ApplicationController
       Message.with_thread_participants(with_thread_parent(result))
     end
 
-    def first_unread_from(messages)
+    def first_unread
       # A forum member can view a post without a membership (access is
       # forum-derived), so there may be no unread state to anchor on.
       return unless @membership&.unread?
-      messages.ordered.since(@membership.unread_at).first
+      @membership.first_unread_message
     end
 
     def target_message(messages)

--- a/app/javascript/controllers/rooms_list_controller.js
+++ b/app/javascript/controllers/rooms_list_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
       received: this.#addBadge.bind(this)
     })
     this.roomListChannel ??= await cable.subscribeTo({ channel: "RoomListChannel" }, {
-      received: this.#roomUpdated.bind(this)
+      received: this.#roomListReceived.bind(this)
     })
     this.involvementsChannel ??= await cable.subscribeTo({ channel: "UserInvolvementsChannel" }, {
       received: this.#updateInvolvement.bind(this)
@@ -115,17 +115,52 @@ export default class extends Controller {
     this.dispatch("addBadge", { detail: { roomId: roomId } })
   }
   
+  // The shared room-list stream carries two payload kinds: a rename
+  // ({roomId, sortableName}) and a touched nudge ({roomId, roomSize,
+  // roomUpdatedAt}) published once per message for the whole account.
+  #roomListReceived(payload) {
+    if (payload.sortableName !== undefined) {
+      this.#roomUpdated(payload)
+    } else {
+      this.#touched(payload)
+    }
+  }
+
   #roomUpdated({ roomId, sortableName }) {
     const rooms = this.#findRoomTargets(roomId)
 
     rooms.forEach(room => {
       const sortedListTarget = room.closest('[data-sorted-list-target]')
       if (!sortedListTarget) return
-      
+
       sortedListTarget.dataset.name = sortableName
     })
 
     this.dispatch("renamed", { detail: { roomId: roomId } })
+  }
+
+  // A room was touched by a new message. Refresh its sort metadata for
+  // everyone; derive unread locally — only a member not viewing the room
+  // gets the dot (the viewer sees the message land, so they stay read).
+  #touched({ roomId, roomSize, roomUpdatedAt }) {
+    const rooms = this.#findRoomTargets(roomId)
+
+    rooms.forEach(room => {
+      const sortedListTarget = room.closest('[data-sorted-list-target]')
+      if (!sortedListTarget) return
+
+      sortedListTarget.dataset.updatedAt = roomUpdatedAt
+      sortedListTarget.dataset.size = roomSize
+
+      if (Current.room?.id != roomId) {
+        if (sortedListTarget.dataset.sortedListPriority) {
+          sortedListTarget.dataset.sortedListPriority = "0"
+        }
+        room.classList.add(this.unreadClass)
+      }
+    })
+
+    this.dispatch("unread", { detail: { roomId: roomId } })
   }
   
   #updateInvolvement({ roomId, involvement }) {

--- a/app/javascript/controllers/rooms_list_controller.js
+++ b/app/javascript/controllers/rooms_list_controller.js
@@ -117,7 +117,8 @@ export default class extends Controller {
   
   // The shared room-list stream carries two payload kinds: a rename
   // ({roomId, sortableName}) and a touched nudge ({roomId, roomSize,
-  // roomUpdatedAt}) published once per message for the whole account.
+  // roomUpdatedAt, creatorId}) published once per message for the whole
+  // account.
   #roomListReceived(payload) {
     if (payload.sortableName !== undefined) {
       this.#roomUpdated(payload)
@@ -139,10 +140,11 @@ export default class extends Controller {
     this.dispatch("renamed", { detail: { roomId: roomId } })
   }
 
-  // A room was touched by a new message. Refresh its sort metadata for
-  // everyone; derive unread locally — only a member not viewing the room
-  // gets the dot (the viewer sees the message land, so they stay read).
-  #touched({ roomId, roomSize, roomUpdatedAt }) {
+  // A room was touched by a new message or forum post. Refresh its sort
+  // metadata for everyone; derive unread locally — no dot for the member
+  // viewing the room (they see it land) or for the creator's own clients
+  // (a forum author lands on their new post, not the forum).
+  #touched({ roomId, roomSize, roomUpdatedAt, creatorId }) {
     const rooms = this.#findRoomTargets(roomId)
 
     rooms.forEach(room => {
@@ -152,7 +154,7 @@ export default class extends Controller {
       sortedListTarget.dataset.updatedAt = roomUpdatedAt
       sortedListTarget.dataset.size = roomSize
 
-      if (Current.room?.id != roomId) {
+      if (Current.room?.id != roomId && Current.user?.id != creatorId) {
         if (sortedListTarget.dataset.sortedListPriority) {
           sortedListTarget.dataset.sortedListPriority = "0"
         }

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,20 +4,8 @@ class Membership < ApplicationRecord
   belongs_to :room
   belongs_to :user
 
-  has_many :unread_notifications, ->(membership) {
-    scope = since(membership.unread_at || Time.current)
-
-    if membership.room.direct?
-      scope
-    else
-      scope.where(
-        "EXISTS (SELECT 1 FROM notifications WHERE notifications.message_id = messages.id
-          AND notifications.user_id = ? AND notifications.activity_type = 'mention')
-         OR messages.mentions_everyone = ?",
-        membership.user_id, true
-      ).distinct
-    end
-  }, through: :room, source: :messages
+  # After the room association: Unreadable's unread_notifications goes through it.
+  include Unreadable
 
   scope :with_ordered_room, -> { includes(:room).joins(:room).order("rooms.sortable_name") }
   scope :with_room_by_activity, -> { includes(:room).joins(:room).order("rooms.messages_count DESC") }
@@ -39,112 +27,18 @@ class Membership < ApplicationRecord
   scope :without_thread_rooms, -> { joins(:room).where.not(rooms: { type: %w[ Rooms::Thread Rooms::Post ] }) }
   scope :active_rooms, -> { joins(:room).where(rooms: { active: true }) }
   scope :with_messages, -> { joins(:room).where("rooms.messages_count > 0") }
-  # Memberships that have unread messages OR whose room was updated recently.
-  # Used to filter direct messages in the sidebar to only show recent conversations.
-  scope :recently_active_or_unread, ->(since: 7.days.ago) {
-    joins(:room).where("memberships.unread_at IS NOT NULL OR rooms.updated_at > ?", since)
-  }
-
-  scope :read,    -> { where(unread_at: nil) }
-  scope :unread,  -> { where.not(unread_at: nil) }
 
   class LastVisibleMemberError < StandardError; end
 
   # User-initiated leave: clear involvement (cascades to starred via
   # Membership::Starrable#unstar_if_invisible). The row stays `active = true`.
   # Distinct from admin-driven User#deactivate / Room#deactivate, which flip
-  # `active` instead and preserve involvement / starred / unread_at for later
-  # reactivation.
+  # `active` instead and preserve involvement / starred / read-cursor state
+  # for later reactivation.
   def leave!
     with_lock do
       room.ensure_visible_members_remain!(excluding: user_id)
       update!(involvement: :invisible)
     end
   end
-
-  def read_until(time)
-    return if read? || time < unread_at
-
-    new_unread_at = room.messages.without_events.ordered.where("created_at > ?", time).first&.created_at
-    update!(unread_at: new_unread_at, unread_notifications_count: count_unread_notifications_from(new_unread_at))
-    broadcast_read if read?
-  end
-
-  def mark_unread_at(message)
-    update!(unread_at: message.created_at, unread_notifications_count: count_unread_notifications_from(message.created_at))
-    broadcast_unread
-  end
-
-  def read
-    update!(unread_at: nil, unread_notifications_count: 0)
-    broadcast_read
-  end
-
-  def clear_unread_notifications_until(time)
-    update!(unread_notifications_count: count_unread_notifications_after(time))
-  end
-
-  def read?
-    unread_at.blank?
-  end
-
-  def unread?
-    unread_at.present?
-  end
-
-  def has_unread_notifications?
-    unread_notifications_count > 0
-  end
-
-  # Recompute the count of notification-worthy unread messages from a given anchor.
-  # Returns 0 when the anchor is nil (membership is read).
-  def count_unread_notifications_from(anchor_time)
-    return 0 if anchor_time.nil?
-
-    base = room.messages.where("created_at >= ?", anchor_time)
-
-    if room.direct?
-      base.count
-    else
-      base.where(
-        "messages.mentions_everyone = ? OR EXISTS (" \
-          "SELECT 1 FROM notifications WHERE notifications.message_id = messages.id " \
-          "AND notifications.user_id = ? AND notifications.activity_type = 'mention')",
-        true, user_id
-      ).count
-    end
-  end
-
-  private
-    def broadcast_read
-      ReadRoomsChannel.broadcast_to(user, { room_id: room_id })
-    end
-
-    def broadcast_unread
-      UserUnreadRoomsChannel.broadcast_to(user, unread_payload)
-      UnreadNotificationsChannel.broadcast_to(user, notification_payload) if has_unread_notifications?
-    end
-
-    def count_unread_notifications_after(time)
-      return 0 if unread_at.nil?
-
-      Notification.joins(:message)
-        .where(user_id: user_id, activity_type: "mention", messages: { room_id: room_id })
-        .where("messages.created_at >= ?", unread_at)
-        .where("notifications.created_at > ?", time)
-        .count
-    end
-
-    def unread_payload
-      {
-        roomId: room.id,
-        roomSize: room.messages_count,
-        roomUpdatedAt: room.last_active_at.iso8601,
-        forceUnread: true
-      }
-    end
-
-    def notification_payload
-      { roomId: room.id }
-    end
 end

--- a/app/models/membership/connectable.rb
+++ b/app/models/membership/connectable.rb
@@ -14,12 +14,33 @@ module Membership::Connectable
   ACTIVITY_TIERS = { active: 10.minutes, away: 1.hour, recently_active: 24.hours }.freeze
 
   class_methods do
+    # Server shutdown drops every connection at once, so every watcher's
+    # cursor advances to their room's head first — messages they watched live
+    # count as seen. Explicit mark-as-unread survives.
     def disconnect_all
+      connected.where(marked_unread: false).update_all(<<~SQL.squish)
+        last_read_at = COALESCE(
+          (SELECT m.created_at FROM messages m
+            WHERE m.room_id = memberships.room_id AND m.active = TRUE
+            ORDER BY m.created_at DESC, m.id DESC LIMIT 1),
+          CURRENT_TIMESTAMP),
+        last_read_message_id = COALESCE(
+          (SELECT m.id FROM messages m
+            WHERE m.room_id = memberships.room_id AND m.active = TRUE
+            ORDER BY m.created_at DESC, m.id DESC LIMIT 1),
+          0)
+      SQL
       connected.update_all connected_at: nil, connections: 0, updated_at: Time.current
     end
 
     def connect(membership, connections)
-      where(id: membership.id).update_all(connections: connections, connected_at: Time.current, unread_at: nil, unread_notifications_count: 0)
+      head_at, head_id = membership.room_head_position
+      where(id: membership.id).update_all(
+        connections: connections, connected_at: Time.current,
+        last_read_at: head_at, last_read_message_id: head_id,
+        marked_unread: false, unread_notifications_count: 0,
+        updated_at: Time.current
+      )
     end
 
     def last_connected_at_for(user_ids)
@@ -74,14 +95,21 @@ module Membership::Connectable
     touch :connected_at
   end
 
+  # Fully leaving a room counts everything watched live as seen, so the
+  # cursor advances to the room's head — unless the member explicitly marked
+  # the room unread, which must survive the disconnect.
   def disconnected
     decrement_connections
-    update! connected_at: nil if connections < 1
+    if connections < 1
+      update! connected_at: nil
+      advance_cursor_to_head unless marked_unread?
+    end
   end
 
   def refresh_connection
     increment_connections unless connected?
     touch :connected_at
+    advance_cursor_to_head unless marked_unread?
   end
 
   def increment_connections

--- a/app/models/membership/unreadable.rb
+++ b/app/models/membership/unreadable.rb
@@ -11,10 +11,10 @@
 # reset every member to caught-up; a membership with no cursor (created in
 # the deploy window by pre-cursor code) reads as read, not all-unread.
 #
-# marked_unread covers the two states a cursor cannot: an explicit
-# mark-as-unread (which must survive connection churn without being wiped by
-# a cursor advance) and forum dots (a forum owns no messages, so there is no
-# message for a cursor to fall behind).
+# marked_unread covers the one state a cursor cannot: an explicit
+# mark-as-unread, which must survive connection churn without being wiped by
+# a cursor advance. (A forum owns no messages, but its dot still derives —
+# from posts created after the cursor. See UNSEEN_POSTS_SQL.)
 module Membership::Unreadable
   extend ActiveSupport::Concern
 
@@ -29,6 +29,22 @@ module Membership::Unreadable
           OR (messages.created_at = memberships.last_read_at AND messages.id > memberships.last_read_message_id))
     )
   SQL
+
+  # A forum owns no messages: its dot derives from active posts (sub-rooms)
+  # created after the cursor instead. Time-only comparison — the cursor's
+  # message id means nothing against posts. Rides
+  # index_rooms_on_parent_room_and_created.
+  UNSEEN_POSTS_SQL = <<~SQL.squish
+    EXISTS (
+      SELECT 1 FROM rooms posts
+      WHERE posts.parent_room_id = memberships.room_id
+        AND posts.type = 'Rooms::Post'
+        AND posts.active = TRUE
+        AND posts.created_at > memberships.last_read_at
+    )
+  SQL
+
+  UNSEEN_SQL = "(#{UNSEEN_MESSAGES_SQL} OR #{UNSEEN_POSTS_SQL})"
 
   included do
     has_many :unread_notifications, ->(membership) {
@@ -52,7 +68,7 @@ module Membership::Unreadable
 
     scope :read, -> {
       where(marked_unread: false)
-        .where("memberships.connected_at >= :ttl OR memberships.last_read_at IS NULL OR NOT #{UNSEEN_MESSAGES_SQL}",
+        .where("memberships.connected_at >= :ttl OR memberships.last_read_at IS NULL OR NOT #{UNSEEN_SQL}",
                ttl: Membership::Connectable::CONNECTION_TTL.ago)
     }
     scope :unread, -> {
@@ -60,7 +76,7 @@ module Membership::Unreadable
         where(marked_unread: true).or(
           where(connected_at: [ nil, ...Membership::Connectable::CONNECTION_TTL.ago ])
             .where.not(last_read_at: nil)
-            .where(UNSEEN_MESSAGES_SQL)
+            .where(UNSEEN_SQL)
         )
       )
     }
@@ -68,7 +84,7 @@ module Membership::Unreadable
     # Used to filter direct messages in the sidebar to only show recent conversations.
     scope :recently_active_or_unread, ->(since: 7.days.ago) {
       joins(:room).where(
-        "memberships.marked_unread = TRUE OR (memberships.last_read_at IS NOT NULL AND #{UNSEEN_MESSAGES_SQL}) OR rooms.updated_at > :since",
+        "memberships.marked_unread = TRUE OR (memberships.last_read_at IS NOT NULL AND #{UNSEEN_SQL}) OR rooms.updated_at > :since",
         since: since
       )
     }
@@ -101,6 +117,22 @@ module Membership::Unreadable
         )
       SQL
     }
+    # The forum analog of caught_up_besides: caught up on every post except,
+    # at most, the given one. The set whose cursor may safely advance past
+    # that post.
+    scope :caught_up_besides_post, ->(post) {
+      where(marked_unread: false).where(<<~SQL.squish, post_id: post.id)
+        NOT EXISTS (
+          SELECT 1 FROM rooms posts
+          WHERE posts.parent_room_id = memberships.room_id
+            AND posts.type = 'Rooms::Post'
+            AND posts.active = TRUE
+            AND posts.id != :post_id
+            AND (memberships.last_read_at IS NULL
+              OR posts.created_at > memberships.last_read_at)
+        )
+      SQL
+    }
 
     before_create :snapshot_read_cursor
   end
@@ -113,7 +145,7 @@ module Membership::Unreadable
     return false if involved_in_invisible?
     return true if marked_unread?
     return false if connected?
-    unseen_messages?
+    unseen_messages? || unseen_posts?
   end
 
   def read
@@ -165,7 +197,8 @@ module Membership::Unreadable
   end
 
   # When this membership became unread: the first unseen message's timestamp.
-  # Nil when read, or when the unread state is flag-only (forum dots).
+  # Nil when read, or when the unread carries no message (a forum's
+  # post-derived dot, or an explicit mark in an empty room).
   def unread_since
     return nil unless unread?
     first_unread_message&.created_at
@@ -179,6 +212,12 @@ module Membership::Unreadable
   def unseen_messages?
     return false if last_read_at.nil?
     room.messages.after_cursor(last_read_at, last_read_message_id).exists?
+  end
+
+  # The forum arm of unread?: active posts created after the cursor.
+  def unseen_posts?
+    return false if last_read_at.nil? || !room.forum?
+    room.posts.where("created_at > ?", last_read_at).exists?
   end
 
   # Recompute the count of notification-worthy messages after a cursor

--- a/app/models/membership/unreadable.rb
+++ b/app/models/membership/unreadable.rb
@@ -1,0 +1,266 @@
+# Derived unread. A membership stores a (last_read_at, last_read_message_id)
+# cursor — the position of the last message its member has seen — and
+# unread-ness is derived by comparing that cursor against the room's active
+# messages. Sending a message writes nothing to member rows (the sender's own
+# cursor aside), and a soft-deleted message stops counting automatically
+# because the comparison only sees active messages.
+#
+# The cursor advances at view-time: when the membership is created, when the
+# member presents in the room, on presence refresh, and when they fully
+# disconnect (messages watched live count as seen). The cutover migration
+# reset every member to caught-up; a membership with no cursor (created in
+# the deploy window by pre-cursor code) reads as read, not all-unread.
+#
+# marked_unread covers the two states a cursor cannot: an explicit
+# mark-as-unread (which must survive connection churn without being wiped by
+# a cursor advance) and forum dots (a forum owns no messages, so there is no
+# message for a cursor to fall behind).
+module Membership::Unreadable
+  extend ActiveSupport::Concern
+
+  # A membership has unseen messages when an active message in its room sits
+  # strictly after its cursor. Correlated form, for scopes over memberships.
+  UNSEEN_MESSAGES_SQL = <<~SQL.squish
+    EXISTS (
+      SELECT 1 FROM messages
+      WHERE messages.room_id = memberships.room_id
+        AND messages.active = TRUE
+        AND (messages.created_at > memberships.last_read_at
+          OR (messages.created_at = memberships.last_read_at AND messages.id > memberships.last_read_message_id))
+    )
+  SQL
+
+  included do
+    has_many :unread_notifications, ->(membership) {
+      scope = if membership.last_read_at
+        after_cursor(membership.last_read_at, membership.last_read_message_id)
+      else
+        none
+      end
+
+      if membership.room.direct?
+        scope
+      else
+        scope.where(
+          "EXISTS (SELECT 1 FROM notifications WHERE notifications.message_id = messages.id
+            AND notifications.user_id = ? AND notifications.activity_type = 'mention')
+           OR messages.mentions_everyone = ?",
+          membership.user_id, true
+        ).distinct
+      end
+    }, through: :room, source: :messages
+
+    scope :read, -> {
+      where(marked_unread: false)
+        .where("memberships.connected_at >= :ttl OR memberships.last_read_at IS NULL OR NOT #{UNSEEN_MESSAGES_SQL}",
+               ttl: Membership::Connectable::CONNECTION_TTL.ago)
+    }
+    scope :unread, -> {
+      visible.merge(
+        where(marked_unread: true).or(
+          where(connected_at: [ nil, ...Membership::Connectable::CONNECTION_TTL.ago ])
+            .where.not(last_read_at: nil)
+            .where(UNSEEN_MESSAGES_SQL)
+        )
+      )
+    }
+    # Memberships that have unread messages OR whose room was updated recently.
+    # Used to filter direct messages in the sidebar to only show recent conversations.
+    scope :recently_active_or_unread, ->(since: 7.days.ago) {
+      joins(:room).where(
+        "memberships.marked_unread = TRUE OR (memberships.last_read_at IS NOT NULL AND #{UNSEEN_MESSAGES_SQL}) OR rooms.updated_at > :since",
+        since: since
+      )
+    }
+    # Memberships for whom the given message is unseen: their cursor sits
+    # before it and they weren't watching live (connected members see the
+    # message as it lands; an explicit mark-as-unread counts as not watching).
+    # This is the eligibility test for unread_notifications_count bumps and
+    # their reversals.
+    scope :with_message_unseen, ->(created_at, id) {
+      where("memberships.last_read_at IS NOT NULL AND (memberships.last_read_at < :t OR (memberships.last_read_at = :t AND memberships.last_read_message_id < :id))",
+            t: created_at, id: id)
+        .merge(
+          where(marked_unread: true)
+            .or(where(connected_at: [ nil, ...Membership::Connectable::CONNECTION_TTL.ago ]))
+        )
+    }
+    # Memberships caught up on everything except, at most, the given message —
+    # no explicit mark, nothing else unseen. The set whose cursor may safely
+    # advance past that message.
+    scope :caught_up_besides, ->(message) {
+      where(marked_unread: false).where(<<~SQL.squish, message_id: message.id)
+        NOT EXISTS (
+          SELECT 1 FROM messages
+          WHERE messages.room_id = memberships.room_id
+            AND messages.active = TRUE
+            AND messages.id != :message_id
+            AND (memberships.last_read_at IS NULL
+              OR messages.created_at > memberships.last_read_at
+              OR (messages.created_at = memberships.last_read_at AND messages.id > memberships.last_read_message_id))
+        )
+      SQL
+    }
+
+    before_create :snapshot_read_cursor
+  end
+
+  def read?
+    !unread?
+  end
+
+  def unread?
+    return false if involved_in_invisible?
+    return true if marked_unread?
+    return false if connected?
+    unseen_messages?
+  end
+
+  def read
+    head_at, head_id = room_head_position
+    update!(last_read_at: head_at, last_read_message_id: head_id, marked_unread: false, unread_notifications_count: 0)
+    broadcast_read
+  end
+
+  def mark_unread_at(message)
+    cursor_at, cursor_id = position_before(message)
+    update!(
+      last_read_at: cursor_at, last_read_message_id: cursor_id, marked_unread: true,
+      unread_notifications_count: count_unseen_notifications(cursor_at, cursor_id)
+    )
+    broadcast_unread
+  end
+
+  def read_until(time)
+    return if read?
+
+    next_unread = room.messages.without_events.ordered.where("created_at > ?", time).first
+    if next_unread.nil?
+      read
+    else
+      cursor_at, cursor_id = position_before(next_unread)
+      return if cursor_at_or_after?(cursor_at, cursor_id)
+
+      update!(
+        last_read_at: cursor_at, last_read_message_id: cursor_id, marked_unread: false,
+        unread_notifications_count: count_unseen_notifications(cursor_at, cursor_id)
+      )
+    end
+  end
+
+  # Marks the room unread from its latest message without recomputing the
+  # badge or broadcasting — the quiet involve-with-unread path.
+  def rewind_to_unread
+    last = room.messages.reorder(:created_at, :id).last
+    cursor_at, cursor_id = last ? position_before(last) : [ Time.at(0), 0 ]
+    update!(last_read_at: cursor_at, last_read_message_id: cursor_id, marked_unread: true)
+  end
+
+  def clear_unread_notifications_until(time)
+    update!(unread_notifications_count: count_unread_notifications_after(time))
+  end
+
+  def has_unread_notifications?
+    unread_notifications_count > 0
+  end
+
+  # When this membership became unread: the first unseen message's timestamp.
+  # Nil when read, or when the unread state is flag-only (forum dots).
+  def unread_since
+    return nil unless unread?
+    first_unread_message&.created_at
+  end
+
+  def first_unread_message
+    return nil if last_read_at.nil?
+    room.messages.after_cursor(last_read_at, last_read_message_id).order(:created_at, :id).first
+  end
+
+  def unseen_messages?
+    return false if last_read_at.nil?
+    room.messages.after_cursor(last_read_at, last_read_message_id).exists?
+  end
+
+  # Recompute the count of notification-worthy messages after a cursor
+  # position. Returns 0 for a nil cursor (membership reads as read).
+  def count_unseen_notifications(from_at = last_read_at, from_id = last_read_message_id)
+    return 0 if from_at.nil?
+
+    base = room.messages.after_cursor(from_at, from_id)
+
+    if room.direct?
+      base.count
+    else
+      base.where(
+        "messages.mentions_everyone = ? OR EXISTS (" \
+          "SELECT 1 FROM notifications WHERE notifications.message_id = messages.id " \
+          "AND notifications.user_id = ? AND notifications.activity_type = 'mention')",
+        true, user_id
+      ).count
+    end
+  end
+
+  # Advances the cursor to the room's newest message — the member has seen
+  # everything up to now. Skips callbacks: pure bookkeeping.
+  def advance_cursor_to_head
+    head_at, head_id = room_head_position
+    update_columns(last_read_at: head_at, last_read_message_id: head_id, updated_at: Time.current)
+  end
+
+  # The room's newest active message position, or a caught-up-as-of-now
+  # sentinel for a room with no messages (never nil: a nil cursor reads as
+  # read and would silence future dots).
+  def room_head_position
+    head = room.messages.reorder(:created_at, :id).last
+    head ? [ head.created_at, head.id ] : [ Time.current, 0 ]
+  end
+
+  private
+    def snapshot_read_cursor
+      return if last_read_at.present?
+      self.last_read_at, self.last_read_message_id = room_head_position if room
+    end
+
+    def position_before(message)
+      previous = room.messages.before_cursor(message.created_at, message.id)
+                     .reorder(created_at: :desc, id: :desc).first
+      previous ? [ previous.created_at, previous.id ] : [ Time.at(0), 0 ]
+    end
+
+    def cursor_at_or_after?(time, id)
+      last_read_at.present? &&
+        (last_read_at > time || (last_read_at == time && last_read_message_id >= id))
+    end
+
+    def count_unread_notifications_after(time)
+      return 0 if last_read_at.nil? || read?
+
+      Notification.joins(:message)
+        .where(user_id: user_id, activity_type: "mention", messages: { room_id: room_id })
+        .merge(Message.after_cursor(last_read_at, last_read_message_id))
+        .where("notifications.created_at > ?", time)
+        .count
+    end
+
+    def broadcast_read
+      ReadRoomsChannel.broadcast_to(user, { room_id: room_id })
+    end
+
+    def broadcast_unread
+      UserUnreadRoomsChannel.broadcast_to(user, unread_payload)
+      UnreadNotificationsChannel.broadcast_to(user, notification_payload) if has_unread_notifications?
+    end
+
+    def unread_payload
+      {
+        roomId: room.id,
+        roomSize: room.messages_count,
+        roomUpdatedAt: room.last_active_at.iso8601,
+        forceUnread: true
+      }
+    end
+
+    def notification_payload
+      { roomId: room.id }
+    end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -61,6 +61,13 @@ class Message < ApplicationRecord
     where(table[:created_at].lt(time))
       .or(where(table[:created_at].eq(time)).where(table[:id].lt(id)))
   }
+  # Mirror of before_cursor: everything strictly after a (time, id) point.
+  # Powers derived unread — messages after a membership's read cursor.
+  scope :after_cursor, ->(time, id) {
+    table = arel_table
+    where(table[:created_at].gt(time))
+      .or(where(table[:created_at].eq(time)).where(table[:id].gt(id)))
+  }
   scope :with_bookmark_status_for, ->(user) {
     joins(sanitize_sql_array([ <<~SQL.squish, user.id ])).select("messages.*, (bookmarks.id IS NOT NULL) AS is_bookmarked")
       LEFT JOIN bookmarks

--- a/app/models/message/broadcasts.rb
+++ b/app/models/message/broadcasts.rb
@@ -40,8 +40,8 @@ module Message::Broadcasts
     end
 
     if ignore_if_older_message
-      # Filter in SQL: exclude users who have read or whose unread_at is after this message
-      scope = scope.where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
+      # Filter in SQL: only users for whom this message is still unseen
+      scope = scope.merge(Membership.with_message_unseen(created_at, id))
     end
 
     scope.pluck(:user_id)

--- a/app/models/message/threadable.rb
+++ b/app/models/message/threadable.rb
@@ -6,7 +6,7 @@ module Message::Threadable
     after_create_commit :update_thread_reply_count
     after_create_commit :update_parent_message_threads
     after_create_commit :update_forum_gallery_card
-    after_create_commit :mark_forum_unread
+    after_create_commit :surface_on_forum
     after_create_commit :create_thread_reply_notifications
     after_update_commit :broadcast_parent_message_to_threads
   end
@@ -54,13 +54,13 @@ module Message::Threadable
       room.broadcast_gallery_card_to_top if room.post?
     end
 
-    # A post's activity pokes the forum's sidebar unread for the members who should
-    # see it — a new post reaches every member, a mention reaches the people named,
-    # a plain reply reaches no one (its followers get an Activity notification). The
-    # forum owns no messages, so this is how the signal reaches its sidebar entry;
-    # opening the forum clears it via presence (Membership::Connectable.connect).
-    def mark_forum_unread
-      room.parent_room.mark_unread_from_post(self) if room.post?
+    # A post's opening message is the forum's version of receiving a message:
+    # it surfaces the forum's sidebar entry for every member. A plain reply
+    # reaches no one this way (its followers get an Activity notification),
+    # and opening the forum clears the dot via presence
+    # (Membership::Connectable.connect).
+    def surface_on_forum
+      room.parent_room.receive_post(self) if room.post?
     end
 
     def create_thread_reply_notifications

--- a/app/models/message/unreadable.rb
+++ b/app/models/message/unreadable.rb
@@ -2,13 +2,13 @@ module Message::Unreadable
   extend ActiveSupport::Concern
 
   included do
-    # Order matters: deliver_to_room sets unread_at for disconnected read
-    # memberships, and increment_unread_notifications_counters then bumps the
-    # counter for memberships with unread_at <= created_at. Swap them and the
-    # counter never bumps for a read → unread transition.
+    # Order matters: deliver_to_room advances the sender's read cursor, and
+    # increment_unread_notifications_counters then bumps the counter for
+    # memberships whose cursor sits before this message. Swap them and a
+    # caught-up DM sender would bump their own badge.
     after_create_commit :deliver_to_room
     after_create_commit :increment_unread_notifications_counters
-    after_update_commit :clear_unread_timestamps_if_deactivated
+    after_update_commit :rebalance_unread_counters_if_deactivated
     after_update_commit :destroy_notifications_if_deactivated
     after_update_commit :restore_unread_notifications_counters_if_reactivated
   end
@@ -22,8 +22,8 @@ module Message::Unreadable
     # Mirrors the with_has_unread_notifications semantics: DM rooms count every
     # unread message (including the sender's, matching the old scope which made
     # no creator distinction in DMs); other rooms only count mentions and
-    # @everyone. Connected users (unread_at IS NULL) are skipped — they see
-    # the message live, and senders almost always fall in this bucket.
+    # @everyone. Members watching live are skipped — they see the message as it
+    # lands, and senders almost always fall in this bucket.
     def increment_unread_notifications_counters
       return if event?
 
@@ -38,11 +38,11 @@ module Message::Unreadable
       return if recipient_ids.empty?
 
       Membership.where(room_id: room_id, user_id: recipient_ids)
-                .where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
+                .merge(Membership.with_message_unseen(created_at, id))
                 .update_all("unread_notifications_count = unread_notifications_count + 1")
     end
 
-    def clear_unread_timestamps_if_deactivated
+    def rebalance_unread_counters_if_deactivated
       return unless saved_change_to_attribute?(:active) && !active?
       rebalance_unread_counters
     end
@@ -54,10 +54,10 @@ module Message::Unreadable
     end
 
     # When a soft-deleted message is reactivated (a console/admin path),
-    # restore the counter bumps that clear_unread_timestamps_if_deactivated
-    # took away. Only DM and @everyone messages are restored — named mentions
-    # need their Notification rows back to count under either the old scope
-    # or the new column, and we don't recreate those on reactivation.
+    # restore the counter bumps that rebalance_unread_counters took away.
+    # Only DM and @everyone messages are restored — named mentions need their
+    # Notification rows back to count, and we don't recreate those on
+    # reactivation.
     def restore_unread_notifications_counters_if_reactivated
       return unless saved_change_to_attribute?(:active) && active?
       return if event?
@@ -67,42 +67,26 @@ module Message::Unreadable
       return if recipient_ids.empty?
 
       Membership.where(room_id: room_id, user_id: recipient_ids)
-                .where("unread_at IS NOT NULL AND unread_at <= ?", created_at)
+                .merge(Membership.with_message_unseen(created_at, id))
                 .update_all("unread_notifications_count = unread_notifications_count + 1")
     end
 
-    # Keeps memberships.unread_notifications_count and unread_at consistent
-    # when this message disappears from the room (soft- or hard-deleted).
-    # Called by Message#destroy_all_associated_records as well as the
-    # deactivation callback above.
+    # Keeps memberships.unread_notifications_count consistent when this
+    # message disappears from the room (soft- or hard-deleted). Called by
+    # Message#destroy_all_associated_records as well as the deactivation
+    # callback above.
     #
-    # Two effects per call:
-    #   1. DMs only: every membership whose unread window contained this
-    #      message loses one from its count (using < to leave the anchor
-    #      membership for the second pass below).
-    #   2. Any membership anchored exactly at this message's timestamp gets
-    #      its anchor advanced to the next active message (or marked read),
-    #      with its counter recomputed from the new anchor.
+    # Only the DM counter needs rebalancing here: DMs count every unseen
+    # message, so each membership whose cursor sat before this one loses a
+    # count. Mention counters unwind through the notification destroy
+    # (Notification.decrement_membership_counters), and derived unread itself
+    # self-heals — the cursor comparison only sees active messages, so no
+    # anchor needs advancing.
     def rebalance_unread_counters
-      if room.direct?
-        Membership.where(room_id: room_id)
-                  .where("unread_at IS NOT NULL AND unread_at < ?", created_at)
-                  .update_all("unread_notifications_count = MAX(unread_notifications_count - 1, 0)")
-      end
+      return unless room.direct?
 
-      room.memberships.where(unread_at: created_at).find_each do |membership|
-        next_unread = room.messages.active.ordered
-                         .where("created_at > ?", created_at)
-                         .first
-
-        if next_unread
-          membership.update!(
-            unread_at: next_unread.created_at,
-            unread_notifications_count: membership.count_unread_notifications_from(next_unread.created_at)
-          )
-        else
-          membership.read
-        end
-      end
+      Membership.where(room_id: room_id)
+                .merge(Membership.with_message_unseen(created_at, id))
+                .update_all("unread_notifications_count = MAX(unread_notifications_count - 1, 0)")
     end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -61,7 +61,7 @@ class Notification < ApplicationRecord
       next unless message
 
       Membership.where(room_id: message.room_id, user_id: notification.user_id)
-                .where("unread_at IS NOT NULL AND unread_at <= ?", message.created_at)
+                .merge(Membership.with_message_unseen(message.created_at, message.id))
                 .update_all("unread_notifications_count = MAX(unread_notifications_count - 1, 0)")
     end
   end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -102,7 +102,7 @@ class Room < ApplicationRecord
 
   def receive(message)
     catch_up_sender(message)
-    broadcast_unread_to_disconnected_users(message)
+    broadcast_touched
   end
 
   # Routing-vocabulary symbols that apply to a message in this room — a subset
@@ -395,19 +395,14 @@ class Room < ApplicationRecord
         .update_all(last_read_at: message.created_at, last_read_message_id: message.id, updated_at: Time.current)
     end
 
-    def broadcast_unread_to_disconnected_users(message)
-      users = memberships.visible.disconnected.where.not(user: message.creator).includes(:user).map(&:user)
-      return if users.empty?
-
-      payload = {
-        roomId: id,
-        roomSize: messages_count,
-        roomUpdatedAt: last_active_at.iso8601,
-        forceUnread: true
-      }
-      users.each do |user|
-        UserUnreadRoomsChannel.broadcast_to(user, payload)
-      end
+    # One shared publish per message, whatever the room's size. Every open
+    # sidebar in the account gets the touched room's sort metadata and derives
+    # its own unread state client-side: non-members find no matching row, and
+    # the member viewing the room sees the message land, so no dot.
+    def broadcast_touched
+      RoomListChannel.broadcast_to(Account.sole, { roomId: id, roomSize: messages_count, roomUpdatedAt: last_active_at.iso8601 })
+    rescue ActiveRecord::RecordNotFound
+      # No account yet (e.g., during setup or seed)
     end
 
     # Cascade-deactivate the chat threads spawned off this room's messages. Only

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -10,9 +10,13 @@ class Room < ApplicationRecord
   has_many :memberships, -> { active } do
     def grant_to(users)
       room = proxy_association.owner
+      # New members start caught up to the room's head — messages after the
+      # grant dot them. update_only keeps a rejoining member's cursor intact.
+      head = room.messages.reorder(:created_at, :id).last
+      head_at, head_id = head ? [ head.created_at, head.id ] : [ Time.current, 0 ]
       Membership.upsert_all(
-        Array(users).collect { |user| { room_id: room.id, user_id: user.id, involvement: room.default_involvement(user: user), active: true } },
-        unique_by: %i[room_id user_id]
+        Array(users).collect { |user| { room_id: room.id, user_id: user.id, involvement: room.default_involvement(user: user), active: true, last_read_at: head_at, last_read_message_id: head_id } },
+        unique_by: %i[room_id user_id], update_only: %i[involvement active]
       )
     end
 
@@ -97,7 +101,8 @@ class Room < ApplicationRecord
   end
 
   def receive(message)
-    unread_memberships(message)
+    catch_up_sender(message)
+    broadcast_unread_to_disconnected_users(message)
   end
 
   # Routing-vocabulary symbols that apply to a message in this room — a subset
@@ -109,7 +114,7 @@ class Room < ApplicationRecord
 
   def involve_user(user, unread: false)
     membership = memberships.create_with(involvement: "mentions").find_or_create_by(user: user)
-    membership.update(unread_at: messages.last&.created_at || Time.current) if unread && membership.read?
+    membership.rewind_to_unread if unread && membership.read?
     membership.ensure_receives_mentions!
   end
 
@@ -380,14 +385,14 @@ class Room < ApplicationRecord
       self.last_active_at = Time.current
     end
 
-    def unread_memberships(message)
-      # Mark read users as unread
-      memberships.visible.disconnected.read.where.not(user: message.creator)
-        .update_all(unread_at: message.created_at, updated_at: Time.current)
-
-      # Broadcast to ALL disconnected users (not just newly unread)
-      # Already-unread users need updated roomSize/roomUpdatedAt for sidebar ordering
-      broadcast_unread_to_disconnected_users(message)
+    # Sending means the sender has seen everything — but only advance their
+    # cursor when they were already caught up. A sender with an open unread
+    # window (away in a DM, or an explicit mark) keeps it: their own message
+    # lands inside the window, matching how the badge counts it.
+    def catch_up_sender(message)
+      memberships.where(user_id: message.creator_id)
+        .merge(Membership.caught_up_besides(message))
+        .update_all(last_read_at: message.created_at, last_read_message_id: message.id, updated_at: Time.current)
     end
 
     def broadcast_unread_to_disconnected_users(message)

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -102,7 +102,7 @@ class Room < ApplicationRecord
 
   def receive(message)
     catch_up_sender(message)
-    broadcast_touched
+    broadcast_touched(creator_id: message.creator_id)
   end
 
   # Routing-vocabulary symbols that apply to a message in this room — a subset
@@ -397,10 +397,12 @@ class Room < ApplicationRecord
 
     # One shared publish per message, whatever the room's size. Every open
     # sidebar in the account gets the touched room's sort metadata and derives
-    # its own unread state client-side: non-members find no matching row, and
-    # the member viewing the room sees the message land, so no dot.
-    def broadcast_touched
-      RoomListChannel.broadcast_to(Account.sole, { roomId: id, roomSize: messages_count, roomUpdatedAt: last_active_at.iso8601 })
+    # its own unread state client-side: non-members find no matching row, the
+    # member viewing the room sees the message land, and the creator's own
+    # clients skip the dot (they may be elsewhere — a forum author lands on
+    # their new post, a sender's second device sits in another room).
+    def broadcast_touched(creator_id:)
+      RoomListChannel.broadcast_to(Account.sole, { roomId: id, roomSize: messages_count, roomUpdatedAt: last_active_at.iso8601, creatorId: creator_id })
     rescue ActiveRecord::RecordNotFound
       # No account yet (e.g., during setup or seed)
     end

--- a/app/models/rooms/forum.rb
+++ b/app/models/rooms/forum.rb
@@ -115,17 +115,22 @@ class Rooms::Forum < Room
               .update_all(involvement: "invisible")
   end
 
-  # Poke the forum's sidebar unread for a new post — a dot, like any new room
-  # message — for the members who should see it. A forum owns no messages, so this
-  # mirrors a chat room's unread behavior against the forum's own memberships. It
-  # deliberately does NOT bump last_active_at — a post surfaces the forum via its
-  # unread state (which sorts to the top of its group), not chat-style reordering.
+  # A new post is the forum's version of receiving a message: the author's
+  # cursor advances and one shared nudge goes out, exactly like Room#receive.
+  # Every other member's dot derives from the post's position against their
+  # cursor (Membership::Unreadable::UNSEEN_POSTS_SQL) — nothing is written to
+  # member rows. It deliberately does NOT bump last_active_at — a post
+  # surfaces the forum via its unread state (which sorts to the top of its
+  # group), not chat-style reordering.
   #
   # Mentions are deliberately NOT surfaced here: a forum mention behaves like a
   # thread mention, reaching the named member through Activity only (see
   # Message::Mentionee), not a sidebar dot or number badge.
-  def mark_unread_from_post(message)
-    mark_members_unread(message) if message.room.opening_message?(message)
+  def receive_post(message)
+    return unless message.room.opening_message?(message)
+
+    catch_up_author(message.room)
+    broadcast_touched(creator_id: message.creator_id)
   end
 
   private
@@ -137,19 +142,12 @@ class Rooms::Forum < Room
       ForumFollowCleanupJob.perform_later(forum: self, user: user)
     end
 
-    # Every disconnected member but the author — a member viewing the gallery sees
-    # the post live and their presence already keeps them read. A forum owns no
-    # messages, so its dot can't derive from a read cursor: the marked_unread
-    # flag carries it, and presence (connect) clears it on open.
-    def mark_members_unread(message)
-      recipients = memberships.visible.disconnected.where.not(user_id: message.creator_id)
-      recipients.read.update_all(marked_unread: true, updated_at: Time.current)
-      recipients.includes(:user).each { |membership| broadcast_dot(membership) }
-    end
-
-    def broadcast_dot(membership)
-      UserUnreadRoomsChannel.broadcast_to(membership.user, {
-        roomId: id, roomSize: messages_count, roomUpdatedAt: last_active_at.iso8601, forceUnread: true
-      })
+    # Posting means the author has seen the forum's newest state — advance
+    # their cursor past their own post so it never dots them, unless another
+    # unseen post keeps their window open (mirrors Room#catch_up_sender).
+    def catch_up_author(post)
+      memberships.where(user_id: post.creator_id)
+        .merge(Membership.caught_up_besides_post(post))
+        .update_all(last_read_at: post.created_at, last_read_message_id: 0, updated_at: Time.current)
     end
 end

--- a/app/models/rooms/forum.rb
+++ b/app/models/rooms/forum.rb
@@ -138,10 +138,12 @@ class Rooms::Forum < Room
     end
 
     # Every disconnected member but the author — a member viewing the gallery sees
-    # the post live and their presence already keeps them read.
+    # the post live and their presence already keeps them read. A forum owns no
+    # messages, so its dot can't derive from a read cursor: the marked_unread
+    # flag carries it, and presence (connect) clears it on open.
     def mark_members_unread(message)
       recipients = memberships.visible.disconnected.where.not(user_id: message.creator_id)
-      recipients.read.update_all(unread_at: message.created_at, updated_at: Time.current)
+      recipients.read.update_all(marked_unread: true, updated_at: Time.current)
       recipients.includes(:user).each { |membership| broadcast_dot(membership) }
     end
 

--- a/app/models/user/notifiable.rb
+++ b/app/models/user/notifiable.rb
@@ -129,14 +129,17 @@ module User::Notifiable
           m.read_until(until_time) if include_dms
           next
         end
+        next if m.last_read_at.nil?
+
+        unseen_window = m.room.messages.without_events
+          .after_cursor(m.last_read_at, m.last_read_message_id)
+          .created_before(until_time)
 
         notified_message_ids = Notification.where(user: self)
-          .where(message_id: m.room.messages.without_events.between(m.unread_at, until_time).select(:id))
+          .where(message_id: unseen_window.select(:id))
           .pluck(:message_id)
 
-        non_notified = m.room.messages.without_events
-          .where.not(id: notified_message_ids)
-          .between(m.unread_at, until_time)
+        non_notified = unseen_window.where.not(id: notified_message_ids)
 
         if non_notified.none?
           m.read_until(until_time)

--- a/app/views/users/sidebars/rooms/_direct.html.erb
+++ b/app/views/users/sidebars/rooms/_direct.html.erb
@@ -1,11 +1,14 @@
-<% cache membership do %>
+<%# Unread is derived, not stored — a new message doesn't touch the
+    membership row, so the derived state must be part of the cache key. %>
+<% membership_unread = membership.unread? %>
+<% cache [ membership, membership_unread ] do %>
   <% members = @direct_room_members&.dig(membership.room.id).presence || membership.room.users.without(membership.user).presence || [ membership.user ] %>
 
-  <%= link_to_room membership.room, class: [ "direct", "unread": membership.unread? ], id: dom_id(membership.room, :list),
+  <%= link_to_room membership.room, class: [ "direct", "unread": membership_unread ], id: dom_id(membership.room, :list),
         data: {
           sorted_list_target: "item",
-          sorted_list_priority: membership.unread? ? 0 : 1,
-          updated_at: (membership.unread_at || membership.room.updated_at)&.iso8601
+          sorted_list_priority: membership_unread ? 0 : 1,
+          updated_at: ((membership_unread && membership.unread_since) || membership.room.updated_at)&.iso8601
         } do %>
     <% if members.many? %>
       <div class="avatar__group">

--- a/db/migrate/20260709000001_add_read_cursor_to_memberships.rb
+++ b/db/migrate/20260709000001_add_read_cursor_to_memberships.rb
@@ -1,0 +1,30 @@
+class AddReadCursorToMemberships < ActiveRecord::Migration[8.2]
+  def up
+    add_column :memberships, :last_read_at, :datetime
+    add_column :memberships, :last_read_message_id, :integer
+    add_column :memberships, :marked_unread, :boolean, default: false, null: false
+
+    # One-time reset at cutover: every member starts caught up to their room's
+    # head (or to now, in a room with no messages), so the next message dots
+    # them. Legacy unread state is deliberately not carried over.
+    execute <<~SQL.squish
+      UPDATE memberships SET
+        last_read_at = COALESCE(
+          (SELECT m.created_at FROM messages m
+            WHERE m.room_id = memberships.room_id AND m.active = TRUE
+            ORDER BY m.created_at DESC, m.id DESC LIMIT 1),
+          CURRENT_TIMESTAMP),
+        last_read_message_id = COALESCE(
+          (SELECT m.id FROM messages m
+            WHERE m.room_id = memberships.room_id AND m.active = TRUE
+            ORDER BY m.created_at DESC, m.id DESC LIMIT 1),
+          0)
+    SQL
+  end
+
+  def down
+    remove_column :memberships, :marked_unread
+    remove_column :memberships, :last_read_message_id
+    remove_column :memberships, :last_read_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_04_000001) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_09_000001) do
   create_table "account_join_codes", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "code", null: false
@@ -145,6 +145,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_04_000001) do
     t.integer "connections", default: 0, null: false
     t.datetime "created_at", null: false
     t.string "involvement", default: "mentions"
+    t.datetime "last_read_at"
+    t.integer "last_read_message_id"
+    t.boolean "marked_unread", default: false, null: false
     t.integer "room_id", null: false
     t.boolean "starred", default: false, null: false
     t.datetime "unread_at"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -584,6 +584,36 @@ columns:
     default_function:
     collation:
     comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: last_read_at
+    cast_type: *1
+    sql_type_metadata: *2
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: last_read_message_id
+    cast_type: *3
+    sql_type_metadata: *4
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
+    auto_increment:
+    name: marked_unread
+    cast_type: *8
+    sql_type_metadata: *9
+    'null': false
+    default: false
+    default_function:
+    collation:
+    comment:
   - &25 !ruby/object:ActiveRecord::ConnectionAdapters::SQLite3::Column
     auto_increment:
     name: room_id
@@ -3001,4 +3031,4 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-version: 20260704000001
+version: 20260709000001

--- a/docs/plans/2026-07-08-001-perf-realtime-delivery-at-scale-plan.md
+++ b/docs/plans/2026-07-08-001-perf-realtime-delivery-at-scale-plan.md
@@ -1,0 +1,446 @@
+---
+title: "perf: Real-time delivery at scale"
+type: perf
+date: 2026-07-08
+origin: docs/brainstorms/2026-07-08-realtime-delivery-at-scale-requirements.md
+---
+
+# perf: Real-time delivery at scale
+
+## Summary
+
+Decouple a message's send-path cost from room membership size so a large (Discord/Slack-scale) community can run on self-hosted Sabha without the fan-out overwhelming its single SQLite writer. The work ships as seven independent PRs mapped to the study's R0–R6: make AnyCable required, derive unread instead of pushing it per-member, move the sidebar signal onto a shared stream, adopt AnyCable presence, add an `@everyone` guardrail, defer residual per-recipient broadcasts, and add JWT identification for connection storms. Existing behavior is preserved throughout.
+
+---
+
+## Problem Frame
+
+Posting a message to an N-member room currently does per-member work twice, synchronously on the poster's request thread. `Room#unread_memberships` (`app/models/room.rb:383-391`) runs a bulk `update_all(unread_at:)` across every disconnected read member and then `broadcast_unread_to_disconnected_users` (`app/models/room.rb:393-406`) loops every such member pushing a `UserUnreadRoomsChannel` payload — on every message, mention or not. Mentions add more per-recipient loops (`Message::Mentionee#create_mention_notifications`, `app/models/message/mentionee.rb:63-85`), and `@everyone` widens the recipient set to the whole room. `Rooms::Forum#mark_members_unread` (`app/models/rooms/forum.rb:127-146`) repeats the same shape per forum post.
+
+The message body itself is already right: `broadcast_append_to room, :messages` is one O(1) publish that anycable-go fans out. The divergence is the sidebar/unread signalling on bespoke per-user channels, which are per-user *by construction* and force the Ruby-side loop. On self-hosted Sabha each per-member write also competes for the one SQLite write lock — so the loop is writer contention, not just request CPU. Load testing (`docs/performance/load-testing.md`) confirms message throughput is dominated by room membership size, and that connection *establishment* — not steady-state holding — is the sharp ceiling. This is pre-emptive headroom: nothing is on fire, but the per-member send path is what would make a large community migrating off Discord/Slack fall over.
+
+The mechanism, prior art, and recommendations are worked out in the origin requirements doc and the study it draws on (see Sources).
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Derive unread from a delete-aware last-read cursor, mirroring Mattermost.** Keep a per-member last-read marker advanced at view time; derive the unread count and the dot from "messages after the marker," with the member row advanced only on view. This is Mattermost's `TotalMsgCount − ChannelMembers.MsgCount` derivation (`server/channels/store/sqlstore/channel_store.go:898-926`, `GetChannelUnread`) with the advance on view (`UpdateLastViewedAt`, `:2747-2803`). Two correctness constraints the naive form misses: (1) **`rooms.messages_count` (Rails `counter_cache`) is not delete-aware** — the app soft-deletes messages via `deactivate`, which does not decrement `counter_cache`, so `messages_count − snapshot` would count deleted messages as phantom unread; derive against a delete-aware active-message count or a `(created_at, id)` last-read cursor instead. (2) A **NULL/absent marker must read as "read," not "everything unread"** (`COALESCE`), so members not yet backfilled don't see every room light up (see U2). Mattermost's `TotalMsgCount` is a purpose-maintained counter, not Rails' delete-blind `counter_cache` — do not reuse `counter_cache` as the total.
+- KTD1a. **The mention badge (`unread_notifications_count`) is coupled to the `unread_at` write U2 removes — re-derive it.** Today `Message::Unreadable#increment_unread_notifications_counters` bumps the badge only `WHERE unread_at IS NOT NULL AND unread_at <= created_at`, and that guard depends on `deliver_to_room` having just set `unread_at` (the ordering comment in `message/unreadable.rb`). Removing the broad per-member `unread_at` write makes that match zero rows, so a disconnected mentionee/DM recipient would get no badge bump (AE2 fails). The recompute paths (`count_unread_notifications_from`, `read_until`, `mark_unread_at`) also anchor on the `unread_at` timestamp, which a last-read cursor cannot feed without a translation. **Resolved (2026-07-09): `unread_at` is replaced by the cursor; the badge counter is retained but re-anchored on it.** The `increment_unread_notifications_counters` guard and the `.unread` badge-eligibility filter both re-express as a cursor comparison (`cursor < message (created_at, id)`) instead of an `unread_at` predicate, so a disconnected mentionee/DM recipient is bumped without the removed broad write, and the recompute paths re-anchor on the cursor. The counter is kept rather than fully derived precisely so `Push::Subscription`'s device-badge aggregate stays a cheap `unread_notifications_count > 0` pre-filter (`app/models/push/subscription.rb`) — it must stay honest.
+
+- KTD2. **Preserve sidebar liveness by pairing write-removal with a single shared nudge.** Removing the per-member push (R1) without a replacement would regress live sidebar updates for members connected-elsewhere. R1 therefore replaces the per-member loop with *one* shared, account-scoped "room touched" nudge on the existing `RoomListChannel` shared-stream shape (`stream_for Current.account`), which works on both plain ActionCable and AnyCable. R2 then moves that nudge onto an AnyCable signed stream and retires the per-user channels. No liveness gap between the two PRs.
+
+- KTD3. **Keep the existing admin-only, open-rooms-only `@everyone` floor; layer the ceiling and confirm on top.** Today `@everyone` is already gated — `Message#ensure_everyone_mention_allowed` (`app/models/message.rb:396-407`) requires a `Rooms::Open` and an administrator, raising a validation error otherwise. The guardrail extends this gate with a member-count ceiling (`Room#active_member_count`, `app/models/room.rb:187-195`): above it, `@everyone` degrades instead of doing per-member notification work. **`@everyone` is not push-only** — `Message::Mentionee#create_mention_notifications` does a `Notification.insert_all` for `room.user_ids`, then loops `broadcast_activity_indicator` per recipient, `increment_unread_notifications_counters` bumps the badge for the same set, and the email path enqueues per-member bundle items (`docs/features/NOTIFICATIONS.md`: "`@everyone` creates rows for all room members"). Push is one of at least four O(members) passes. **Resolved (2026-07-09): the Zulip model — durable in-app rows kept, expensive external fan-out bounded.** Above the ceiling `@everyone` keeps the two cheap, durable in-app surfaces — the bulk `Notification.insert_all` (deferred to the job) and the single `increment_unread_notifications_counters` bump — so the Activity tab, its dot, and the mention badge are all preserved (R3/R11). It bounds the genuinely expensive O(members) passes: the per-recipient *live* broadcast loops (activity-indicator render, Activity append, live badge publish), the **push** fan-out, and the **email** bundle fan-out — degrading them to a single room-wide signal with sender feedback. This mirrors Zulip (rows written; the wildcard wakeup/push suppressed), not Mattermost (notification suppressed entirely), and it answers the study's stated cap rationale — an uncapped wildcard is a push to every device that hits APNs/FCM limits and reads as spam (the mobile lens). The row insert and badge bump ride the deferred job, so no O(members) work lands synchronously on the poster's request.
+
+- KTD4. **AnyCable presence is live-only; keep a persisted last-seen.** Presence replaces the real-time role of `Membership::Connectable#connected_at`, but push gating reads `connected?` (60s TTL) and email gating reads `workspace_locally_away?` (1h tier). Retain a persisted last-seen column for those and for activity tiers; presence replaces only the live driver, not the whole `Membership::Connectable` model.
+
+- KTD5. **Tenant-scope every shared/signed stream by a tenanted model.** Under `activerecord-tenanted`, a bare-symbol stream name (`:sidebar`) collides across workspaces. The shared nudge must be scoped by a tenanted model (`broadcast_* Current.account, :sidebar`), mirroring `RoomListChannel` and `BotEventsChannel.stream_name_for`. This is the easiest way to ship a change that passes self-hosted tests but silently cross-talks in SaaS.
+
+- KTD6. **JWT identification skips `Connection#connect` — which does authorization and user materialization, not just tracking.** When anycable-go decodes identity in Go, `Connection#connect` never runs, so U10 must preserve three things it currently performs, none of which is "connection tracking": (a) **SaaS tenant-membership authorization** — `connect_saas` verifies a live `WorkspaceMembership` for the tenant (`app/channels/application_cable/connection.rb`); the gem's own identification only checks the tenant DB exists, not that the identity is a member, so cross-tenant access is the sharpest risk; (b) **lazy tenant-user materialization** — `membership.user || membership.create_user!`, without which a first-connecting member has no `Current.user` and every channel subscribe fails; (c) **ban/deactivation rejection** — `reject_unauthorized_connection if user.banned? || user.deactivated?`, which under a cached JWT stops firing until the token expires. Preserve each: bind the tenant as a validated signed claim minted only after `WorkspaceMembership` was checked, materialize the tenant user, and bound the ban/deactivation window with a short `jwt_ttl` or a forced-disconnect on ban. Presence/last-seen already lives on channel subscribe (`PresenceChannel#present`), so it needs no relocation. Emit both cable meta-tag variants — plain `action_cable_meta_tag` and the tenanted `?wid=` form (`saas/app/helpers/tenanting_helper.rb`). Budget `RAILS_MAX_THREADS`: under AnyCable the connection-establishment path (Rails RPC + SQLite contention) becomes the ceiling this PR targets.
+
+- KTD7. **Backfills and deferrals use plain batched idempotent jobs, never `ActiveJob::Continuable`.** Under `activerecord-tenanted`, Continuable's checkpoint/resume can restore the wrong tenant — unsafe. Per-batch commits also release the SQLite writer between batches, which is the point. This mirrors the recent thread-fanout work (`docs/plans/2026-07-04-001-thread-fanout-and-forum-deactivation-plan.md`, decision F1).
+
+- KTD8. **Characterization-first on the fan-out tests.** `test/controllers/messages_controller_test.rb` pins today's behavior (`assert_broadcasts UserUnreadRoomsChannel..., 1`; `assert_no_broadcasts "unread_rooms"`; payload capture). These encode the current per-user contract and must be rewritten as protective coverage before the refactor, not deleted after.
+
+---
+
+## High-Level Technical Design
+
+**Send-path cost, before and after R1+R2.** Today the send path forks into per-member writes and per-member publishes; after, it touches one counter and one shared publish.
+
+```mermaid
+flowchart TB
+  subgraph Before["Today — O(members) on the request"]
+    P1[Message posted] --> A1[broadcast_append_to room, :messages]
+    P1 --> B1["unread_memberships: update_all(unread_at:) over N members"]
+    P1 --> C1["broadcast_unread_to_disconnected_users: loop N per-user publishes"]
+    P1 --> D1["mentions: loop N broadcast_activity_indicator renders"]
+  end
+  subgraph After["After R1+R2 — O(1) from Ruby"]
+    P2[Message posted] --> A2[broadcast_append_to room, :messages]
+    P2 --> B2["room counter already bumped (counter_cache)"]
+    P2 --> C2["one shared 'room touched' nudge → anycable-go fans out"]
+    P2 --> D2["mention badge eager (bulk); activity render deferred to job"]
+  end
+```
+
+**PR sequencing and dependencies.** Seven PRs, one per study recommendation. R1 is transport-agnostic and needs nothing. The AnyCable-native PRs (R2/R3/R6) depend on R0's **cutover** (the fallback removal, U11), not merely its deprecation step (U1) — shipping them while the in-process fallback still exists would leave a holdout on `ANYCABLE_ENABLED=false` booting fine but with a broken sidebar, presence, and reconnect.
+
+```mermaid
+flowchart LR
+  U1["PR1a · R0 deprecate (U1): default anycable-go, fallback stays"]
+  U11["PR1b · R0 cutover (U11): remove fallback"]
+  R1["PR2 · R1 Derived unread (transport-agnostic)"]
+  R2["PR3 · R2 Shared signed-stream sidebar"]
+  R3["PR4 · R3 AnyCable presence"]
+  R4["PR5 · R4 @everyone guardrail"]
+  R5["PR6 · R5 Defer residual broadcasts"]
+  R6["PR7 · R6 JWT identification"]
+  U1 --> U11
+  U11 --> R2
+  R1 --> R2
+  U11 --> R3
+  U11 --> R6
+  R1 -. measure in isolation first .-> R2
+```
+
+**`@everyone` guardrail decision flow (R4).** The existing admin/open gate stays as the floor; the ceiling and confirm are new.
+
+```mermaid
+flowchart TB
+  S[Sender submits @everyone] --> G{Open room AND administrator?}
+  G -- no --> E[Validation error - unchanged from today]
+  G -- yes --> T{active_member_count above ceiling?}
+  T -- no --> C{above confirm threshold?}
+  C -- no --> N[Send normally]
+  C -- yes --> K[Compose-time confirm shows recipient count] --> N
+  T -- yes --> Z[Degrade to a single shared nudge; feedback to sender]
+```
+
+---
+
+## Requirements
+
+Carried from the origin (brainstorm R1–R11). Grouped by concern; each maps to a study recommendation and therefore a PR (mapping table in Sources). The `@everyone` requirements are corrected from the origin: the origin assumed any member could `@everyone` today, but the code already restricts it to administrators in open rooms — that floor is kept (see KTD3).
+
+**Precondition**
+- R1. AnyCable is required in both self-hosted and SaaS modes; the disable path is removed behind a one-release deprecation of `ANYCABLE_ENABLED=false`.
+
+**Unread**
+- R2. Room-unread is derived from a room counter and a per-member last-read snapshot; a message advances no per-member unread row and issues no per-member sidebar push.
+- R3. Every unread surface visible today is preserved: room unread dot and count, mark-as-unread, the Activity tab, and mention badges. Mentions, DMs, and thread/followed replies stay eager `Notification` records.
+
+**Transport**
+- R4. The residual sidebar/unread signal rides one shared signed stream that anycable-go fans out, tenant-scoped by a tenanted model, replacing the per-user unread channels; the payload stays consumer-agnostic for a future JSON/native subscriber.
+- R5. "Who's connected" comes from AnyCable presence rather than per-message DB `connected_at` reads; a persisted last-seen is kept for push/email gating and activity tiers.
+
+**`@everyone` guardrail**
+- R6. `@everyone` keeps its existing floor (administrator, open room only) and gains a hard member-count ceiling above which it degrades to a single shared nudge instead of per-member notification work.
+- R7. A permitted sender sees a compose-time confirm showing the real recipient count, tiered by room size (no friction small; inline confirm bar medium; never a modal).
+- R8. Every `@everyone` path gives the sender explicit feedback — never a silent drop.
+
+**Resilience**
+- R9. Residual per-recipient broadcasts still running synchronously in `MessagesController#create` move off the request path into a job.
+- R10. Connection storms are absorbed via JWT identification so anycable-go skips the `Connection#connect` RPC on reconnect.
+
+**Compatibility (cross-cutting)**
+- R11. No user-visible regression to unread, notification, or presence behavior; existing self-hosted installs upgrade without manual reconfiguration beyond the announced AnyCable requirement. Validated in both `bin/rails test` and `SAAS=true bin/rails test saas/test/`.
+
+---
+
+## Implementation Units
+
+Grouped into seven PRs. Each PR is independently landable; U-IDs are stable across reordering.
+
+### PR 1 · R0 — Make AnyCable required
+
+#### U1. Deprecation release: default to anycable-go, keep the fallback functional
+
+- Goal: Make anycable-go the default and warn on `ANYCABLE_ENABLED=false`, while the in-process fallback stays fully functional for one release, so a self-hoster who hasn't cut over is warned — not broken.
+- Requirements: R1, R11
+- Dependencies: none
+- Files: `bin/dev`, `Procfile.dev`, `Procfile.dev.anycable`, `config/environments/development.rb` (the `ANYCABLE_ENABLED` branch), an initializer or boot check to emit the deprecation warning, `test/controllers/anycable_rpc_test.rb`, typing-channel test.
+- Approach: Make anycable-go the default `bin/dev` path (fold `Procfile.dev.anycable` into `Procfile.dev`). Emit a deprecation warning when `ANYCABLE_ENABLED=false` is resolved. **Do not** flip `config/cable.yml` to `adapter: any_cable` or drop the `ANYCABLE_ENABLED` branching yet — that branching is what keeps the redis ActionCable fallback working, and removing it here is the cutover, which would break holdouts in the deprecation release (the silent break R1/R11/AE6 forbid). The fallback must keep delivering real-time, not merely boot.
+- Patterns to follow: existing `Procfile.dev*` and accessory wiring in `config/deploy*.yml`.
+- Execution note: keep `broadcast_batching: true` on — disabling it floods anycable-go per the load-testing notes.
+- Test scenarios:
+  - Covers R1. anycable-go RPC stays mounted: POST `/_anycable/connect` returns 401 (`test/controllers/anycable_rpc_test.rb` stays green).
+  - Covers AE6. With `ANYCABLE_ENABLED=false`, the deprecation warning is logged AND real-time still works on the fallback — assert a broadcast is delivered on the redis adapter, not merely that the app boots.
+  - anycable-go is the default when no flag is set.
+  - Both suites green (`bin/rails test`, `SAAS=true bin/rails test saas/test/`).
+- Verification: dev defaults to anycable-go; a fallback install logs the warning and still delivers messages.
+
+#### U11. Cutover release: remove the in-process fallback
+
+- Goal: After one deprecation release, make AnyCable required by removing the fallback path entirely. This is the boundary the AnyCable-only transport PRs (R2/R3/R6) gate on.
+- Requirements: R1, R11
+- Dependencies: U1 (ships in a later release than U1)
+- Files: `config/cable.yml`, `config/anycable.yml`, `config/environments/development.rb`, `app/helpers/application_helper.rb` (`anycable_whisper_enabled?`), `app/channels/typing_notifications_channel.rb` (the `AnyCable::Rails.enabled?` stream-option branch), `app/views/layouts/application.html.erb` (the `anycable-whisper` meta), `config/deploy.yml`, `config/deploy.multitenant.yml`, `.env.sample`, `.env.multitenant.sample`, `.github/workflows/deploy_with_kamal.yml`, `test/controllers/anycable_rpc_test.rb`.
+- Approach: Set `adapter: any_cable` across all app envs in `config/cable.yml` (keep `adapter: test` for the test env), drop the `ANYCABLE_ENABLED` branching in `config/anycable.yml` and `config/environments/development.rb`, remove the two `AnyCable::Rails.enabled?` app branches (whisper becomes unconditional) and the JS meta gate, and remove the disable path from the deploy configs and env samples. Grep for every remaining `ANYCABLE_ENABLED` reference (deploy workflow, env samples) so none is orphaned.
+- Patterns to follow: the HTTP-RPC-mode setup already in `config/anycable.yml`.
+- Test scenarios:
+  - `whisper` typing works without any `ANYCABLE_ENABLED` gate (typing-channel test asserts the whisper stream option is always set).
+  - No remaining `AnyCable::Rails.enabled?` conditional in `app/`; no remaining `ANYCABLE_ENABLED` reference in configs, env samples, or the deploy workflow (grep assertion).
+  - Both suites green.
+- Verification: the fallback is gone; deploy configs no longer offer a disable path; the transport PRs can assume AnyCable.
+
+### PR 2 · R1 — Derived unread
+
+#### U2. Per-member last-read snapshot, read-time derivation, view-time advance
+
+- Goal: Stop writing per-member unread on send; derive it from the room counter and a per-member snapshot advanced on view.
+- Requirements: R2, R3
+- Dependencies: none (transport-agnostic)
+- Files: `db/migrate/` (add the last-read snapshot column to `memberships`; `db/schema.rb`), `app/models/membership.rb`, `app/models/membership/unreadable.rb` or `app/models/message/unreadable.rb`, `app/models/room.rb` (`receive`, `unread_memberships`), `app/models/membership/connectable.rb` (the `connect`/`present` path that clears unread today), `app/jobs/` (batched backfill job), `test/models/membership_test.rb`, `test/models/room_test.rb`, `test/models/message_test.rb`.
+- Approach: Add a per-member last-read marker advanced when the member views/presents in the room. Derive unread against a **delete-aware** basis (an active-message count or a `(created_at, id)` cursor), not raw `messages_count`, since soft-delete doesn't decrement `counter_cache` (KTD1). Derive with `COALESCE(marker, read)` semantics so a member without a marker yet reads as read, not all-unread (KTD1 interim rule). Remove the broad `update_all(unread_at:)` from `Room#unread_memberships` so send touches no per-member unread row — but re-derive the mention badge (`unread_notifications_count`), which today's `increment_unread_notifications_counters` bumps only for rows the removed write just set (KTD1a). **Decided: replace `unread_at` with the cursor and re-anchor the badge counter's bump and `.unread` eligibility on the cursor comparison** (keep the counter, don't fully derive it). Reconcile `mark_unread_at` / `read_until` / `count_unread_notifications_from` (`app/models/membership.rb`), which anchor on the `unread_at` timestamp, onto the cursor. Backfill via a batched idempotent job (KTD7); the job must read and write separate columns so a retried batch stays idempotent (do not read `unread_at` to compute the marker in the same job that clears `unread_at`).
+- Technical design (directional, not spec): derivation mirrors Mattermost `GetChannelUnread` (`TotalMsgCount − MsgCount`); view-advance mirrors `UpdateLastViewedAt`. **Decided (2026-07-09): a `(created_at, id)` cursor column replacing `unread_at`**, with the unread count derived on read from `index_messages_on_active_room_created` (delete-honest) rather than a stored snapshot. Must still satisfy the delete-aware and COALESCE-read constraints above, plus the KTD1a badge re-anchoring.
+- Patterns to follow: the derived-access pattern already live in `Rooms::Thread`/`Rooms::Forum` (access delegated to `parent_room#viewable_by?` instead of fanned-out rows); counter_cache on `messages_count`.
+- Execution note: characterization-first — pin current unread/mark-unread behavior in `membership_test`/`messages_controller_test` before changing the write path (KTD8).
+- Test scenarios:
+  - Covers AE1. A member disconnected while 20 messages land has the correct derived unread count on reopen, with no per-message unread write to their row (assert no broad `update_all(unread_at:)` fires on send; assert derived count = 20).
+  - Covers AE2. A **disconnected** `@mentioned` (or DM'd) user still gets an eager `Notification` and `unread_notifications_count` bump — the badge re-derivation (KTD1a) must fire without the removed broad write; assert the badge increments for a disconnected mentionee specifically.
+  - A member with no marker yet (mid-backfill) renders as read, not every-room-unread (`COALESCE` semantics).
+  - A soft-deleted (`deactivate`d) message does not count toward derived unread — no phantom dot after deletion.
+  - Viewing/presenting in a room advances only that member's marker (single-row write), zeroing derived unread.
+  - Mark-as-unread from a message moves the marker behind that message; the dot reappears; `read_until` still resolves.
+  - Send to a large room performs no per-member unread write (integration: assert row-write count independent of membership size).
+  - Backfill job is idempotent under retry/resume even mid-run — reading and writing separate columns (a resumed batch must not read an already-cleared source); runs in batches with per-batch commits.
+  - Both suites green.
+- Verification: a message to an N-member room issues one counter update and zero per-member unread writes; unread counts render correctly for connected, disconnected, and mark-as-unread members.
+
+#### U3. Replace the per-member unread push with one shared nudge
+
+- Goal: Preserve live sidebar updates while removing the per-member broadcast loop.
+- Requirements: R2, R4, R11
+- Dependencies: U2
+- Files: `app/models/room.rb` (`broadcast_unread_to_disconnected_users` → shared nudge), `app/models/membership.rb` (`broadcast_unread`), `app/channels/room_list_channel.rb` (or a sibling shared channel), `app/javascript/controllers/rooms_list_controller.js`, `test/controllers/messages_controller_test.rb`, `test/models/room_test.rb`.
+- Approach: Delete the per-member `UserUnreadRoomsChannel` loop; broadcast one shared "room touched" nudge to the account-scoped shared stream (`RoomListChannel` shape, `stream_for Current.account`, tenant-scoped per KTD5). The nudge is **not** content-free — it carries `roomUpdatedAt` (the active `updatedAt`-desc sidebar sort key) so a touched room still re-floats by recency; it drops the per-member `forceUnread`/per-user unread state. Repoint `rooms_list_controller.js` to derive/refetch that room's unread on the nudge rather than consuming a per-user `{roomId, roomSize, forceUnread}` payload. This rides plain ActionCable or AnyCable equally (RoomListChannel already proves the shape), so it ships in R1's PR without depending on R0.
+- Patterns to follow: `RoomListChannel#stream_for Current.account` and its `rooms_list_controller.js#roomUpdated` handler; keep `broadcast_append` for the message body untouched.
+- Execution note: rewrite the `messages_controller_test` fan-out assertions (the `UserUnreadRoomsChannel`/`unread_rooms` guards) as protective coverage first (KTD8).
+- Test scenarios:
+  - Send to a room issues one shared-stream nudge, not N per-user publishes (assert one broadcast on the account stream; assert no `UserUnreadRoomsChannel` broadcast).
+  - A member connected to a *different* room still sees the touched room's sidebar update live (system test).
+  - The nudge is tenant-scoped: in SaaS, a broadcast in workspace A never reaches workspace B (SaaS suite; assert stream name carries the tenanted model).
+  - Both suites green.
+- Verification: sidebar unread updates live for connected-elsewhere members via a single shared publish; no per-user unread channel broadcast remains on the send path.
+
+#### U4. Forum-post parity
+
+- Goal: Apply the same derived-unread + shared-nudge treatment to the forum path so no O(members) loop survives there.
+- Requirements: R2, R4
+- Dependencies: U2, U3
+- Files: `app/models/rooms/forum.rb` (`mark_members_unread`, `mark_unread_from_post`, `broadcast_dot`), `test/models/rooms/forum_test.rb` (or equivalent).
+- Approach: Replace `mark_members_unread`'s per-member `update_all` + per-member `broadcast_dot` loop with the derived snapshot and the shared nudge, matching U2/U3. Forums are auto-join and community-wide, so this is the highest-fan-out path.
+- Patterns to follow: U2/U3.
+- Test scenarios:
+  - A new forum post performs no per-member unread write and issues one shared nudge (assert row-write count independent of community size).
+  - Forum unread dot still appears for members who haven't viewed the post.
+  - Both suites green.
+- Verification: posting to a large forum touches one counter and one shared publish.
+
+### PR 3 · R2 — Shared signed-stream sidebar
+
+#### U5. Move the shared nudge onto an AnyCable signed stream; retire per-user channels
+
+- Goal: Formalize the shared nudge as an AnyCable signed stream and retire the bespoke per-user unread channels where the payload is shareable.
+- Requirements: R4
+- Dependencies: U11 (cutover — signed streams are AnyCable-only), U3
+- Files: `app/channels/user_unread_rooms_channel.rb`, `app/channels/unread_notifications_channel.rb`, `app/channels/user_involvements_channel.rb` (retire/repoint as shareable), `app/javascript/controllers/rooms_list_controller.js`, `app/models/room.rb`/`app/models/membership.rb` (broadcast call sites), channel tests.
+- Approach: Broadcast the shared nudge via an AnyCable signed stream (the `$pubsub`/signed-stream path anycable-rails-core auto-enables), keeping the stream name derived from a tenanted model. **Retire only `UserUnreadRoomsChannel`** — its payload is identical across members. `UnreadNotificationsChannel` (the mention badge; recipients = `mentionee_ids`/`@everyone`) and `UserInvolvementsChannel` (per-membership `involvement`) are genuinely per-recipient and **stay targeted** (confirmed 2026-07-09 — not foldable); R5 defers the mention-badge loop but does not fold it onto the shared stream. Keep the nudge payload consumer-agnostic (carrying `roomUpdatedAt`) so a future JSON/native subscriber reads the same stream (native-friendly design constraint).
+- Patterns to follow: `AnyCable::Rails.signed_stream_name`; `RoomListChannel`; `BotEventsChannel.stream_name_for` for tenant-scoped stream names.
+- Test scenarios:
+  - The sidebar subscribes to the signed shared stream; a broadcast reaches all subscribers via one publish.
+  - Signed-stream name is rejected when tampered/unsigned (unsigned streams not allowed by default).
+  - Tenant isolation holds on the signed stream (SaaS suite).
+  - `UserUnreadRoomsChannel` is gone and no call site still broadcasts to it; `UnreadNotificationsChannel` and `UserInvolvementsChannel` remain (per-recipient) but ride the deferred job from R5.
+  - Both suites green.
+- Verification: the room-touched sidebar nudge rides one signed, tenant-scoped shared stream carrying `roomUpdatedAt`; `UserUnreadRoomsChannel` is retired while the genuinely per-recipient channels stay targeted.
+
+### PR 4 · R3 — AnyCable presence
+
+#### U6. Replace the DB connected_at live driver with AnyCable presence
+
+- Goal: Make "who's connected to this room" a Go-side fact instead of a per-message DB read/loop, keeping a persisted last-seen for gating.
+- Requirements: R5
+- Dependencies: U11 (cutover — AnyCable presence is AnyCable-only)
+- Files: `app/channels/presence_channel.rb`, `app/channels/room_channel.rb`, `app/models/membership/connectable.rb`, `app/javascript/controllers/presence_controller.js`, `test/channels/presence_channel_test.rb`, `test/models/membership_test.rb`.
+- Approach: Add `AnyCable::Rails::Channel::Presence` + `join_presence`/`leave_presence` on the room stream; drive the live "present/absent" view from the presence set. Retain a persisted last-seen column written on presence join/leave so push (`connected?`, 60s) and email (`workspace_locally_away?`, 1h) gating and activity tiers keep working (KTD4). Presence is live-only and ephemeral; it replaces the real-time driver, not the persisted model.
+- Patterns to follow: the existing `PresenceChannel`/`presence_controller.js` wiring and its `with_tenant_context` command wrapping; whisper's `@anycable/web` client usage in `typing_notifications_controller.js`.
+- Test scenarios:
+  - Presenting joins the presence set; unsubscribing/disconnecting leaves it (with the configured delay).
+  - A persisted last-seen is written on join/leave; `connected?` (60s) and `workspace_locally_away?` (1h) still compute correctly.
+  - Presence-derived "who's here" no longer requires a per-message `connected_at` read.
+  - Tenant-scoped: presence sets don't leak across workspaces (SaaS suite).
+  - Both suites green.
+- Verification: room presence is driven by the AnyCable presence set; push/email gating still reads persisted last-seen.
+
+### PR 5 · R4 — @everyone guardrail
+
+#### U7. Server: hard ceiling and degrade-to-nudge above it
+
+- Goal: Bound `@everyone` fan-out above a member ceiling while keeping the existing admin/open floor.
+- Requirements: R6, R8
+- Dependencies: none
+- Files: `app/models/message.rb` (`ensure_everyone_mention_allowed`, the `mentions_everyone` recipient resolution), `app/models/message/mentionee.rb` (`create_mention_notifications`, the `broadcast_activity_indicator` loop), `app/models/message/unreadable.rb` (`increment_unread_notifications_counters`), `app/models/message/broadcasts.rb` (`broadcast_notifications`), `app/models/room.rb` (`active_member_count`), `test/models/message_test.rb`, `test/controllers/messages_controller_test.rb`.
+- Approach: Extend the existing gate: keep the `Rooms::Open` + `administrator?` floor unchanged; add a `Room#active_member_count` ceiling. **Decided (2026-07-09): the Zulip model (see KTD3 / Decisions).** Above the ceiling, `@everyone` keeps the two cheap, durable in-app surfaces — the `Notification.insert_all` over `room.user_ids` in `create_mention_notifications` (deferred to the job) and the single `increment_unread_notifications_counters` bump — so the Activity tab, its dot, and the mention badge survive (R3/R11). It bounds the expensive external O(members) passes: the per-recipient `broadcast_activity_indicator` loop, the `broadcast_notifications` live-badge loop, the **push** candidate fan-out (`push_candidate_memberships_for`, which resolves `@everyone` to `room.user_ids`), and the **email** bundle fan-out (`email_candidate_user_ids_for`) — degrading them to a single shared room-wide signal with sender feedback. The per-recipient `broadcast_activity_indicator` loop is shared with U9 (defer residual broadcasts); U9 owns moving it off the request path, U7 owns bounding it above the ceiling — sequence so they don't fight over the same call site. Ceiling default: `active_member_count > 1000`, config-tunable.
+- Patterns to follow: `ensure_everyone_mention_allowed` as the compose-time gate; `Room#active_member_count` (5-min cached) as the count source; `Membership#effective_involvement` as the delivery-time eligibility source of truth (reuse, don't re-derive).
+- Test scenarios:
+  - Covers AE4. `@everyone` above the ceiling degrades to one shared room-wide signal: no per-recipient live broadcast, and no push/email fan-out to the whole room (assert the push and email candidate sets are bounded, not `room.user_ids`); the Activity-tab rows + badge are still written via the deferred job; the sender is told it was delivered room-wide.
+  - Above the ceiling, push is not enqueued to the whole membership — assert `push_candidate_memberships_for` (or the enqueued push set) does not scale with `active_member_count`; below the ceiling it fans out as today.
+  - Covers AE5. A regular member cannot `@everyone` (unchanged floor); a non-open room rejects `@everyone` (unchanged).
+  - Below the ceiling, an admin's `@everyone` in an open room fans out as today.
+  - Threshold is read from config (tunable), not hard-coded at a call site.
+  - Both suites green.
+- Verification: `@everyone` above the ceiling issues no per-recipient push, email, or live broadcast fan-out (the expensive external passes degrade to one room-wide signal), while the deferred Activity-tab rows + badge are preserved; the admin/open floor is intact.
+
+#### U8. Compose-time confirm with recipient count
+
+- Goal: Show a permitted sender the blast size before send, tiered by room size.
+- Requirements: R7, R8
+- Dependencies: U7
+- Files: `app/javascript/controllers/` (composer confirm controller), `app/views/messages/` or the composer partial, `test/system/` (compose confirm system test).
+- Approach: In the composer, when `@everyone` is present and the room is above a small confirm threshold, show an inline confirm bar with the real recipient count (`Room#active_member_count`) that the sender acknowledges before send — no friction below the threshold, never a modal (matches Sabha's restraint). Reference calibration: Mattermost confirms above 5 members (client), Zulip's banner above 15. **Decided: confirm above 15, config-tunable.** No new non-REST controller action — the existing create path plus the client confirm suffice.
+- Patterns to follow: existing Stimulus composer controllers; inline banner styling already used in the UI.
+- Test scenarios:
+  - Covers AE3. In a room of ~50 members, a permitted sender typing `@everyone` sees an inline confirm showing the recipient count before send.
+  - Below the confirm threshold, no confirm appears.
+  - Acknowledging sends; dismissing does not.
+  - Test expectation: system-test the confirm interaction; unit-test the threshold boundary.
+- Verification: the confirm bar appears above the threshold with an accurate count and blocks send until acknowledged.
+
+### PR 6 · R5 — Defer residual broadcasts
+
+#### U9. Move the synchronous per-recipient broadcasts off the request path
+
+- Goal: Get the remaining synchronous per-recipient work out of `MessagesController#create`.
+- Requirements: R9
+- Dependencies: none
+- Files: `app/models/message/mentionee.rb` (the synchronous `broadcast_activity_indicator` loop, `:83`), `app/models/message/broadcasts.rb` (`broadcast_notifications` residual loop), `app/jobs/` (new/existing broadcast job), `test/models/message_test.rb`, `test/jobs/`.
+- Approach: Wrap the still-synchronous per-recipient `broadcast_activity_indicator` render loop (and any residual `UnreadNotificationsChannel` loop not shared by R2) in a `perform_later` job, following the app's existing custom-job-wrapping pattern (`BroadcastMentionNotificationsJob`, `BroadcastMentioneeSidebarUpdatesJob`) rather than Turbo's `_later` helpers, which the app doesn't use. Plain, idempotent job (KTD7).
+- Patterns to follow: `BroadcastMentionNotificationsJob`, `BroadcastMentioneeSidebarUpdatesJob`.
+- Test scenarios:
+  - Posting a mention enqueues the broadcast job rather than rendering per-recipient inline (`assert_enqueued_jobs`).
+  - The job renders the activity indicator for each recipient when performed (`perform_enqueued_jobs`).
+  - `MessagesController#create` no longer runs the per-recipient render synchronously (integration: request time independent of mentionee count).
+  - Both suites green.
+- Verification: the mention activity-indicator render is off the request path; create latency no longer scales with mentionee count.
+
+### PR 7 · R6 — JWT identification
+
+#### U10. JWT identification for connection storms
+
+- Goal: Let anycable-go decode identity in Go and skip the Rails `Connection#connect` RPC on reconnect.
+- Requirements: R10
+- Dependencies: U11 (cutover — JWT identification is AnyCable-only)
+- Files: `app/views/layouts/application.html.erb` (`action_cable_with_jwt_meta_tag`), `saas/app/helpers/tenanting_helper.rb` (the tenanted `?wid=` meta variant), `app/channels/application_cable/connection.rb` (per-connect work that must move), `config/anycable.yml` (secret/ttl), a small JSON cable-config/discovery endpoint (`app/controllers/api/` — native-readiness, see below), `test/controllers/anycable_rpc_test.rb`, `test/channels/application_cable/connection_test.rb`.
+- Approach: Emit `action_cable_with_jwt_meta_tag` carrying the connection identifiers for both the plain and tenanted (`?wid=`) cable URLs; configure `jwt_ttl`. **Sign the JWT with a distinct client-facing secret, not `ANYCABLE_SECRET`** (two-secret split, per Decisions) — signed-stream signing derives from that same client-facing secret; `ANYCABLE_SECRET` stays the RPC/broadcast master. Pair the short `jwt_ttl` with a REST-API token-refresh path so native clients (which lack the browser session cookie and use JWT as their primary socket-auth) can refresh, and so the ban/revocation window stays bounded. Preserve the three things `Connection#connect` does that JWT-in-Go can't (KTD6): (1) mint the tenant as a validated signed claim only after `WorkspaceMembership` was checked, so the token can't grant cross-tenant access; (2) materialize the tenant user (`membership.create_user!`) so a first-connecting member has a resolvable `Current.user`; (3) enforce ban/deactivation via a short `jwt_ttl` or a forced-disconnect on ban rather than waiting for token expiry. Presence/last-seen already fires on channel subscribe, so it needs no relocation. Keep `restore_from_cache: true`. Budget `RAILS_MAX_THREADS`.
+- Patterns to follow: existing meta-tag emission in the layout and `tenanting_helper.rb`; `restore_from_cache` already configured in `config/anycable.yml`; the `Api::Bots::BaseController` token-auth pattern for the JSON endpoint.
+- Native-readiness (scope-preserving — this does *not* build the native client API): the web client reads its socket credentials from `action_cable_with_jwt_meta_tag` in HTML, which a headless native/JSON client can't scrape. So expose the *same* JWT + cable config through a small JSON endpoint (a cable-config / `.well-known`-style discovery doc returning the plain and `?wid=` cable URL(s) and a freshly-minted token), mirroring the `api/bots` token-auth pattern; the REST token-refresh path above is that endpoint's refresh sibling. This builds no end-user content API and no JSON events stream — it only keeps U10's identity/transport reachable by a non-browser client, so the separate native track (and a "point the app at your self-hosted URL" flow) inherits a token+transport contract instead of retrofitting one. Everything else U10 does is unchanged.
+- Test scenarios:
+  - Covers AE6-adjacent. A JWT-identified client connects without invoking `Connection#connect` (no RPC hit).
+  - Native-readiness: a headless client fetches the cable URL(s) + a valid token from the JSON config endpoint (no HTML scraping) and the token is accepted by anycable-go identification; the tenanted (`?wid=`) URL is present in SaaS.
+  - Both cable meta-tag variants (plain and `?wid=`) carry a valid token.
+  - An expired token triggers a `token_expired` disconnect the client can refresh.
+  - SaaS cross-tenant: a token minted for workspace A cannot subscribe to workspace B's streams.
+  - SaaS revocation: a token minted while a member of workspace A is rejected (or the socket dropped) once that `WorkspaceMembership` is removed, within the `jwt_ttl` window.
+  - SaaS first-connect: a member connecting for the first time via JWT still has a materialized tenant `User` and resolvable `Current.user` (channel subscribes succeed).
+  - A banned/deactivated user's reconnect is rejected or force-disconnected — not served live until token expiry.
+  - Reconnect storm: connection establishment no longer hits the Rails RPC per reconnect (load-test observation, noted in verification).
+  - Both suites green.
+- Verification: reconnecting clients skip the Rails connect RPC; a reconnect burst no longer saturates the establishment path in the load test; cross-tenant, revocation, first-connect, and ban cases are all covered in the SaaS suite.
+
+---
+
+## Acceptance Examples
+
+Carried from the origin, with the `@everyone` examples corrected to the kept admin/open floor.
+
+- AE1. Covers R2, R3. Given a member disconnected while 20 messages land, when they reopen the room, then unread is derived (`messages_count − snapshot`) and correct, with no per-message unread write to their row.
+- AE2. Covers R3. Given a user is `@mentioned`, when the message posts, then they still get an eager `Notification` and `unread_notifications_count` bump.
+- AE3. Covers R7. Given a room of ~50 members, when a permitted sender types `@everyone`, then an inline confirm shows the recipient count before send.
+- AE4. Covers R6, R8. Given a room above the ceiling, when `@everyone` is sent, then it degrades to a single shared nudge and the sender is told it was room-wide, not per-member.
+- AE5. Covers R6, R11. Given the existing floor, when a regular member (or any member in a non-open room) attempts `@everyone`, then it is rejected as today — no loosening.
+- AE6. Covers R1, R11. Given a self-hoster on `ANYCABLE_ENABLED=false`, when they upgrade to the deprecation release, then Sabha boots with a warning, not a failure.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later**
+- Idle-member skip (Zulip's soft-deactivation, `zerver/lib/soft_deactivation.py`) for the notification/email path — largely subsumed by derived unread; revisit only if that path stays hot after R1–R3.
+- Absolute-scale work: clustering / multi-node anycable-go, sharding, or growing one community past a single node and writer.
+
+**Outside this initiative**
+- Discord/Slack import tooling — a separate planned PR; "migrate" here means carrying the scale, not importing content.
+- Native client surfaces (the JSON events channel for message *content*, the end-user content API, the push gateway) — a separate track. This work stays native-friendly (payload-shape-agnostic nudge in R2) and ships exactly one small native-facing surface: U10's JSON cable-config/discovery endpoint, which exposes only socket credentials (cable URL + JWT), not content. It builds no events stream and no end-user API.
+- Search, media/attachments, and auth scaling — unchanged except where they touch the fan-out path.
+
+---
+
+## Risks & Dependencies
+
+- **JWT bypasses connect-side authorization (P0).** `Connection#connect` is where the SaaS path verifies `WorkspaceMembership`, materializes the tenant user, and rejects banned/deactivated users. JWT-in-Go skips it, so a token could grant cross-tenant access, serve a first-connecting member with no user row, or keep a banned user live — all until `jwt_ttl`. Mitigation: KTD6 / U10 — mint the tenant as a validated signed claim post-authorization, materialize the tenant user, and bound the ban window with a short ttl or forced-disconnect; covered by the SaaS cross-tenant/revocation/first-connect/ban test scenarios.
+- **Shared nudge trades write cost for read cost and reaches the whole account (measure before U5).** The shared nudge on `stream_for Current.account` reaches every connected member install-wide. **Resolved (2026-07-09): the nudge carries `roomUpdatedAt`** — the load-bearing sidebar sort key `rooms_list_controller.js` needs for recency ordering — so sort metadata does not degrade; it drops only the per-member `forceUnread`/per-user unread state (derived/refetched client-side). The residual risk is the O(connected) fan-out itself: every connected client is nudged on every message anywhere and refetches that room's unread. Reads don't contend the SQLite writer (WAL), so this is likely acceptable, but KTD2's "no gap" covers the dot only — measure the O(connected) refetch on the large-room harness before U5.
+- **Two-release integrity.** If any AnyCable-only feature (U5/U6/U10) ships before the cutover (U11) removes the fallback, a holdout on `ANYCABLE_ENABLED=false` boots but is functionally broken. Mitigation: U5/U6/U10 depend on U11; alternatively, once any AnyCable-only feature merges, `ANYCABLE_ENABLED=false` must hard-fail rather than warn.
+- **Cross-tenant stream collision in SaaS.** A bare-symbol shared stream leaks across workspaces and passes self-hosted tests. Mitigation: KTD5 — scope every shared/signed stream by a tenanted model; assert tenant isolation in the SaaS suite for U3/U5/U6.
+- **`@everyone` behavior change perceived as a regression.** The origin assumed any member could `@everyone`; the code restricts it to admins in open rooms. Mitigation: KTD3 keeps that floor; AE5 pins it.
+- **Derived-unread backfill under tenancy.** A wrong-tenant resume is severe, and an un-backfilled member must not render every room unread mid-migration. Mitigation: KTD7 (plain batched idempotent job, per-batch commits, no `ActiveJob::Continuable`, read/write separate columns) plus the `COALESCE` interim rule (KTD1) and the mid-backfill test in U2.
+- **One secret spanning RPC auth, JWT signing, and stream signing.** `anycable.secret` already authenticates the Rails↔anycable-go RPC/broadcast channel; overloading it for JWT identity and stream signing means a single leak grants identity impersonation, not just broadcast spoofing. **Resolved (2026-07-09): a two-secret split** — `ANYCABLE_SECRET` stays the infra RPC/broadcast master; a distinct client-facing secret signs JWT identity, with signed-stream signing derived from it. JWT rotates on a token cadence (short `jwt_ttl` + REST refresh) independent of the infra link; native clients drive this (no browser cookie). See Decisions.
+- **Pro-only assumption.** Presence, signed streams, and JWT are AnyCable OSS features (confirmed against the AnyCable docs) — no Pro dependency. Load-test the establishment path after R6; keep `broadcast_batching` on.
+- **Dependency:** R2, R3, R6 depend on R0's cutover (U11). R1 does not (transport-agnostic). R2 also depends on R1 (shareable payload). R4, R5 are independent.
+
+---
+
+## System-Wide Impact
+
+- **SQLite writer:** removing the per-member unread write on send is the primary relief — fewer, shorter write transactions per message on the single writer (self-hosted and per-tenant SaaS alike).
+- **Real-time transport:** the sidebar moves from per-user channels to one shared, tenant-scoped stream; presence moves from DB reads to the AnyCable presence set.
+- **Config/ops contract:** `ANYCABLE_ENABLED=false` is deprecated then removed; anycable-go becomes a required accessory in both deploy configs. Self-hosters get one release of warning.
+- **Both deployment modes:** every unit must pass `bin/rails test` and `SAAS=true bin/rails test saas/test/`; `Current.reset` in teardown; tenant-scoped streams and cache keys.
+
+---
+
+## Decisions & Open Questions
+
+The questions flagged in earlier drafts were resolved 2026-07-09 after grounding each in the current code. Remaining items are genuinely execution-time or empirical.
+
+**Resolved (2026-07-09)**
+
+- **`@everyone` above the ceiling: the Zulip model — durable in-app rows kept, expensive external fan-out bounded (was: resolve before U7).** The degrade **keeps** the two cheap durable in-app surfaces — the bulk `Notification.insert_all` (deferred to the job) and the single `increment_unread_notifications_counters` bump — so the Activity tab, its dot, and the mention badge survive (suppressing rows would save only one bulk INSERT while deleting the Activity-tab entry — a direct R3/R11 collision). It **bounds** the genuinely expensive O(members) passes — the per-recipient live broadcast loops (activity-indicator render `mentionee.rb:83`, Activity append, live badge `broadcasts.rb:27-29`), the **push** candidate fan-out (`push_candidate_memberships_for`, which resolves `@everyone` to `room.user_ids`), and the **email** bundle fan-out (`email_candidate_user_ids_for`) — degrading them to one room-wide signal with sender feedback. This mirrors Zulip (rows written; the wildcard wakeup/push suppressed), not Mattermost (notification suppressed entirely), and it answers the study's cap rationale: an uncapped wildcard is a push to every device that hits APNs/FCM limits and reads as spam (the study's mobile lens). Push/email were **not** left "unaffected" — bounding them is the point of the ceiling.
+
+- **`unread_at` is replaced by a `(created_at, id)` last-read cursor (was: marker shape + `unread_at` fate).** Room-unread count derives on read from `index_messages_on_active_room_created (active, room_id, created_at)` — delete-honest for free, with no counter drift (`rooms.messages_count`/counter_cache is create/destroy-only, not `active`-aware, so a count-snapshot marker has no honest backing column). `Message.before_cursor` already implements the `(created_at, id)` comparison. The mention-badge counter (`unread_notifications_count`) is **retained** — not fully derived — so the push device-badge aggregate (`Push::Subscription`) stays a cheap `count > 0` pre-filter; but its bump-precondition and `.unread` eligibility (KTD1a) re-anchor on the cursor comparison instead of the removed `unread_at` write. The `unread_at`-anchored rebalance callbacks retire with the column.
+
+- **Two AnyCable secrets — infra vs client-facing (was: resolve before U10).** `ANYCABLE_SECRET` stays the server↔server RPC + broadcast master; a distinct **client-facing** secret signs JWT identity, with signed-stream signing derived from it (AnyCable derives-unless-overridden). Rationale is native-client-driven: Flutter/Electron clients have no browser session cookie, so JWT becomes their *primary* socket-auth path and the client-facing secret is a real client trust boundary that must (a) rotate independently of the infra RPC link, and (b) pair with a short `jwt_ttl` + REST-API token refresh to bound the ban/revocation window (KTD6) for long-lived, background-reconnecting mobile tokens. Blast radius is contained both ways — an infra leak can't forge client identity, a client-secret leak can't spoof the RPC link — without burdening self-hosters with three secrets. Promotable to a third distinct stream-signing secret later at low cost if cached-stream-token leakage ever warrants it.
+
+- **Thresholds: confirm at 15, ceiling at 1000 — both config-tunable.** Zulip's `wildcard_mention_threshold` (15) and Mattermost's `MaxNotificationsPerChannel` default (1000), from the prior art the study cites.
+
+- **Only `UserUnreadRoomsChannel` retires onto the shared stream (was: which channels fully retire).** Its payload is identical across members. `UnreadNotificationsChannel` (the mention badge; recipients = `mentionee_ids`/`@everyone`) and `UserInvolvementsChannel` (each membership's own `involvement` column) are genuinely per-recipient and **stay targeted** — confirmed, not "fold where identical." The shared nudge is **not** content-free: it must carry `roomUpdatedAt`, the active `updatedAt`-desc sidebar sort key in `rooms_list_controller.js`, or a touched room won't re-float by recency (see the R1 Risk note and U5).
+
+**Still open (execution-time / empirical)**
+
+- The `RAILS_MAX_THREADS` value that clears the establishment-path ceiling under AnyCable — measured on the load-test harness during R6/U10, not resolvable at a desk.
+
+---
+
+## Sources & Research
+
+**Origin and study**
+- `docs/brainstorms/2026-07-08-realtime-delivery-at-scale-requirements.md` — the requirements this plan implements (R1–R11).
+- `sabha_docs/performance/2026-07-06-chat-realtime-scale-comparison-requirements.md` — the study; R0–R6 recommendations and call sites.
+- `sabha_docs/performance/realtime-broadcast-fanout.md`; `sabha_docs/performance/discord-scaling.md` — mechanism detail and extreme-scale validation.
+- `docs/performance/load-testing.md` — concurrency ceilings; the before/after harness.
+- `docs/multi-tenant/activerecord-tenanted-guide.md` — the tenant-scoped-stream rule (KTD5).
+- `docs/features/NOTIFICATIONS.md` — the dispatcher R3–R5 preserve; `@everyone` is push-only.
+
+**Study recommendation → PR → units**
+
+| Study rec | PR | Brainstorm reqs | Units |
+|---|---|---|---|
+| R0 AnyCable required | PR 1 | R1 | U1, U11 |
+| R1 lazy unread | PR 2 | R2, R3 | U2, U3, U4 |
+| R2 shared-stream sidebar | PR 3 | R4 | U5 |
+| R3 AnyCable presence | PR 4 | R5 | U6 |
+| R4 wildcard cap | PR 5 | R6, R7, R8 | U7, U8 |
+| R5 defer residual | PR 6 | R9 | U9 |
+| R6 JWT | PR 7 | R10 | U10 |
+| (cross-cutting) | all PRs | R11 | validated per unit in both suites |
+
+**Verified Sabha call sites**
+- `app/models/room.rb` — `receive` (`:99`), `unread_memberships` (`:383`), `broadcast_unread_to_disconnected_users` (`:393`), `active_member_count` (`:187`).
+- `app/models/membership.rb` / `membership/connectable.rb` — `unread_at`, `connect`/`present` (clears unread), `read`, `mark_unread_at`, `read_until`, `connected?` (60s TTL); `unread_notifications_count`.
+- `app/models/message/unreadable.rb` — `deliver_to_room`, `increment_unread_notifications_counters` (ordering matters, `:5-8`).
+- `app/models/message/broadcasts.rb` / `message/mentionee.rb` — `broadcast_create`, `broadcast_notifications`, `create_mention_notifications`, the synchronous `broadcast_activity_indicator` loop.
+- `app/models/message.rb` — `ensure_everyone_mention_allowed` (`:396-407`, the existing admin/open gate).
+- `app/models/rooms/forum.rb` — `mark_members_unread`, `broadcast_dot` (`:127-146`).
+- `app/models/user/role.rb` — `member/moderator/administrator/bot`; `staff?`, `can_moderate?` (roles are global, not per-room).
+- `app/channels/` — `RoomListChannel` (`stream_for Current.account`, the shared-stream model), `UserUnreadRoomsChannel`, `UnreadNotificationsChannel`, `UserInvolvementsChannel` (per-user, to retire), `PresenceChannel`, `TypingNotificationsChannel` (whisper).
+- `app/javascript/controllers/rooms_list_controller.js` — the single sidebar consumer subscribing to four channels.
+- `config/cable.yml`, `config/anycable.yml`, `bin/dev`, `Procfile.dev*`, `config/deploy*.yml` — the AnyCable fork (R0).
+- `saas/app/helpers/tenanting_helper.rb` — `tenanted_action_cable_meta_tag` (`?wid=`), relevant to R6.
+
+**Reference implementations** (`/Users/ashwin/dev/mattermost`, `/Users/ashwin/dev/zulip`)
+- Mattermost derived unread: `server/channels/store/sqlstore/post_store.go:295-312` (counter bump), `channel_store.go:898-926` (`GetChannelUnread`), `:2747-2803` (`UpdateLastViewedAt`), `:2959-2992` (`IncrementMentionCount`, eager).
+- Mattermost `@all` cap: `server/channels/app/notification.go:471-518` (suppress + ephemeral), default `MaxNotificationsPerChannel = 1000` (`server/public/model/config.go:2576`), `PermissionUseChannelMentions`; client confirm above `NOTIFY_ALL_MEMBERS = 5` (`webapp/channels/src/utils/constants.tsx:1496`).
+- Zulip wildcard: compose banner threshold `wildcard_mention_threshold = 15` (`web/src/compose_validate.ts:106`), `can_mention_many_users_group` (`zerver/lib/message.py:1489-1496`), enforced in `zerver/actions/message_send.py:1921-1934`.
+
+**AnyCable primitives** (docs.anycable.io) — presence (`AnyCable::Rails::Channel::Presence`, `join_presence`), signed streams (`$pubsub`, `AnyCable::Rails.signed_stream_name`, `--streams_secret`), JWT (`action_cable_with_jwt_meta_tag`, `anycable.secret`, `jwt_ttl`), HTTP-RPC single-container setup — all OSS, no Pro dependency.

--- a/saas/test/channels/room_list_channel_test.rb
+++ b/saas/test/channels/room_list_channel_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class SaasRoomListChannelTest < ActionCable::Channel::TestCase
+  include SaasTestHelper
+
+  tests RoomListChannel
+
+  test "two workspaces' room-list streams do not collide" do
+    with_provisioned_workspace(name: "Stream WS A", creator: global_identities(:alice)) do |ws_a|
+      with_provisioned_workspace(name: "Stream WS B", creator: global_identities(:bob)) do |ws_b|
+        stream_a = ApplicationRecord.with_tenant(ws_a.external_id.to_s) { RoomListChannel.broadcasting_for(Account.sole) }
+        stream_b = ApplicationRecord.with_tenant(ws_b.external_id.to_s) { RoomListChannel.broadcasting_for(Account.sole) }
+
+        assert_not_equal stream_a, stream_b
+
+        # The stream identity is the account's GlobalID, which carries the
+        # tenant — a room-touched nudge in one workspace can never reach
+        # another workspace's sidebars.
+        [ [ stream_a, ws_a ], [ stream_b, ws_b ] ].each do |stream, workspace|
+          gid = GlobalID.parse(stream.delete_prefix("room_list:"))
+          assert_equal workspace.external_id.to_s, gid.tenant
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/inboxes_controller_test.rb
+++ b/test/controllers/inboxes_controller_test.rb
@@ -399,14 +399,16 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
   test "clear marks memberships as read" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: @david)
-    membership.update!(unread_at: 1.hour.ago)
+    force_all_unread membership
 
     # Create a mention so mark_inbox_as_read finds a notified room
-    room.messages.create!(
-      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
-      creator: @jason,
-      client_message_id: "clear_test_mention"
-    )
+    travel_to(1.minute.ago) do
+      room.messages.create!(
+        body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+        creator: @jason,
+        client_message_id: "clear_test_mention"
+      )
+    end
 
     # First visit activity to set the session timestamp
     get inbox_activity_index_url
@@ -422,7 +424,7 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
   test "clear stays on page when stay param is present" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: @david)
-    membership.update!(unread_at: 1.hour.ago)
+    force_all_unread membership
 
     get inbox_activity_index_url
     post inbox_clearance_url, params: { stay: true }
@@ -430,10 +432,12 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "clear with scope direct_messages only clears DM rooms" do
-    # DM room
+    # DM room with an unseen message — a minute old, because loaded_at stamps
+    # truncate to seconds and a just-created message would outrun them
     dm_room = rooms(:david_and_jason)
+    travel_to(1.minute.ago) { dm_room.messages.create!(creator: @jason, body: "hi", client_message_id: "dm_scope_clear") }
     dm_membership = dm_room.memberships.find_by(user: @david)
-    dm_membership.update!(unread_at: 1.hour.ago)
+    force_all_unread dm_membership
 
     # Regular room with mention
     room_with_mention = rooms(:pets)
@@ -442,7 +446,7 @@ class InboxesControllerTest < ActionDispatch::IntegrationTest
       creator: @jason
     )
     membership_with_mention = room_with_mention.memberships.find_by(user: @david)
-    membership_with_mention.update!(unread_at: 1.hour.ago)
+    force_all_unread membership_with_mention
 
     # Visit direct_messages page to set session timestamp
     get inbox_direct_messages_url

--- a/test/controllers/messages/unreads_controller_test.rb
+++ b/test/controllers/messages/unreads_controller_test.rb
@@ -6,7 +6,7 @@ class Messages::UnreadsControllerTest < ActionDispatch::IntegrationTest
     @room = rooms(:watercooler)
     @message = @room.messages.create!(creator: users(:jason), body: "Test message")
     @membership = @room.memberships.find_by(user: users(:david))
-    @membership.update!(unread_at: nil)
+    catch_up @membership
   end
 
   test "create marks message as unread" do
@@ -17,6 +17,6 @@ class Messages::UnreadsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     @membership.reload
     assert @membership.unread?
-    assert_equal @message.created_at, @membership.unread_at
+    assert_equal @message, @membership.first_unread_message
   end
 end

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -62,7 +62,8 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     # Per-user broadcast: disconnected reader gets one update on their UserUnreadRoomsChannel.
     # Global no-broadcast guards the CRIT-3 thundering-herd fix: no broadcast to "unread_rooms".
     other_member = @room.memberships.visible.where.not(user: users(:david)).first
-    other_member.update!(unread_at: nil, connected_at: nil)
+    catch_up other_member
+    other_member.update!(connected_at: nil)
 
     stream_name = UserUnreadRoomsChannel.broadcasting_for(other_member.user)
     assert_broadcasts stream_name, 1 do
@@ -78,7 +79,8 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     # must still receive roomSize/roomUpdatedAt via UserUnreadRoomsChannel through
     # Room#broadcast_unread_to_disconnected_users, otherwise the sidebar sort goes stale.
     jason_membership = @room.memberships.find_by(user: users(:jason))
-    jason_membership.update!(unread_at: nil, connected_at: nil)
+    catch_up jason_membership
+    jason_membership.update!(connected_at: nil)
 
     stream_name = UserUnreadRoomsChannel.broadcasting_for(users(:jason))
     payloads = capture_broadcasts(stream_name) do

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -76,6 +76,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, nudges.size
     assert_equal @room.id, nudges.first["roomId"]
+    assert_equal users(:david).id, nudges.first["creatorId"], "the nudge carries the sender so their own clients skip the dot"
   end
 
   test "mentioning a user in a room they're not viewing refreshes their sidebar sort metadata" do

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -58,41 +58,43 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "creating a message broadcasts unread to per-user channels but never to the global unread_rooms channel" do
-    # Per-user broadcast: disconnected reader gets one update on their UserUnreadRoomsChannel.
-    # Global no-broadcast guards the CRIT-3 thundering-herd fix: no broadcast to "unread_rooms".
+  test "creating a message publishes one shared room nudge instead of per-user unread broadcasts" do
+    # One account-wide publish regardless of member count; each client derives
+    # its own unread state from it. No per-user UserUnreadRoomsChannel push and
+    # no global "unread_rooms" broadcast (the original thundering-herd fix).
     other_member = @room.memberships.visible.where.not(user: users(:david)).first
     catch_up other_member
     other_member.update!(connected_at: nil)
 
-    stream_name = UserUnreadRoomsChannel.broadcasting_for(other_member.user)
-    assert_broadcasts stream_name, 1 do
-      assert_no_broadcasts "unread_rooms" do
-        post room_messages_url(@room, format: :turbo_stream), params: { message: { body: "New one", client_message_id: SecureRandom.uuid } }
+    nudges = capture_broadcasts(RoomListChannel.broadcasting_for(Account.sole)) do
+      assert_no_broadcasts UserUnreadRoomsChannel.broadcasting_for(other_member.user) do
+        assert_no_broadcasts "unread_rooms" do
+          post room_messages_url(@room, format: :turbo_stream), params: { message: { body: "New one", client_message_id: SecureRandom.uuid } }
+        end
       end
     end
+
+    assert_equal 1, nudges.size
+    assert_equal @room.id, nudges.first["roomId"]
   end
 
   test "mentioning a user in a room they're not viewing refreshes their sidebar sort metadata" do
-    # Regression: BroadcastMentioneeSidebarUpdatesJob now replaces only the inner link partial,
-    # not the full row. The cross-room mention case (user disconnected from the mentioned room)
-    # must still receive roomSize/roomUpdatedAt via UserUnreadRoomsChannel through
-    # Room#broadcast_unread_to_disconnected_users, otherwise the sidebar sort goes stale.
+    # The shared nudge carries the sidebar sort keys (roomUpdatedAt, roomSize),
+    # so a disconnected mentionee's sidebar re-floats the room without a
+    # per-user push; their client derives the unread dot from the nudge.
     jason_membership = @room.memberships.find_by(user: users(:jason))
     catch_up jason_membership
     jason_membership.update!(connected_at: nil)
 
-    stream_name = UserUnreadRoomsChannel.broadcasting_for(users(:jason))
-    payloads = capture_broadcasts(stream_name) do
+    nudges = capture_broadcasts(RoomListChannel.broadcasting_for(Account.sole)) do
       post room_messages_url(@room, format: :turbo_stream),
         params: { message: { body: "<div>Hey #{mention_attachment_for(:jason)}</div>", client_message_id: SecureRandom.uuid } }
     end
 
-    sort_payload = payloads.find { |p| p["forceUnread"] == true }
-    assert sort_payload, "expected a UserUnreadRoomsChannel payload with forceUnread for the disconnected mentionee"
-    assert_equal @room.id, sort_payload["roomId"]
-    assert_equal @room.reload.messages_count, sort_payload["roomSize"]
-    assert_equal @room.last_active_at.iso8601, sort_payload["roomUpdatedAt"]
+    nudge = nudges.find { |n| n["roomId"] == @room.id }
+    assert nudge, "expected a shared room-list nudge carrying the room's sort metadata"
+    assert_equal @room.reload.messages_count, nudge["roomSize"]
+    assert_equal @room.last_active_at.iso8601, nudge["roomUpdatedAt"]
   end
 
   test "update updates a message belonging to the user" do

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -19,7 +19,7 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     room = rooms(:pets)
     room.messages.create!(creator: users(:jason), body: "Seen already", client_message_id: "separator_seen")
     first_unread = room.messages.create!(creator: users(:jason), body: "New to you", client_message_id: "separator_unread")
-    room.memberships.find_by!(user: users(:david)).update!(unread_at: first_unread.created_at)
+    rewind_unread_to room.memberships.find_by!(user: users(:david)), first_unread
 
     get room_url(room)
 
@@ -30,7 +30,7 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
   test "show renders no new-messages separator when the membership is read" do
     room = rooms(:pets)
     room.messages.create!(creator: users(:jason), body: "Nothing new", client_message_id: "separator_none")
-    room.memberships.find_by!(user: users(:david)).update!(unread_at: nil)
+    catch_up room.memberships.find_by!(user: users(:david))
 
     get room_url(room)
 

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -15,6 +15,29 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show renders the new-messages separator inside the first unread message" do
+    room = rooms(:pets)
+    room.messages.create!(creator: users(:jason), body: "Seen already", client_message_id: "separator_seen")
+    first_unread = room.messages.create!(creator: users(:jason), body: "New to you", client_message_id: "separator_unread")
+    room.memberships.find_by!(user: users(:david)).update!(unread_at: first_unread.created_at)
+
+    get room_url(room)
+
+    assert_response :success
+    assert_select "[data-message-id='#{first_unread.id}'] #unread_separator", count: 1
+  end
+
+  test "show renders no new-messages separator when the membership is read" do
+    room = rooms(:pets)
+    room.messages.create!(creator: users(:jason), body: "Nothing new", client_message_id: "separator_none")
+    room.memberships.find_by!(user: users(:david)).update!(unread_at: nil)
+
+    get room_url(room)
+
+    assert_response :success
+    assert_select "#unread_separator", count: 0
+  end
+
   test "shows records the last room visited in a cookie" do
     get room_url(users(:david).rooms.last)
     assert_equal users(:david).rooms.last.id.to_s, response.cookies["last_room"]

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -217,6 +217,68 @@ class MembershipTest < ActiveSupport::TestCase
     assert @membership.unread?
   end
 
+  test "presenting in a room clears unread state and the notification badge" do
+    @membership.update!(unread_at: 1.hour.ago, unread_notifications_count: 3)
+
+    @membership.present
+
+    @membership.reload
+    assert @membership.read?
+    assert_equal 0, @membership.unread_notifications_count
+    assert @membership.connected?
+  end
+
+  test "read_until advances the anchor past the given time and recomputes the badge" do
+    room = @membership.room
+    first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "read_until_1")
+    second = room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "read_until_2")
+    mention = room.messages.create!(
+      creator: users(:jason),
+      body: "<div>Hey #{mention_attachment_for(:david)}</div>",
+      client_message_id: "read_until_3"
+    )
+    @membership.update!(unread_at: first.created_at)
+
+    @membership.read_until(first.created_at)
+
+    @membership.reload
+    assert @membership.unread?
+    assert_equal second.created_at, @membership.unread_at
+    assert_equal 1, @membership.unread_notifications_count, "the mention after the new anchor must still count"
+    assert mention.created_at > @membership.unread_at
+  end
+
+  test "read_until marks read when no messages remain after the given time" do
+    room = @membership.room
+    last = room.messages.create!(creator: users(:jason), body: "Last", client_message_id: "read_until_last")
+    @membership.update!(unread_at: last.created_at, unread_notifications_count: 2)
+
+    @membership.read_until(last.created_at)
+
+    @membership.reload
+    assert @membership.read?
+    assert_equal 0, @membership.unread_notifications_count
+  end
+
+  test "read_until ignores a time before the current anchor" do
+    room = @membership.room
+    first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "read_until_noop_1")
+    second = room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "read_until_noop_2")
+    @membership.update!(unread_at: second.created_at)
+
+    @membership.read_until(first.created_at)
+
+    assert_equal second.created_at, @membership.reload.unread_at
+  end
+
+  test "read_until is a no-op when already read" do
+    @membership.update!(unread_at: nil)
+
+    @membership.read_until(Time.current)
+
+    assert @membership.reload.read?
+  end
+
   # Leave! tests
 
   test "leave! makes membership invisible" do

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -188,37 +188,50 @@ class MembershipTest < ActiveSupport::TestCase
 
   # Read/Unread tests
 
-  test "mark_unread_at sets unread_at to message created_at" do
+  test "mark_unread_at makes the message the first unread" do
     message = @membership.room.messages.create!(creator: users(:jason), body: "Test")
-    @membership.update!(unread_at: nil)
+    catch_up @membership
 
     @membership.mark_unread_at(message)
 
-    assert_equal message.created_at, @membership.unread_at
     assert @membership.unread?
+    assert_equal message, @membership.first_unread_message
   end
 
-  test "read clears unread_at" do
-    @membership.update!(unread_at: 1.hour.ago)
+  test "read clears unread state" do
+    message = @membership.room.messages.create!(creator: users(:jason), body: "Unseen")
+    rewind_unread_to @membership, message
 
     @membership.read
 
-    assert_nil @membership.unread_at
     assert @membership.read?
+    assert_nil @membership.first_unread_message
   end
 
   test "read? and unread? are opposites" do
-    @membership.update!(unread_at: nil)
+    message = @membership.room.messages.create!(creator: users(:jason), body: "Unseen")
+
+    catch_up @membership
     assert @membership.read?
     assert_not @membership.unread?
 
-    @membership.update!(unread_at: 1.hour.ago)
+    rewind_unread_to @membership, message
     assert_not @membership.read?
     assert @membership.unread?
   end
 
+  test "a membership with no cursor yet reads as read, not all-unread" do
+    @membership.room.messages.create!(creator: users(:jason), body: "History")
+    @membership.update_columns(last_read_at: nil, last_read_message_id: nil, marked_unread: false)
+
+    assert @membership.read?
+    assert_not Membership.unread.exists?(@membership.id)
+  end
+
   test "presenting in a room clears unread state and the notification badge" do
-    @membership.update!(unread_at: 1.hour.ago, unread_notifications_count: 3)
+    message = @membership.room.messages.create!(creator: users(:jason), body: "Unseen")
+    rewind_unread_to @membership, message
+    @membership.update!(unread_notifications_count: 3)
 
     @membership.present
 
@@ -237,21 +250,22 @@ class MembershipTest < ActiveSupport::TestCase
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
       client_message_id: "read_until_3"
     )
-    @membership.update!(unread_at: first.created_at)
+    rewind_unread_to @membership, first
 
     @membership.read_until(first.created_at)
 
     @membership.reload
     assert @membership.unread?
-    assert_equal second.created_at, @membership.unread_at
+    assert_equal second, @membership.first_unread_message
     assert_equal 1, @membership.unread_notifications_count, "the mention after the new anchor must still count"
-    assert mention.created_at > @membership.unread_at
+    assert mention.created_at > @membership.first_unread_message.created_at
   end
 
   test "read_until marks read when no messages remain after the given time" do
     room = @membership.room
     last = room.messages.create!(creator: users(:jason), body: "Last", client_message_id: "read_until_last")
-    @membership.update!(unread_at: last.created_at, unread_notifications_count: 2)
+    rewind_unread_to @membership, last
+    @membership.update!(unread_notifications_count: 2)
 
     @membership.read_until(last.created_at)
 
@@ -264,19 +278,67 @@ class MembershipTest < ActiveSupport::TestCase
     room = @membership.room
     first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "read_until_noop_1")
     second = room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "read_until_noop_2")
-    @membership.update!(unread_at: second.created_at)
+    rewind_unread_to @membership, second
 
     @membership.read_until(first.created_at)
 
-    assert_equal second.created_at, @membership.reload.unread_at
+    assert_equal second, @membership.reload.first_unread_message
   end
 
   test "read_until is a no-op when already read" do
-    @membership.update!(unread_at: nil)
+    catch_up @membership
 
     @membership.read_until(Time.current)
 
     assert @membership.reload.read?
+  end
+
+  test "fully disconnecting counts messages watched live as seen" do
+    @membership.present
+    @membership.room.messages.create!(creator: users(:jason), body: "Watched live", client_message_id: "watched_live")
+
+    @membership.disconnected
+
+    assert @membership.reload.read?, "messages that landed while connected must not dot the room after leaving"
+  end
+
+  test "disconnecting preserves an explicit mark-as-unread" do
+    @membership.present
+    message = @membership.room.messages.create!(creator: users(:jason), body: "Keep me unread", client_message_id: "keep_unread")
+    @membership.mark_unread_at(message)
+
+    @membership.disconnected
+
+    @membership.reload
+    assert @membership.unread?, "an explicit mark must survive leaving the room"
+    assert_equal message, @membership.first_unread_message
+  end
+
+  test "refreshing the connection advances the cursor" do
+    @membership.present
+    @membership.room.messages.create!(creator: users(:jason), body: "Seen on heartbeat", client_message_id: "heartbeat_seen")
+
+    @membership.refresh_connection
+    @membership.update_columns(connected_at: nil, connections: 0)
+
+    assert @membership.reload.read?
+  end
+
+  test "disconnect_all advances cursors but preserves explicit marks" do
+    watching = memberships(:david_watercooler)
+    marked = memberships(:jason_watercooler)
+    watching.present
+    marked.present
+
+    message = watching.room.messages.create!(creator: users(:kevin), body: "Before shutdown", client_message_id: "shutdown_msg")
+    marked.mark_unread_at(message)
+
+    Membership.disconnect_all
+
+    assert watching.reload.read?, "a watcher's cursor advances on shutdown"
+    marked.reload
+    assert marked.unread?, "an explicit mark survives shutdown"
+    assert_equal message, marked.first_unread_message
   end
 
   # Leave! tests
@@ -345,7 +407,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications returns mentioned messages for non-direct rooms" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     # Message mentioning david — should be an unread notification
     mentioned_msg = room.messages.create!(
@@ -368,7 +430,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications returns all messages for direct rooms" do
     dm_room = rooms(:david_and_jason)
     membership = dm_room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     msg = dm_room.messages.create!(
       body: "Hey!",
@@ -382,7 +444,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications includes @everyone messages" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     everyone_sgid = Everyone.new.attachable_sgid
     body_html = "<div><action-text-attachment sgid=\"#{everyone_sgid}\" content-type=\"application/vnd.sabha.mention\"></action-text-attachment></div>"
@@ -400,7 +462,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "has_unread_notifications? true when mentioned in unread messages" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     room.messages.create!(
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
@@ -414,7 +476,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "has_unread_notifications? false when no mentions in unread messages" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     room.messages.create!(
       body: "<div>No mentions here</div>",
@@ -428,7 +490,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "has_unread_notifications? false when read" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: nil)
+    catch_up membership
 
     assert_not membership.has_unread_notifications?
   end
@@ -436,7 +498,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count tracks mentioned unread messages" do
     room = rooms(:pets)
     david_membership = room.memberships.find_by(user: users(:david))
-    david_membership.update!(unread_at: 1.day.ago)
+    force_all_unread david_membership
 
     room.messages.create!(
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
@@ -455,7 +517,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count not bumped by non-mentioning messages" do
     room = rooms(:pets)
     david_membership = room.memberships.find_by(user: users(:david))
-    david_membership.update!(unread_at: 1.day.ago)
+    force_all_unread david_membership
 
     room.messages.create!(
       body: "<div>No mention</div>",
@@ -469,7 +531,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count zero when read" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: nil)
+    catch_up membership
 
     assert_equal 0, membership.unread_notifications_count
   end
@@ -477,7 +539,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count drops when a mention message is soft-deleted" do
     room = rooms(:pets)
     david_membership = room.memberships.find_by(user: users(:david))
-    david_membership.update!(unread_at: 1.day.ago)
+    force_all_unread david_membership
 
     message = room.messages.create!(
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
@@ -495,7 +557,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count drops when a DM message is soft-deleted" do
     dm_room = rooms(:david_and_jason)
     membership = dm_room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     earlier = dm_room.messages.create!(
       body: "first",
@@ -522,7 +584,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count drops when a mention message is hard-destroyed" do
     room = rooms(:pets)
     david_membership = room.memberships.find_by(user: users(:david))
-    david_membership.update!(unread_at: 1.day.ago)
+    force_all_unread david_membership
 
     message = room.messages.create!(
       body: "<div>Hey #{mention_attachment_for(:david)}</div>",
@@ -540,7 +602,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count drops when a DM message is hard-destroyed" do
     dm_room = rooms(:david_and_jason)
     membership = dm_room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     earlier = dm_room.messages.create!(
       body: "first",
@@ -565,7 +627,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count restores when a soft-deleted DM message is reactivated" do
     dm_room = rooms(:david_and_jason)
     membership = dm_room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     message = dm_room.messages.create!(
       body: "hello",
@@ -585,7 +647,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count restores when a soft-deleted @everyone message is reactivated" do
     room = rooms(:pets)
     membership = room.memberships.find_by(user: users(:david))
-    membership.update!(unread_at: 1.day.ago)
+    force_all_unread membership
 
     everyone_sgid = Everyone.new.attachable_sgid
     body_html = "<div><action-text-attachment sgid=\"#{everyone_sgid}\" content-type=\"application/vnd.sabha.mention\"></action-text-attachment></div>"
@@ -608,7 +670,14 @@ class MembershipTest < ActiveSupport::TestCase
   test "unread_notifications_count bumps the DM sender when their unread window includes the message" do
     dm_room = rooms(:david_and_jason)
     sender_membership = dm_room.memberships.find_by(user: users(:jason))
-    sender_membership.update!(unread_at: 1.day.ago)
+
+    unseen = dm_room.messages.create!(
+      body: "waiting for jason",
+      creator: users(:david),
+      client_message_id: "dm_sender_window_anchor"
+    )
+    rewind_unread_to sender_membership, unseen
+    sender_membership.update!(unread_notifications_count: 1)
 
     dm_room.messages.create!(
       body: "self-aware",
@@ -616,7 +685,8 @@ class MembershipTest < ActiveSupport::TestCase
       client_message_id: "dm_sender_in_window"
     )
 
-    assert_equal 1, sender_membership.reload.unread_notifications_count
+    assert_equal 2, sender_membership.reload.unread_notifications_count,
+      "a sender with an open unread window keeps it, and their own DM message counts inside it"
   end
 
   test "unread_notifications_count recomputes when DM message at the unread anchor is soft-deleted" do
@@ -634,12 +704,13 @@ class MembershipTest < ActiveSupport::TestCase
       client_message_id: "dm_follow_up"
     )
 
-    membership.update!(unread_at: anchor.created_at, unread_notifications_count: 2)
+    rewind_unread_to membership, anchor
+    membership.update!(unread_notifications_count: 2)
 
     anchor.deactivate
 
     membership.reload
-    assert_equal follow_up.created_at, membership.unread_at
+    assert_equal follow_up, membership.first_unread_message
     assert_equal 1, membership.unread_notifications_count
   end
 

--- a/test/models/message/broadcasts_test.rb
+++ b/test/models/message/broadcasts_test.rb
@@ -6,7 +6,7 @@ class Message::BroadcastsTest < ActiveSupport::TestCase
     @user = users(:david)
   end
 
-  test "notification_recipient_ids filters by unread_at when ignore_if_older_message is true" do
+  test "notification_recipient_ids filters to unseen when ignore_if_older_message is true" do
     everyone_sgid = Everyone.new.attachable_sgid
     body_html = "<div><action-text-attachment sgid=\"#{everyone_sgid}\" content-type=\"application/vnd.sabha.mention\"></action-text-attachment></div>"
 
@@ -16,18 +16,18 @@ class Message::BroadcastsTest < ActiveSupport::TestCase
       creator: @user
     )
 
-    # Mark one user as having read (unread_at = nil)
-    @room.memberships.find_by(user: users(:jason)).update!(unread_at: nil)
+    # One user has seen everything
+    catch_up @room.memberships.find_by(user: users(:jason))
 
-    # Mark another user as unread before this message
-    @room.memberships.find_by(user: users(:david)).update!(unread_at: 1.hour.ago)
+    # Another user's cursor sits before this message
+    force_all_unread @room.memberships.find_by(user: users(:david))
 
     user_ids = message.send(:notification_recipient_ids, true)
 
-    # David should be included (unread_at before message)
+    # David should be included (message unseen for them)
     assert_includes user_ids, users(:david).id
 
-    # Jason should be excluded (read - unread_at is nil)
+    # Jason should be excluded (caught up)
     assert_not_includes user_ids, users(:jason).id
   end
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -31,19 +31,21 @@ class MessageTest < ActiveSupport::TestCase
   test "creating a message marks disconnected read memberships as unread" do
     room = rooms(:pets)
     recipient_membership = room.memberships.find_by!(user: users(:david))
-    recipient_membership.update!(unread_at: nil)
+    catch_up recipient_membership
     recipient_membership.update_columns(connected_at: nil, connections: 0)
 
     message = room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "deliver_to_room_marks_unread")
 
-    assert_equal message.created_at, recipient_membership.reload.unread_at
+    recipient_membership.reload
+    assert recipient_membership.unread?
+    assert_equal message, recipient_membership.first_unread_message
   end
 
-  test "mention to a read disconnected recipient sets unread_at and bumps unread_notifications_count" do
+  test "mention to a read disconnected recipient sets unread and bumps unread_notifications_count" do
     room = rooms(:pets)
     recipient_membership = room.memberships.find_by!(user: users(:david))
-    recipient_membership.update!(unread_at: nil, unread_notifications_count: 0)
-    recipient_membership.update_columns(connected_at: nil, connections: 0)
+    catch_up recipient_membership
+    recipient_membership.update_columns(connected_at: nil, connections: 0, unread_notifications_count: 0)
 
     message = room.messages.create!(
       creator: users(:jason),
@@ -52,14 +54,15 @@ class MessageTest < ActiveSupport::TestCase
     )
 
     recipient_membership.reload
-    assert_equal message.created_at, recipient_membership.unread_at
+    assert recipient_membership.unread?
+    assert_equal message, recipient_membership.first_unread_message
     assert_equal 1, recipient_membership.unread_notifications_count
   end
 
   test "creating a message leaves connected memberships read" do
     room = rooms(:pets)
     recipient_membership = room.memberships.find_by!(user: users(:david))
-    recipient_membership.update!(unread_at: nil)
+    catch_up recipient_membership
     recipient_membership.update_columns(connected_at: Time.current, connections: 1)
 
     room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "connected_stays_read")
@@ -70,7 +73,7 @@ class MessageTest < ActiveSupport::TestCase
   test "creating a message leaves the sender's membership read even when disconnected" do
     room = rooms(:pets)
     sender_membership = room.memberships.find_by!(user: users(:jason))
-    sender_membership.update!(unread_at: nil)
+    catch_up sender_membership
     sender_membership.update_columns(connected_at: nil, connections: 0)
 
     room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "sender_stays_read")
@@ -81,21 +84,23 @@ class MessageTest < ActiveSupport::TestCase
   test "creating a message does not move an already-unread membership's anchor" do
     room = rooms(:pets)
     membership = room.memberships.find_by!(user: users(:david))
+    catch_up membership
     membership.update_columns(connected_at: nil, connections: 0)
 
     first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "anchor_first")
-    assert_equal first.created_at, membership.reload.unread_at
+    assert_equal first, membership.reload.first_unread_message
 
     room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "anchor_second")
 
-    assert_equal first.created_at, membership.reload.unread_at,
+    assert_equal first, membership.reload.first_unread_message,
       "the unread anchor must stay at the first unseen message so the New separator doesn't drift"
   end
 
   test "creating a message does not mark invisible memberships unread" do
     room = rooms(:pets)
     membership = room.memberships.find_by!(user: users(:david))
-    membership.update!(unread_at: nil, involvement: :invisible)
+    catch_up membership
+    membership.update!(involvement: :invisible)
     membership.update_columns(connected_at: nil, connections: 0)
 
     room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "invisible_stays_read")
@@ -104,13 +109,12 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   test "@everyone to a read disconnected member sets unread and bumps the badge" do
-    # Pins the KTD-sensitive callback ordering: deliver_to_room must set unread_at
-    # before increment_unread_notifications_counters checks it, or a read member
-    # never gets the badge bump.
+    # Pins the KTD-sensitive eligibility: a read, disconnected member's badge
+    # must bump on send even though sending no longer writes their unread row.
     room = rooms(:pets)
     membership = room.memberships.find_by!(user: users(:david))
-    membership.update!(unread_at: nil, unread_notifications_count: 0)
-    membership.update_columns(connected_at: nil, connections: 0)
+    catch_up membership
+    membership.update_columns(connected_at: nil, connections: 0, unread_notifications_count: 0)
 
     everyone_sgid = Everyone.new.attachable_sgid
     message = room.messages.create!(
@@ -120,20 +124,50 @@ class MessageTest < ActiveSupport::TestCase
     )
 
     membership.reload
-    assert_equal message.created_at, membership.unread_at
+    assert membership.unread?
+    assert_equal message, membership.first_unread_message
     assert_equal 1, membership.unread_notifications_count
+  end
+
+  test "sending writes no per-member unread rows, and the count derives on reopen" do
+    room = rooms(:pets)
+    reader = room.memberships.find_by!(user: users(:david))
+    catch_up reader
+    reader.update_columns(connected_at: nil, connections: 0)
+
+    snapshot = -> { room.memberships.where.not(user_id: users(:jason).id).order(:id).pluck(:updated_at, :last_read_at, :last_read_message_id, :marked_unread) }
+    before = snapshot.call
+
+    20.times { |i| room.messages.create!(creator: users(:jason), body: "Msg #{i}", client_message_id: "burst_#{i}") }
+
+    assert_equal before, snapshot.call, "sending must not write any non-sender membership row"
+    assert_equal 20, room.messages.after_cursor(reader.last_read_at, reader.last_read_message_id).count,
+      "the derived unread count reflects every message that landed while away"
+    assert reader.reload.unread?
+  end
+
+  test "a rejoining member keeps their read cursor" do
+    room = rooms(:pets)
+    membership = room.memberships.find_by!(user: users(:david))
+    anchor = room.messages.create!(creator: users(:jason), body: "Anchor", client_message_id: "regrant_anchor")
+    rewind_unread_to membership, anchor
+
+    room.memberships.grant_to(users(:david))
+
+    assert_equal anchor, membership.reload.first_unread_message, "re-granting must not reset the cursor to head"
   end
 
   test "DM to a read disconnected recipient sets unread and bumps the badge" do
     room = rooms(:david_and_jason)
     membership = room.memberships.find_by!(user: users(:david))
-    membership.update!(unread_at: nil, unread_notifications_count: 0)
-    membership.update_columns(connected_at: nil, connections: 0)
+    catch_up membership
+    membership.update_columns(connected_at: nil, connections: 0, unread_notifications_count: 0)
 
     message = room.messages.create!(creator: users(:jason), body: "Hey", client_message_id: "dm_to_read_disconnected")
 
     membership.reload
-    assert_equal message.created_at, membership.unread_at
+    assert membership.unread?
+    assert_equal message, membership.first_unread_message
     assert_equal 1, membership.unread_notifications_count
   end
 
@@ -165,74 +199,56 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal [], message_mentioning_a_non_member.mentionees
   end
 
-  test "deactivating message clears unread timestamps pointing to it" do
+  test "a deactivated message stops counting toward unread" do
     room = rooms(:pets)
-    user = users(:david)
-    membership = room.memberships.find_by(user: user)
+    membership = room.memberships.find_by(user: users(:david))
 
-    # Create two messages
     message1 = room.messages.create!(creator: users(:jason), body: "First message", client_message_id: "msg1")
     message2 = room.messages.create!(creator: users(:jason), body: "Second message", client_message_id: "msg2")
 
-    # Mark membership as unread at message1
-    membership.update!(unread_at: message1.created_at)
+    rewind_unread_to membership, message1
     assert membership.unread?
-    assert_equal message1.created_at, membership.unread_at
+    assert_equal message1, membership.first_unread_message
 
-    # Deactivate message1
     message1.deactivate
 
-    # Should update unread_at to message2 since it's the next unread message
+    # Derived unread only sees active messages, so the first unread moves on
     membership.reload
     assert membership.unread?
-    assert_equal message2.created_at, membership.unread_at
+    assert_equal message2, membership.first_unread_message
   end
 
-  test "deactivating last unread message marks membership as read" do
+  test "deactivating the last unread message leaves the membership read" do
     room = rooms(:pets)
-    user = users(:david)
-    membership = room.memberships.find_by(user: user)
+    membership = room.memberships.find_by(user: users(:david))
 
-    # Create one message
     message = room.messages.create!(creator: users(:jason), body: "Only message", client_message_id: "msg1")
-
-    # Mark membership as unread at this message
-    membership.update!(unread_at: message.created_at)
+    rewind_unread_to membership, message
     assert membership.unread?
 
-    # Deactivate the message
     message.deactivate
 
-    # Should mark membership as read since no unread messages remain
+    # No phantom dot: nothing active sits after the cursor anymore
     membership.reload
     assert membership.read?
-    assert_nil membership.unread_at
+    assert_nil membership.first_unread_message
   end
 
-  test "deactivating message only affects memberships with matching unread_at" do
+  test "deactivating a message leaves other members' unread anchors alone" do
     room = rooms(:pets)
-    user1 = users(:david)
-    user2 = users(:jason)
-    membership1 = room.memberships.find_by(user: user1)
-    membership2 = room.memberships.find_by(user: user2)
+    membership1 = room.memberships.find_by(user: users(:david))
+    membership2 = room.memberships.find_by(user: users(:jason))
 
-    # Create two messages
     message1 = room.messages.create!(creator: users(:jason), body: "First message", client_message_id: "msg1")
     message2 = room.messages.create!(creator: users(:jason), body: "Second message", client_message_id: "msg2")
 
-    # Mark memberships with different unread_at timestamps
-    membership1.update!(unread_at: message1.created_at)
-    membership2.update!(unread_at: message2.created_at)
+    rewind_unread_to membership1, message1
+    rewind_unread_to membership2, message2
 
-    # Deactivate message1
     message1.deactivate
 
-    # Only membership1 should be affected
-    membership1.reload
-    membership2.reload
-
-    assert_equal message2.created_at, membership1.unread_at  # Updated to next message
-    assert_equal message2.created_at, membership2.unread_at  # Unchanged
+    assert_equal message2, membership1.reload.first_unread_message  # moved past the deleted message
+    assert_equal message2, membership2.reload.first_unread_message  # unchanged
   end
 
   test "@everyone mention sets mentions_everyone flag" do

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -56,6 +56,87 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal 1, recipient_membership.unread_notifications_count
   end
 
+  test "creating a message leaves connected memberships read" do
+    room = rooms(:pets)
+    recipient_membership = room.memberships.find_by!(user: users(:david))
+    recipient_membership.update!(unread_at: nil)
+    recipient_membership.update_columns(connected_at: Time.current, connections: 1)
+
+    room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "connected_stays_read")
+
+    assert recipient_membership.reload.read?
+  end
+
+  test "creating a message leaves the sender's membership read even when disconnected" do
+    room = rooms(:pets)
+    sender_membership = room.memberships.find_by!(user: users(:jason))
+    sender_membership.update!(unread_at: nil)
+    sender_membership.update_columns(connected_at: nil, connections: 0)
+
+    room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "sender_stays_read")
+
+    assert sender_membership.reload.read?
+  end
+
+  test "creating a message does not move an already-unread membership's anchor" do
+    room = rooms(:pets)
+    membership = room.memberships.find_by!(user: users(:david))
+    membership.update_columns(connected_at: nil, connections: 0)
+
+    first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "anchor_first")
+    assert_equal first.created_at, membership.reload.unread_at
+
+    room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "anchor_second")
+
+    assert_equal first.created_at, membership.reload.unread_at,
+      "the unread anchor must stay at the first unseen message so the New separator doesn't drift"
+  end
+
+  test "creating a message does not mark invisible memberships unread" do
+    room = rooms(:pets)
+    membership = room.memberships.find_by!(user: users(:david))
+    membership.update!(unread_at: nil, involvement: :invisible)
+    membership.update_columns(connected_at: nil, connections: 0)
+
+    room.messages.create!(creator: users(:jason), body: "Hello", client_message_id: "invisible_stays_read")
+
+    assert membership.reload.read?
+  end
+
+  test "@everyone to a read disconnected member sets unread and bumps the badge" do
+    # Pins the KTD-sensitive callback ordering: deliver_to_room must set unread_at
+    # before increment_unread_notifications_counters checks it, or a read member
+    # never gets the badge bump.
+    room = rooms(:pets)
+    membership = room.memberships.find_by!(user: users(:david))
+    membership.update!(unread_at: nil, unread_notifications_count: 0)
+    membership.update_columns(connected_at: nil, connections: 0)
+
+    everyone_sgid = Everyone.new.attachable_sgid
+    message = room.messages.create!(
+      creator: users(:jason),
+      body: "<div><action-text-attachment sgid=\"#{everyone_sgid}\" content-type=\"application/vnd.sabha.mention\"></action-text-attachment></div>",
+      client_message_id: "everyone_to_read_disconnected"
+    )
+
+    membership.reload
+    assert_equal message.created_at, membership.unread_at
+    assert_equal 1, membership.unread_notifications_count
+  end
+
+  test "DM to a read disconnected recipient sets unread and bumps the badge" do
+    room = rooms(:david_and_jason)
+    membership = room.memberships.find_by!(user: users(:david))
+    membership.update!(unread_at: nil, unread_notifications_count: 0)
+    membership.update_columns(connected_at: nil, connections: 0)
+
+    message = room.messages.create!(creator: users(:jason), body: "Hey", client_message_id: "dm_to_read_disconnected")
+
+    membership.reload
+    assert_equal message.created_at, membership.unread_at
+    assert_equal 1, membership.unread_notifications_count
+  end
+
   # Event messages
 
   test "without_events scope excludes event messages" do

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -19,11 +19,13 @@ class RoomTest < ActiveSupport::TestCase
     room = rooms(:watercooler)
     last_message = room.messages.create!(creator: users(:jason), body: "Latest", client_message_id: "involve_unread")
     membership = room.memberships.find_by!(user: users(:david))
-    membership.update!(unread_at: nil)
+    catch_up membership
 
     room.involve_user(users(:david), unread: true)
 
-    assert_equal last_message.created_at, membership.reload.unread_at
+    membership.reload
+    assert membership.unread?
+    assert_equal last_message, membership.first_unread_message
   end
 
   test "involve_user with unread does not move an already-unread anchor" do
@@ -31,11 +33,11 @@ class RoomTest < ActiveSupport::TestCase
     first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "involve_anchor_1")
     room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "involve_anchor_2")
     membership = room.memberships.find_by!(user: users(:david))
-    membership.update!(unread_at: first.created_at)
+    rewind_unread_to membership, first
 
     room.involve_user(users(:david), unread: true)
 
-    assert_equal first.created_at, membership.reload.unread_at
+    assert_equal first, membership.reload.first_unread_message
   end
 
   test "revoke membership from user" do

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -459,6 +459,22 @@ class RoomTest < ActiveSupport::TestCase
     end
   end
 
+  test "receiving a message publishes one shared nudge, not one per member" do
+    room = rooms(:watercooler)
+    members = room.memberships.visible.includes(:user).map(&:user)
+    assert members.size >= 2, "fixture should have multiple members for this test to be meaningful"
+    ActionCable.server.pubsub.clear
+
+    assert_broadcasts(RoomListChannel.broadcasting_for(Account.sole), 1) do
+      room.messages.create!(body: "Hello all", creator: members.first, client_message_id: SecureRandom.uuid)
+    end
+
+    members.each do |user|
+      assert_empty ActionCable.server.pubsub.broadcasts(UserUnreadRoomsChannel.broadcasting_for(user)),
+        "the send path should not push per-member unread broadcasts"
+    end
+  end
+
   test "reactivating a sidebar room broadcasts an append to each visible member's sidebar" do
     room = rooms(:pets)
     room.update_columns(active: false)

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -15,6 +15,29 @@ class RoomTest < ActiveSupport::TestCase
     assert rooms(:watercooler).users.include?(users(:kevin))
   end
 
+  test "involve_user with unread marks a read membership unread at the last message" do
+    room = rooms(:watercooler)
+    last_message = room.messages.create!(creator: users(:jason), body: "Latest", client_message_id: "involve_unread")
+    membership = room.memberships.find_by!(user: users(:david))
+    membership.update!(unread_at: nil)
+
+    room.involve_user(users(:david), unread: true)
+
+    assert_equal last_message.created_at, membership.reload.unread_at
+  end
+
+  test "involve_user with unread does not move an already-unread anchor" do
+    room = rooms(:watercooler)
+    first = room.messages.create!(creator: users(:jason), body: "First", client_message_id: "involve_anchor_1")
+    room.messages.create!(creator: users(:jason), body: "Second", client_message_id: "involve_anchor_2")
+    membership = room.memberships.find_by!(user: users(:david))
+    membership.update!(unread_at: first.created_at)
+
+    room.involve_user(users(:david), unread: true)
+
+    assert_equal first.created_at, membership.reload.unread_at
+  end
+
   test "revoke membership from user" do
     rooms(:watercooler).memberships.revoke_from(users(:david))
     assert_not rooms(:watercooler).users.include?(users(:david))

--- a/test/models/rooms/forum_test.rb
+++ b/test/models/rooms/forum_test.rb
@@ -81,6 +81,56 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     assert_includes Membership.shared, membership
   end
 
+  test "an opening post dots disconnected read members but not the author" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to(users(:jason))
+    forum.memberships.grant_to(users(:david))
+    reader = forum.memberships.find_by!(user: users(:jason))
+    reader.update_columns(connected_at: nil, connections: 0, unread_at: nil)
+    author = forum.memberships.find_by!(user: users(:david))
+    author.update_columns(connected_at: nil, connections: 0, unread_at: nil)
+
+    create_forum_post(title: "Fresh question", forum: forum, author: users(:david))
+
+    assert reader.reload.unread?, "a disconnected member should get the forum's sidebar dot"
+    assert author.reload.read?, "the author never dots their own forum"
+  end
+
+  test "an opening post leaves connected members read" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to(users(:jason))
+    connected = forum.memberships.find_by!(user: users(:jason))
+    connected.update_columns(connected_at: Time.current, connections: 1, unread_at: nil)
+
+    create_forum_post(title: "Another question", forum: forum, author: users(:david))
+
+    assert connected.reload.read?, "a member viewing live never gets the dot"
+  end
+
+  test "an opening post does not move an already-unread member's forum anchor" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to(users(:jason))
+    membership = forum.memberships.find_by!(user: users(:jason))
+    anchor = 1.day.ago.change(usec: 0)
+    membership.update_columns(connected_at: nil, connections: 0, unread_at: anchor)
+
+    create_forum_post(title: "Yet another question", forum: forum, author: users(:david))
+
+    assert_equal anchor, membership.reload.unread_at
+  end
+
+  test "a reply to a post does not dot the forum" do
+    forum = rooms(:help_desk)
+    post = create_forum_post(title: "Existing discussion", forum: forum, author: users(:david))
+    forum.memberships.grant_to(users(:jason))
+    reader = forum.memberships.find_by!(user: users(:jason))
+    reader.update_columns(connected_at: nil, connections: 0, unread_at: nil)
+
+    post.messages.create!(body: "A reply", creator: users(:david), client_message_id: "forum_reply_no_dot")
+
+    assert reader.reload.read?, "only a post's opening message dots the forum sidebar"
+  end
+
   # --- Cascade & reactivation correctness --------------------------------
 
   test "restoring a forum restores posts that were active when it was deleted" do

--- a/test/models/rooms/forum_test.rb
+++ b/test/models/rooms/forum_test.rb
@@ -86,9 +86,9 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     forum.memberships.grant_to(users(:jason))
     forum.memberships.grant_to(users(:david))
     reader = forum.memberships.find_by!(user: users(:jason))
-    reader.update_columns(connected_at: nil, connections: 0, unread_at: nil)
+    reader.update_columns(connected_at: nil, connections: 0, marked_unread: false)
     author = forum.memberships.find_by!(user: users(:david))
-    author.update_columns(connected_at: nil, connections: 0, unread_at: nil)
+    author.update_columns(connected_at: nil, connections: 0, marked_unread: false)
 
     create_forum_post(title: "Fresh question", forum: forum, author: users(:david))
 
@@ -100,23 +100,22 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     forum = rooms(:help_desk)
     forum.memberships.grant_to(users(:jason))
     connected = forum.memberships.find_by!(user: users(:jason))
-    connected.update_columns(connected_at: Time.current, connections: 1, unread_at: nil)
+    connected.update_columns(connected_at: Time.current, connections: 1, marked_unread: false)
 
     create_forum_post(title: "Another question", forum: forum, author: users(:david))
 
     assert connected.reload.read?, "a member viewing live never gets the dot"
   end
 
-  test "an opening post does not move an already-unread member's forum anchor" do
+  test "an opening post keeps an already-dotted member's forum dot" do
     forum = rooms(:help_desk)
     forum.memberships.grant_to(users(:jason))
     membership = forum.memberships.find_by!(user: users(:jason))
-    anchor = 1.day.ago.change(usec: 0)
-    membership.update_columns(connected_at: nil, connections: 0, unread_at: anchor)
+    membership.update_columns(connected_at: nil, connections: 0, marked_unread: true)
 
     create_forum_post(title: "Yet another question", forum: forum, author: users(:david))
 
-    assert_equal anchor, membership.reload.unread_at
+    assert membership.reload.unread?, "an already-dotted forum stays dotted"
   end
 
   test "a reply to a post does not dot the forum" do
@@ -124,7 +123,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     post = create_forum_post(title: "Existing discussion", forum: forum, author: users(:david))
     forum.memberships.grant_to(users(:jason))
     reader = forum.memberships.find_by!(user: users(:jason))
-    reader.update_columns(connected_at: nil, connections: 0, unread_at: nil)
+    reader.update_columns(connected_at: nil, connections: 0, marked_unread: false)
 
     post.messages.create!(body: "A reply", creator: users(:david), client_message_id: "forum_reply_no_dot")
 
@@ -309,7 +308,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
 
   test "a new post marks the forum unread for other members but not the author" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
-    forum.memberships.update_all(unread_at: nil)
+    forum.memberships.update_all(marked_unread: false)
 
     Current.set(user: users(:david)) { forum.post!(title: "How do I reset?", body: "b") }
 
@@ -322,7 +321,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
   test "a plain reply does not mark the forum unread" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
     post = Current.set(user: users(:david)) { forum.post!(title: "Q", body: "b") }
-    forum.memberships.update_all(unread_at: nil)
+    forum.memberships.update_all(marked_unread: false)
 
     Current.set(user: users(:kevin)) { post.messages.create!(body: "<div>a reply</div>") }
 
@@ -332,7 +331,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
   test "a mention in a reply does not badge the forum — it surfaces in Activity only" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
     post = Current.set(user: users(:david)) { forum.post!(title: "Q", body: "b") }
-    forum.memberships.update_all(unread_at: nil)
+    forum.memberships.update_all(marked_unread: false)
     mention = %(<action-text-attachment sgid="#{users(:kevin).attachable_sgid}" content-type="application/vnd.sabha.mention"></action-text-attachment>)
 
     Current.set(user: users(:david)) { post.messages.create!(body: "<div>#{mention} ping</div>") }

--- a/test/models/rooms/forum_test.rb
+++ b/test/models/rooms/forum_test.rb
@@ -130,6 +130,57 @@ class Rooms::ForumTest < ActiveSupport::TestCase
     assert reader.reload.read?, "only a post's opening message dots the forum sidebar"
   end
 
+  test "a new post writes no member rows and publishes one shared nudge" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to(users(:jason))
+    forum.memberships.grant_to(users(:kevin))
+    others = forum.memberships.where.not(user_id: users(:david).id)
+    others.each { |membership| catch_up membership }
+    others.update_all(connected_at: nil, connections: 0)
+    before = others.reload.map(&:attributes)
+    ActionCable.server.pubsub.clear
+
+    nudges = capture_broadcasts(RoomListChannel.broadcasting_for(Account.sole)) do
+      create_forum_post(title: "Zero writes", forum: forum, author: users(:david))
+    end
+
+    assert_equal before, others.reload.map(&:attributes), "a post should not touch other members' rows"
+    assert others.all?(&:unread?), "the dot still derives for every member who hasn't seen the post"
+    assert_equal 1, nudges.count { |n| n["roomId"] == forum.id }, "one shared nudge for the forum"
+    others.includes(:user).each do |membership|
+      assert_empty ActionCable.server.pubsub.broadcasts(UserUnreadRoomsChannel.broadcasting_for(membership.user)),
+        "no per-member dot push should fire"
+    end
+  end
+
+  test "an author with an older unseen post keeps their dot when they post" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to(users(:david))
+    author = forum.memberships.find_by!(user: users(:david))
+    catch_up author
+    author.update_columns(connected_at: nil, connections: 0)
+    create_forum_post(title: "Someone else's question", forum: forum, author: users(:kevin))
+    assert author.reload.unread?, "another member's post dots the author like anyone else"
+
+    create_forum_post(title: "The author's own question", forum: forum, author: users(:david))
+
+    assert author.reload.unread?, "posting must not clear the author's dot for posts they haven't seen"
+  end
+
+  test "deleting the only unseen post heals the forum dot" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to(users(:jason))
+    reader = forum.memberships.find_by!(user: users(:jason))
+    catch_up reader
+    reader.update_columns(connected_at: nil, connections: 0)
+    post = create_forum_post(title: "Soon deleted", forum: forum, author: users(:david))
+    assert reader.reload.unread?, "the fresh post dots the reader"
+
+    post.deactivate
+
+    assert reader.reload.read?, "derived forum unread self-heals when the post disappears"
+  end
+
   # --- Cascade & reactivation correctness --------------------------------
 
   test "restoring a forum restores posts that were active when it was deleted" do
@@ -308,7 +359,6 @@ class Rooms::ForumTest < ActiveSupport::TestCase
 
   test "a new post marks the forum unread for other members but not the author" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
-    forum.memberships.update_all(marked_unread: false)
 
     Current.set(user: users(:david)) { forum.post!(title: "How do I reset?", body: "b") }
 
@@ -321,7 +371,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
   test "a plain reply does not mark the forum unread" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
     post = Current.set(user: users(:david)) { forum.post!(title: "Q", body: "b") }
-    forum.memberships.update_all(marked_unread: false)
+    forum.memberships.each { |membership| catch_up membership }
 
     Current.set(user: users(:kevin)) { post.messages.create!(body: "<div>a reply</div>") }
 
@@ -331,7 +381,7 @@ class Rooms::ForumTest < ActiveSupport::TestCase
   test "a mention in a reply does not badge the forum — it surfaces in Activity only" do
     forum = Rooms::Forum.create_for({ name: "Community", creator: users(:david) }, users: users(:david))
     post = Current.set(user: users(:david)) { forum.post!(title: "Q", body: "b") }
-    forum.memberships.update_all(marked_unread: false)
+    forum.memberships.each { |membership| catch_up membership }
     mention = %(<action-text-attachment sgid="#{users(:kevin).attachable_sgid}" content-type="application/vnd.sabha.mention"></action-text-attachment>)
 
     Current.set(user: users(:david)) { post.messages.create!(body: "<div>#{mention} ping</div>") }

--- a/test/models/sidebar_memberships_test.rb
+++ b/test/models/sidebar_memberships_test.rb
@@ -35,7 +35,7 @@ class SidebarMembershipsTest < ActiveSupport::TestCase
     room.messages.create!(creator: @jason, body: "Hello")
 
     # Mark as read and set room as old (after message creation to avoid callback updates)
-    @david.memberships.find_by(room: room).update!(unread_at: nil)
+    catch_up @david.memberships.find_by(room: room)
     room.update_columns(updated_at: 10.days.ago)
 
     direct = @sidebar.direct
@@ -48,7 +48,7 @@ class SidebarMembershipsTest < ActiveSupport::TestCase
     message = room.messages.create!(creator: @jason, body: "Hello")
 
     # Mark as unread and set room as old
-    @david.memberships.find_by(room: room).update!(unread_at: message.created_at)
+    rewind_unread_to @david.memberships.find_by(room: room), message
     room.update_columns(updated_at: 10.days.ago)
 
     direct = @sidebar.direct

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -842,21 +842,25 @@ class UserTest < ActiveSupport::TestCase
   test "mark_direct_messages_as_read clears unread on DM memberships up to the given time" do
     user = users(:david)
     dm = memberships(:david_david_and_kevin)
-    dm.update_column(:unread_at, 30.minutes.ago)
+    # A minute old: loaded_at stamps truncate to seconds, so a message created
+    # "now" would land after the stamp and legitimately stay unread.
+    unseen = travel_to(1.minute.ago) { dm.room.messages.create!(creator: users(:kevin), body: "hi", client_message_id: "dm_mark_read") }
+    rewind_unread_to dm, unseen
 
     user.mark_direct_messages_as_read(Time.current.iso8601)
 
-    assert_nil dm.reload.unread_at, "DM membership must be marked read"
+    assert dm.reload.read?, "DM membership must be marked read"
   end
 
   test "mark_direct_messages_as_read leaves non-DM memberships untouched" do
     user = users(:david)
     non_dm = memberships(:david_designers)
-    non_dm.update_column(:unread_at, 30.minutes.ago)
+    unseen = non_dm.room.messages.create!(creator: users(:jason), body: "hi", client_message_id: "non_dm_untouched")
+    rewind_unread_to non_dm, unseen
 
     user.mark_direct_messages_as_read(Time.current.iso8601)
 
-    assert_not_nil non_dm.reload.unread_at,
+    assert non_dm.reload.unread?,
       "non-DM membership must not be touched by mark_direct_messages_as_read"
   end
 
@@ -864,7 +868,8 @@ class UserTest < ActiveSupport::TestCase
     user = users(:david)
     user.update_column(:activity_seen_at, 1.day.ago)
     non_dm = memberships(:david_designers)
-    non_dm.update_column(:unread_at, 30.minutes.ago)
+    unseen = travel_to(1.minute.ago) { non_dm.room.messages.create!(creator: users(:jason), body: "hi", client_message_id: "inbox_mark_read") }
+    rewind_unread_to non_dm, unseen
 
     now_iso = Time.current.iso8601
     user.mark_inbox_as_read(
@@ -873,7 +878,7 @@ class UserTest < ActiveSupport::TestCase
       activity_loaded_at: now_iso
     )
 
-    assert_nil non_dm.reload.unread_at, "non-direct unread membership must be marked read"
+    assert non_dm.reload.read?, "non-direct unread membership must be marked read"
     assert user.reload.activity_seen_at > 1.minute.ago,
       "activity_seen_at must advance to the activity_loaded_at"
   end
@@ -881,24 +886,27 @@ class UserTest < ActiveSupport::TestCase
   test "mark_inbox_as_read falls back to Time.current when a loaded_at timestamp is stale (> 1 hour old)" do
     user = users(:david)
     membership = memberships(:david_designers)
-    membership.update_column(:unread_at, 5.minutes.ago)
+    unseen = membership.room.messages.create!(creator: users(:jason), body: "hi", client_message_id: "inbox_stale_read")
+    rewind_unread_to membership, unseen
 
-    # A 2-hour-old stamp would leave unread_at untouched (5.minutes.ago > 2.hours.ago).
-    # The freshness check rewrites it to Time.current, so the membership ends up read.
+    # A 2-hour-old stamp would leave the fresh message unread (it's newer than
+    # the stamp). The freshness check rewrites it to Time.current, so the
+    # membership ends up read.
     user.mark_inbox_as_read(
       messages_loaded_at: 2.hours.ago.iso8601,
       notifications_loaded_at: 2.hours.ago.iso8601,
       activity_loaded_at: 2.hours.ago.iso8601
     )
 
-    assert_nil membership.reload.unread_at,
+    assert membership.reload.read?,
       "stale loaded_at must be clamped to Time.current so unread is marked read"
   end
 
   test "mark_inbox_as_read falls back to Time.current when loaded_at is blank" do
     user = users(:david)
     membership = memberships(:david_designers)
-    membership.update_column(:unread_at, 30.minutes.ago)
+    unseen = membership.room.messages.create!(creator: users(:jason), body: "hi", client_message_id: "inbox_blank_read")
+    rewind_unread_to membership, unseen
 
     user.mark_inbox_as_read(
       messages_loaded_at: nil,
@@ -906,7 +914,7 @@ class UserTest < ActiveSupport::TestCase
       activity_loaded_at: nil
     )
 
-    assert_nil membership.reload.unread_at,
+    assert membership.reload.read?,
       "blank loaded_at must be clamped to Time.current so unread is marked read"
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,7 @@ require_relative "test_helpers/dns_test_helper"
 require_relative "test_helpers/bot_api_test_helper"
 require_relative "test_helpers/web_push_pool_reset"
 require_relative "test_helpers/forum_test_helper"
+require_relative "test_helpers/unread_test_helper"
 
 WebMock.enable!
 
@@ -32,7 +33,7 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  include SessionTestHelper, MentionTestHelper, TurboTestHelper, DnsTestHelper, BotApiTestHelper, ForumTestHelper
+  include SessionTestHelper, MentionTestHelper, TurboTestHelper, DnsTestHelper, BotApiTestHelper, ForumTestHelper, UnreadTestHelper
 
   setup do
     # Default to password auth in tests (sign_in helper uses password)

--- a/test/test_helpers/unread_test_helper.rb
+++ b/test/test_helpers/unread_test_helper.rb
@@ -1,0 +1,32 @@
+module UnreadTestHelper
+  # Rewinds a membership's read cursor so `message` and everything after it
+  # reads as unseen — the cursor equivalent of the legacy
+  # `unread_at: message.created_at` setup.
+  def rewind_unread_to(membership, message, marked: false)
+    previous = membership.room.messages
+                         .before_cursor(message.created_at, message.id)
+                         .reorder(created_at: :desc, id: :desc).first
+    membership.update_columns(
+      last_read_at: previous&.created_at || Time.at(0),
+      last_read_message_id: previous&.id || 0,
+      marked_unread: marked
+    )
+  end
+
+  # Rewinds to the beginning of time: every active message reads as unseen —
+  # the cursor equivalent of the legacy `unread_at: 1.day.ago` setup.
+  def force_all_unread(membership)
+    membership.update_columns(last_read_at: Time.at(0), last_read_message_id: 0, marked_unread: false)
+  end
+
+  # Advances the cursor to the room's head: nothing reads as unseen — the
+  # cursor equivalent of the legacy `unread_at: nil` setup.
+  def catch_up(membership)
+    head = membership.room.messages.reorder(:created_at, :id).last
+    membership.update_columns(
+      last_read_at: head&.created_at || Time.current,
+      last_read_message_id: head&.id || 0,
+      marked_unread: false
+    )
+  end
+end


### PR DESCRIPTION
Sending a message used to cost O(members): every disconnected member's row got an unread stamp, and every one of them got a personal ActionCable publish. In a 5,000-member room that's ~5,000 row writes and ~5,000 publishes inside the send path — the biggest write and broadcast amplification in the app. Forum posts had the same shape against community-wide membership.

This PR makes unread a derived property and drops the send path to one row write and one publish, regardless of room size.

## How it works

**Unread is derived, not written.** Each membership stores a read cursor — `(last_read_at, last_read_message_id)`, the position of the last message its member has seen. A room is unread when an active message sits strictly after the cursor (riding the existing `(room_id, active, created_at)` index). Sending writes nothing to member rows; the message row itself is the unread state. Soft-deleting a message self-heals — the comparison only sees active messages.

**The cursor advances at view time:** membership creation, presenting in the room, presence refresh, and full disconnect (messages watched live count as seen). Senders advance past their own message only when they were already caught up, preserving the DM badge semantics. A `marked_unread` flag covers the one state a cursor can't express: an explicit mark-as-unread, which must survive connection churn.

**One shared nudge replaces the per-member push.** The send path now publishes a single account-scoped "room touched" payload (`roomId`, `roomSize`, `roomUpdatedAt`, `creatorId`) on the existing room-list stream. Each client derives its own state: the member viewing the room ignores it, the creator's own clients skip the dot, non-members have no matching sidebar row, everyone else dots and re-sorts locally. Works identically on plain ActionCable and AnyCable. In SaaS the stream identity is the account's GlobalID, which carries the tenant — nudges cannot cross workspaces (asserted in the SaaS suite).

**Forums get full parity.** A forum owns no messages, so its dot derives from posts created after the cursor, through the same partial index on sub-rooms. Posting advances the author's cursor and emits the same single nudge — the per-member flag writes and per-member dot pushes are gone, and deleting a post now heals the dot automatically.

**Mention badges keep their counter,** re-anchored on one shared eligibility scope (cursor behind the message and not watching live) across increment, reactivation, and both decrement paths.

## Cutover

The migration adds the cursor columns and resets every member to caught-up (room head, or now for empty rooms/forums). Legacy unread dots are deliberately not carried over — everyone starts clean and the next message dots them. The old `unread_at` column is still written by nothing but kept for the deploy overlap; dropping it and its two indexes is a follow-up release.

The per-user unread channel has exactly one producer left (explicit mark-as-unread); retiring it entirely is planned alongside the move to signed streams.

## Verification

- Characterization tests pinned the observable unread behavior before the rewrite; the suite asserts a 20-message burst leaves non-sender membership rows byte-identical while the derived count reads correctly, and that sends/posts issue exactly one shared publish and zero per-user broadcasts.
- Both suites green: 1678 self-hosted, 291 SaaS.
- Log-verified in development: a send shows one membership `UPDATE` (the sender's cursor) and one `room_list` publish where a ~330-member room previously showed 326 per-user publishes; forum posts show the author's two cursor writes, one nudge, and no flag fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)