### PR TITLE
Track live room presence via an AnyCable presence set

### DIFF
--- a/app/channels/presence_channel.rb
+++ b/app/channels/presence_channel.rb
@@ -1,4 +1,6 @@
 class PresenceChannel < RoomChannel
+  include AnyCable::Rails::Channel::Presence
+
   on_subscribe   :present, unless: :subscription_rejected?
   on_unsubscribe :absent,  unless: :subscription_rejected?
 
@@ -8,12 +10,14 @@ class PresenceChannel < RoomChannel
       return unless m
 
       m.present
+      join_presence room_presence_stream
       ReadRoomsChannel.broadcast_to(current_user, { room_id: m.room_id })
     end
   end
 
   def absent
     with_tenant_context do
+      leave_presence
       membership&.disconnected
     end
   end
@@ -29,5 +33,18 @@ class PresenceChannel < RoomChannel
       with_tenant_context do
         room&.memberships&.find_by(user: current_user)
       end
+    end
+
+    # The room's own stream, already tenant-scoped by the Room GID. Passed
+    # explicitly so a standalone `present` action (a re-focused tab, no fresh
+    # `stream_for`) still joins the right presence set.
+    def room_presence_stream
+      self.class.broadcasting_for(room)
+    end
+
+    # Key presence by the user, so a member's multiple tabs dedupe to one entry
+    # and a consumer reads a plain user id rather than a connection GID.
+    def user_presence_id
+      current_user.id
     end
 end

--- a/docs/plans/2026-07-08-001-perf-realtime-delivery-at-scale-plan.md
+++ b/docs/plans/2026-07-08-001-perf-realtime-delivery-at-scale-plan.md
@@ -457,7 +457,7 @@ Status per PR. Update the table and dated log as units land; requirements and un
 | PR 1b · R0 cutover | U11 | Not started | — |
 | PR 2 · R1 derived unread | U2, U3, U4 | **Complete, in review** | [#139](https://github.com/sabha-co/sabha/pull/139) (`realtime-delivery-at-scale`) |
 | PR 3 · R2 signed-stream sidebar | U5 | **Complete, in review** | [#140](https://github.com/sabha-co/sabha/pull/140) (`signed-stream-sidebar`, stacked on #139) |
-| PR 4 · R3 AnyCable presence | U6 | Implemented on branch | `anycable-presence` (stacked on #140) |
+| PR 4 · R3 AnyCable presence | U6 | **In review** | [#141](https://github.com/sabha-co/sabha/pull/141) (`anycable-presence`, stacked on #140) |
 | PR 5 · R4 @everyone guardrail | U7, U8 | Not started | — |
 | PR 6 · R5 defer residual | U9 | Not started | — |
 | PR 7 · R6 JWT | U10 | Not started | — |

--- a/docs/plans/2026-07-08-001-perf-realtime-delivery-at-scale-plan.md
+++ b/docs/plans/2026-07-08-001-perf-realtime-delivery-at-scale-plan.md
@@ -457,7 +457,7 @@ Status per PR. Update the table and dated log as units land; requirements and un
 | PR 1b · R0 cutover | U11 | Not started | — |
 | PR 2 · R1 derived unread | U2, U3, U4 | **Complete, in review** | [#139](https://github.com/sabha-co/sabha/pull/139) (`realtime-delivery-at-scale`) |
 | PR 3 · R2 signed-stream sidebar | U5 | **Complete, in review** | [#140](https://github.com/sabha-co/sabha/pull/140) (`signed-stream-sidebar`, stacked on #139) |
-| PR 4 · R3 AnyCable presence | U6 | Not started | — |
+| PR 4 · R3 AnyCable presence | U6 | Implemented on branch | `anycable-presence` (stacked on #140) |
 | PR 5 · R4 @everyone guardrail | U7, U8 | Not started | — |
 | PR 6 · R5 defer residual | U9 | Not started | — |
 | PR 7 · R6 JWT | U10 | Not started | — |
@@ -471,6 +471,7 @@ Status per PR. Update the table and dated log as units land; requirements and un
 - **2026-07-10** — U5 started on `signed-stream-sidebar` (branched off PR 2's branch; ships only after U11 per the dependency note).
 - **2026-07-10** — Decision: R0 is treated as merged for sequencing — PR 3 no longer waits on the U11 cutover landing first (production already defaults to AnyCable; the in-process `$pubsub` fallback keeps a dev holdout working meanwhile).
 - **2026-07-10** — U5 landed on `signed-stream-sidebar` (`667eee5`), opened as [#140](https://github.com/sabha-co/sabha/pull/140) stacked on #139. Log-verified against anycable-go: one shared publish per send/rename, mark-as-unread on the member's ReadRoomsChannel, zero `$pubsub` subscribe RPCs reaching Rails.
+- **2026-07-10** — U6 implemented on `anycable-presence` (stacked on `signed-stream-sidebar`): `PresenceChannel` now `include`s `AnyCable::Rails::Channel::Presence` and joins/leaves the room's own stream (`broadcasting_for(room)`, tenant-scoped by the Room GID) on present/absent. Additive per KTD4 — the `connected_at` last-seen lifecycle (`present`/50s `refresh`/`disconnected`) and all push (`connected?`, 60s), email (`workspace_locally_away?`, 1h), and activity-tier gating read the persisted column unchanged; presence adds only the ephemeral Go-side live set. No JS change (the existing controller already drives present/absent/unsubscribe); a live "who's here" consumer stays on the native track. Degrades gracefully on a dev in-process fallback (`join_presence` no-ops when not `anycabled?`). Both suites green.
 - **2026-07-10** — U5 implemented: the sidebar's shared stream is now a signed `$pubsub` stream (`Account#room_list_stream_name`, GID-scoped per tenant) carrying both nudge and rename payloads; `RoomListChannel` and `UserUnreadRoomsChannel` deleted. Mark-as-unread — the per-user channel's last producer — moved onto `ReadRoomsChannel` (`unread: true` + sort keys), so read-state rides one per-user channel in both directions. Sidebar subscriptions drop 4 → 3, and the shared one no longer costs a Rails subscribe RPC under anycable-go (dev pre-cutover falls back to the gem's in-process `$pubsub` handler). Both suites green.
 
 ### Carried follow-ups

--- a/saas/test/channels/presence_channel_test.rb
+++ b/saas/test/channels/presence_channel_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class SaasPresenceChannelTest < ActionCable::Channel::TestCase
+  tests PresenceChannel
+
+  setup do
+    @workspace = Workspace.create_with_database!(
+      name: "Presence Test",
+      creator: global_identities(:alice)
+    )
+    @membership = global_identities(:alice).workspace_memberships.find_by(tenant: @workspace.external_id.to_s)
+    @user = @membership.user
+
+    ApplicationRecord.with_tenant(@workspace.external_id.to_s) do
+      @room = Rooms::Open.find_by(name: "General")
+      @room.memberships.grant_to(@user)
+    end
+
+    stub_connection(
+      current_user: @user,
+      current_tenant: @workspace.external_id.to_s
+    )
+  end
+
+  teardown do
+    @workspace&.destroy_with_database! if @workspace && Workspace.exists?(id: @workspace.id)
+  end
+
+  test "the presence stream is scoped to the tenant so sets can't collide across workspaces" do
+    ApplicationRecord.with_tenant(@workspace.external_id.to_s) do
+      stream = PresenceChannel.broadcasting_for(@room)
+      gid = GlobalID.parse(stream.delete_prefix("presence:"))
+
+      assert_equal @workspace.external_id.to_s, gid.tenant
+    end
+  end
+
+  test "presenting joins the tenant-scoped presence stream" do
+    ApplicationRecord.with_tenant(@workspace.external_id.to_s) do
+      subscribe room_id: @room.id
+
+      subscription.expects(:join_presence).with(PresenceChannel.broadcasting_for(@room))
+      subscription.present
+    end
+  end
+end

--- a/test/channels/presence_channel_test.rb
+++ b/test/channels/presence_channel_test.rb
@@ -43,6 +43,36 @@ class PresenceChannelTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "presenting joins the room's own presence stream" do
+    membership = users(:david).memberships.first
+    subscribe room_id: membership.room_id
+
+    subscription.expects(:join_presence).with(PresenceChannel.broadcasting_for(membership.room))
+    subscription.present
+  end
+
+  test "going absent leaves the presence set" do
+    membership = users(:david).memberships.first
+    subscribe room_id: membership.room_id
+
+    subscription.expects(:leave_presence)
+    subscription.absent
+  end
+
+  test "presence is keyed by the user id so a member's tabs dedupe to one entry" do
+    membership = users(:david).memberships.first
+    subscribe room_id: membership.room_id
+
+    assert_equal users(:david).id, subscription.send(:user_presence_id)
+  end
+
+  test "the presence stream matches the room's subscription stream" do
+    membership = users(:david).memberships.first
+    subscribe room_id: membership.room_id
+
+    assert_has_stream PresenceChannel.broadcasting_for(membership.room)
+  end
+
   test "absent handles nil @room gracefully (AnyCable HTTP RPC scenario)" do
     # In AnyCable HTTP RPC mode, @room isn't preserved between calls.
     # Simulate this by creating a fresh channel instance and calling absent directly.


### PR DESCRIPTION
Makes "who is present in a room" a real-time fact tracked by anycable-go instead of something only inferable from a per-message database read. The room's presence channel now joins an [AnyCable presence set](https://docs.anycable.io/rails/extensions) when a member becomes present and leaves it when they go absent, so the live set of viewers is maintained in Go and fanned out without touching the SQLite writer.

This is deliberately additive. The persisted `connected_at` last-seen and everything that reads it — push gating (`connected?`, 60s), email gating (`workspace_locally_away?`, 1h), and the activity-status tiers — are untouched and keep reading the database column. Presence adds only the ephemeral live driver; it does not replace the persisted model.

### How it works

- `PresenceChannel` includes `AnyCable::Rails::Channel::Presence` and calls `join_presence` on present, `leave_presence` on absent — mirroring the existing connection lifecycle.
- The presence set is keyed to the room's **own stream** (`broadcasting_for(room)`), which is the exact pattern the AnyCable docs recommend. Because a tenanted model's GlobalID embeds `?tenant=`, the stream name is tenant-scoped for free: workspace A's room 1 and workspace B's room 1 resolve to different presence sets, so presence can't leak across workspaces.
- Presence is keyed by `user_presence_id → current_user.id`, so a member's multiple tabs dedupe to one entry and any consumer reads a plain user id rather than an opaque connection GID.
- No JavaScript change: the existing controller already drives present/absent/unsubscribe, so the set populates server-side. A live "who's here" UI that *consumes* the set is separate, future work.

### Verified against the AnyCable docs

- Presence is an **OSS** feature — no Pro dependency.
- Server-side `join_presence` registers presence independently of any client-side `join` command.
- It behaves identically under HTTP RPC mode.
- Auto-leave on unsubscribe/disconnect happens Go-side "with some configurable delay" — no anycable-go config change required to enable presence.
- Degrades safely on a dev in-process fallback: `join_presence`/`leave_presence` no-op when the connection isn't AnyCable-backed, so nothing breaks and the old `connected_at`-based status still works.

### Tests

- Self-hosted: presenting joins the room's stream, going absent leaves, presence is keyed by user id, and the presence stream matches the room's subscription stream.
- SaaS: the presence stream carries the tenant (decoded GID `?tenant=`) so sets can't collide across workspaces.

Both suites green.
