### PR TITLE
Scope room administration by type and authorize room message streams

### DIFF
--- a/app/channels/concerns/room_streams_are_authorized.rb
+++ b/app/channels/concerns/room_streams_are_authorized.rb
@@ -1,0 +1,15 @@
+# Prepended onto Turbo::StreamsChannel. The subscriber names the channel it wants
+# in the subscribe frame, so authorizing room streams only in RoomStreamsChannel
+# would leave the stock channel as the way around it: same signed stream name, no
+# access check. Turn those names away here and RoomStreamsChannel becomes the
+# only door. Every other stream — the sidebar, the inbox, a membership — is
+# already bound to the user or the account and passes straight through.
+module RoomStreamsAreAuthorized
+  def subscribed
+    if RoomStreamsChannel.guarded_stream?(verified_stream_name_from_params)
+      reject
+    else
+      super
+    end
+  end
+end

--- a/app/channels/room_streams_channel.rb
+++ b/app/channels/room_streams_channel.rb
@@ -1,0 +1,94 @@
+# Authorizes the Turbo streams that carry a room's contents, at the moment the
+# subscription is made, so that losing access actually stops delivery.
+#
+# Turbo's stock channel verifies only the signature on the stream name. That name
+# carries no expiry and no binding to a user, so one harvested while a member
+# keeps working after the membership is gone — and it works just as well for
+# anyone who copies it, member or not. Reconnecting doesn't help: the client
+# replays its subscriptions onto the fresh socket.
+#
+# The room is derived from the verified stream name rather than taken as a
+# parameter, so there's nothing for a subscriber to point somewhere else. The
+# subscriber doesn't get to pick the channel either — Turbo::StreamsChannel turns
+# these names away, so this is the only door onto them. See
+# RoomStreamsAreAuthorized and config/initializers/turbo_streams_authorization.rb.
+class RoomStreamsChannel < ApplicationCable::Channel
+  extend  Turbo::Streams::StreamName
+  include Turbo::Streams::StreamName::ClassMethods
+
+  # The trailing segment of the stream names this channel guards: a room's
+  # message stream and a forum's gallery of posts.
+  GUARDED_SUFFIXES = %w[ messages posts ].freeze
+
+  # A stream name can point at a record that's since been deleted or — in SaaS —
+  # one minted in another workspace, which the tenanted locator refuses outright
+  # rather than returning nil. Nothing resolves either way, and both end in the
+  # same plain reject. Named rather than listed inline because the tenanted error
+  # class doesn't exist in self-hosted mode.
+  LOOKUP_FAILURES = [
+    ActiveRecord::RecordNotFound,
+    "ActiveRecord::Tenanted::Error".safe_constantize
+  ].compact.freeze
+
+  class << self
+    # True for the stream names this channel exists to guard, whoever is asking.
+    # Deliberately free of database work — Turbo::StreamsChannel consults this on
+    # every subscribe, guarded or not.
+    def guarded_stream?(stream_name)
+      GUARDED_SUFFIXES.include? segments(stream_name).last
+    end
+
+    # Stream names are the streamables' GlobalID params joined with ":". A GID
+    # param is base64, which has no colons of its own, so the segments split back
+    # out cleanly.
+    def segments(stream_name)
+      stream_name.to_s.split(":")
+    end
+  end
+
+  def subscribed
+    if stream_name = authorized_stream_name
+      stream_from stream_name
+    else
+      reject
+    end
+  end
+
+  private
+    def authorized_stream_name
+      stream_name = verified_stream_name_from_params
+      stream_name if stream_name.present? && authorized?(stream_name)
+    end
+
+    # Two shapes reach here: "<room>:messages" and "<room>:posts", which every
+    # member of the room shares, and "<user>:<room>:messages", which carries one
+    # person's own state (their bookmark marks) and so belongs to them alone.
+    def authorized?(stream_name)
+      return false unless self.class.guarded_stream?(stream_name)
+
+      segments = self.class.segments(stream_name)
+
+      with_tenant_context do
+        reachable_room?(segments[-2]) && (segments.size < 3 || own_gid_param?(segments[-3]))
+      end
+    end
+
+    def reachable_room?(gid_param)
+      room = locate(gid_param, Room)
+      # A sub-room (forum post or chat thread) derives access from its parent, so
+      # a forum member reaches a post's stream without a row of their own, and a
+      # stale row stops granting it once they lose the parent. Same rule
+      # RoomChannel applies to typing and presence.
+      room.present? && current_user&.reachable_room(room.id).present?
+    end
+
+    def own_gid_param?(gid_param)
+      current_user.present? && locate(gid_param, User) == current_user
+    end
+
+    def locate(gid_param, klass)
+      GlobalID::Locator.locate gid_param, only: klass
+    rescue *LOOKUP_FAILURES
+      nil
+    end
+end

--- a/app/channels/room_streams_channel.rb
+++ b/app/channels/room_streams_channel.rb
@@ -16,10 +16,6 @@ class RoomStreamsChannel < ApplicationCable::Channel
   extend  Turbo::Streams::StreamName
   include Turbo::Streams::StreamName::ClassMethods
 
-  # The trailing segment of the stream names this channel guards: a room's
-  # message stream and a forum's gallery of posts.
-  GUARDED_SUFFIXES = %w[ messages posts ].freeze
-
   # A stream name can point at a record that's since been deleted or — in SaaS —
   # one minted in another workspace, which the tenanted locator refuses outright
   # rather than returning nil. Nothing resolves either way, and both end in the
@@ -31,11 +27,20 @@ class RoomStreamsChannel < ApplicationCable::Channel
   ].compact.freeze
 
   class << self
-    # True for the stream names this channel exists to guard, whoever is asking.
-    # Deliberately free of database work — Turbo::StreamsChannel consults this on
-    # every subscribe, guarded or not.
+    # True for the stream names this channel exists to guard, whoever is asking:
+    # the ones a room's contents ride on. Every one of them trails a plain suffix
+    # after the room — [ room, :messages ] and [ user, room, :messages ] alike —
+    # so the room sits second from the end. Asking the name which model it names
+    # beats matching a list of suffixes: a stream added later, [ room, :updates ],
+    # is guarded the day it appears rather than waiting on someone to remember.
+    #
+    # Deliberately free of database work: Turbo::StreamsChannel consults this on
+    # every subscribe, guarded or not, and a GlobalID names its class outright.
     def guarded_stream?(stream_name)
-      GUARDED_SUFFIXES.include? segments(stream_name).last
+      gid = GlobalID.parse(segments(stream_name)[-2])
+      gid.present? && gid.model_class <= Room
+    rescue NameError
+      false
     end
 
     # Stream names are the streamables' GlobalID params joined with ":". A GID
@@ -60,9 +65,10 @@ class RoomStreamsChannel < ApplicationCable::Channel
       stream_name if stream_name.present? && authorized?(stream_name)
     end
 
-    # Two shapes reach here: "<room>:messages" and "<room>:posts", which every
-    # member of the room shares, and "<user>:<room>:messages", which carries one
-    # person's own state (their bookmark marks) and so belongs to them alone.
+    # Streams shared by everyone in the room — "<room>:messages", "<room>:posts"
+    # — carry only the room check. A longer name leads with the user whose own
+    # state it carries (their bookmark marks), and that user has to be the one
+    # asking.
     def authorized?(stream_name)
       return false unless self.class.guarded_stream?(stream_name)
 

--- a/app/controllers/rooms/access_controller.rb
+++ b/app/controllers/rooms/access_controller.rb
@@ -2,6 +2,7 @@ class Rooms::AccessController < ApplicationController
   include RoomScoped
 
   before_action :ensure_can_administer
+  before_action :ensure_room_is_convertible
 
   def update
     room = @room.toggle_access!(open: open_access?)
@@ -14,5 +15,12 @@ class Rooms::AccessController < ApplicationController
   private
     def open_access?
       params[:open] == "1"
+    end
+
+    # Only open and closed rooms carry this toggle, and the members panel only
+    # draws it for them. Anything else arriving here — a direct room, a forum, a
+    # thread — is an attempt to republish it, not a switch someone was shown.
+    def ensure_room_is_convertible
+      head :forbidden unless @room.convertible?
     end
 end

--- a/app/controllers/rooms/closeds_controller.rb
+++ b/app/controllers/rooms/closeds_controller.rb
@@ -38,6 +38,13 @@ class Rooms::ClosedsController < RoomsController
   end
 
   private
+    # Open and closed rooms convert into each other, so both are in reach here.
+    # Nothing else is: a direct room converted to closed gets a membership list
+    # its creator then controls.
+    def serves?(room)
+      room.convertible?
+    end
+
     # Allows us to edit an open room and turn it into a closed one on saving.
     def force_room_type
       @room = @room.becomes!(Rooms::Closed)

--- a/app/controllers/rooms/directs_controller.rb
+++ b/app/controllers/rooms/directs_controller.rb
@@ -30,6 +30,10 @@ class Rooms::DirectsController < RoomsController
   end
 
   private
+    def serves?(room)
+      room.direct?
+    end
+
     def set_direct_room
       @room = Current.user.rooms.find_by(id: params[:id], type: Rooms::Direct.sti_name)
       redirect_to root_url, alert: "Conversation not found" unless @room

--- a/app/controllers/rooms/forums_controller.rb
+++ b/app/controllers/rooms/forums_controller.rb
@@ -39,6 +39,10 @@ class Rooms::ForumsController < RoomsController
   end
 
   private
+    def serves?(room)
+      room.forum?
+    end
+
     def forum_params
       params.require(:room).permit(:name, :description)
     end

--- a/app/controllers/rooms/opens_controller.rb
+++ b/app/controllers/rooms/opens_controller.rb
@@ -38,6 +38,13 @@ class Rooms::OpensController < RoomsController
   end
 
   private
+    # Open and closed rooms convert into each other, so both are in reach here.
+    # Nothing else is: promoting a direct room or a thread would republish its
+    # conversation to the whole account.
+    def serves?(room)
+      room.convertible?
+    end
+
     # Allows us to edit a closed room and turn it into an open one on saving.
     def force_room_type
       @room = @room.becomes!(Rooms::Open)

--- a/app/controllers/rooms/threads_controller.rb
+++ b/app/controllers/rooms/threads_controller.rb
@@ -38,6 +38,10 @@ class Rooms::ThreadsController < RoomsController
   end
 
   private
+  def serves?(room)
+    room.thread?
+  end
+
   def set_parent_message
     if message = Current.user.reachable_messages.joins(:room).where.not(room: { type: [ "Rooms::Direct", "Rooms::Thread", "Rooms::Forum", "Rooms::Post" ] }).find_by(id: params[:parent_message_id])
       @parent_message = message

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -47,11 +47,24 @@ class RoomsController < ApplicationController
       # stale row must not grant access after they leave the parent. So fall back
       # to parent-derived access, then re-check viewable_by? for any sub-room.
       room ||= viewable_sub_room(params[:room_id] || params[:id])
-      if room = deny_stale_sub_room(room)
+      room = deny_stale_sub_room(room)
+
+      if room && serves?(room)
         @room = room
       else
         redirect_to root_url, alert: "Room not found or inaccessible"
       end
+    end
+
+    # Whether this room is one the namespace is about. #show here serves all six
+    # types, so the base answers yes to everything; a subclass that edits,
+    # converts, or deletes rooms narrows it to its own. Without that narrowing
+    # one namespace reaches another's rooms — the /rooms/opens form loads a
+    # direct room or a thread and turns it into a room the account can browse.
+    # Asked after both lookups above, since either can surface a room this
+    # controller has no business touching.
+    def serves?(room)
+      true
     end
 
     def set_membership

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -7,6 +7,10 @@ class Room < ApplicationRecord
   # source for the type list; both the sub_rooms and without_threads scopes read it.
   SUB_ROOM_TYPES = %w[ Rooms::Thread Rooms::Post ].freeze
 
+  # The two types that convert into each other — the public/private toggle. Every
+  # other type is fixed for its whole life; see #convertible?.
+  CONVERTIBLE_TYPES = %w[ Rooms::Open Rooms::Closed ].freeze
+
   has_many :memberships, -> { active } do
     def grant_to(users)
       room = proxy_association.owner
@@ -57,6 +61,8 @@ class Room < ApplicationRecord
   before_destroy :destroy_all_associated_records
 
   before_validation :set_initial_last_active_at, on: :create
+
+  validate :type_changes_only_between_open_and_closed, on: :update
 
   scope :opens,           -> { where(type: "Rooms::Open") }
   scope :closeds,         -> { where(type: "Rooms::Closed") }
@@ -155,6 +161,12 @@ class Room < ApplicationRecord
 
   def sidebar_room?
     open? || closed? || forum?
+  end
+
+  # Whether this room has a public/private toggle. Only open and closed rooms do:
+  # they're the same room seen two ways, differing in how you get in.
+  def convertible?
+    CONVERTIBLE_TYPES.include?(type)
   end
 
   # Chat threads and forum posts are nested sub-rooms — they derive access from a
@@ -368,6 +380,19 @@ class Room < ApplicationRecord
   end
 
   private
+    # Open and closed rooms convert into each other freely — that's the
+    # public/private toggle. Nothing else moves: a direct room or a sub-room that
+    # turned into an open one would republish a private conversation to everyone
+    # in the account, and a forum that did would strand its posts. The rule lives
+    # here rather than only in the controllers that call becomes! so that every
+    # route to a type change has to get past it.
+    def type_changes_only_between_open_and_closed
+      return unless type_changed?
+      return if CONVERTIBLE_TYPES.include?(type_was) && CONVERTIBLE_TYPES.include?(type)
+
+      errors.add :type, "can't be changed once a room is created"
+    end
+
     # Only Open and Closed rooms spawn chat threads, so only they need the
     # follow-silencing sweep on leave. Forums run their own post-follow cleanup,
     # and directs/sub-rooms have no threads to silence.

--- a/app/views/rooms/forums/gallery.html.erb
+++ b/app/views/rooms/forums/gallery.html.erb
@@ -17,7 +17,7 @@
     renders cards, not a message stream, so it wires presence itself. %>
 <div class="forum" data-controller="presence" data-presence-room-id-value="<%= @room.id %>"
      data-action="visibilitychange@document->presence#visibilityChanged">
-  <%= turbo_stream_from @room, :posts %>
+  <%= turbo_stream_from @room, :posts, channel: "RoomStreamsChannel" %>
   <%# Involvement changes (the nav bell) broadcast to the membership stream —
       subscribe so the button cycles its state, like the chat and post pages. %>
   <%= turbo_stream_from @membership if @membership %>

--- a/app/views/rooms/layouts/_members_panel.html.erb
+++ b/app/views/rooms/layouts/_members_panel.html.erb
@@ -1,4 +1,4 @@
-<% if Current.user.can_administer?(room) && (room.open? || room.closed?) %>
+<% if Current.user.can_administer?(room) && room.convertible? %>
   <%= form_with url: room_access_path(room), method: :patch, data: { controller: "form" } do %>
     <%= hidden_field_tag :open, room.is_a?(Rooms::Open) ? "0" : "1" %>
     <div class="flex align-center gap pad-block">

--- a/app/views/rooms/posts/show.html.erb
+++ b/app/views/rooms/posts/show.html.erb
@@ -12,8 +12,8 @@
     <% end %>
 
     <%= turbo_stream_from @membership if @membership %>
-    <%= turbo_stream_from @post, :messages %>
-    <%= turbo_stream_from Current.user, @post, :messages %>
+    <%= turbo_stream_from @post, :messages, channel: "RoomStreamsChannel" %>
+    <%= turbo_stream_from Current.user, @post, :messages, channel: "RoomStreamsChannel" %>
     <%= button_to_jump_to_newest_message %>
   <% end %>
 

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -19,8 +19,8 @@
   <% end %>
 
   <%= turbo_stream_from @membership %>
-  <%= turbo_stream_from @room, :messages %>
-  <%= turbo_stream_from Current.user, @room, :messages %>
+  <%= turbo_stream_from @room, :messages, channel: "RoomStreamsChannel" %>
+  <%= turbo_stream_from Current.user, @room, :messages, channel: "RoomStreamsChannel" %>
   <%= button_to_jump_to_newest_message %>
 <% end %>
 

--- a/app/views/rooms/threads/show.html.erb
+++ b/app/views/rooms/threads/show.html.erb
@@ -33,8 +33,8 @@
     <% end %>
 
     <%= turbo_stream_from @membership if @membership %>
-    <%= turbo_stream_from @room, :messages %>
-    <%= turbo_stream_from Current.user, @room, :messages %>
+    <%= turbo_stream_from @room, :messages, channel: "RoomStreamsChannel" %>
+    <%= turbo_stream_from Current.user, @room, :messages, channel: "RoomStreamsChannel" %>
     <%= button_to_jump_to_newest_message %>
   <% end %>
 

--- a/config/initializers/turbo_streams_authorization.rb
+++ b/config/initializers/turbo_streams_authorization.rb
@@ -1,0 +1,3 @@
+Rails.application.config.to_prepare do
+  Turbo::StreamsChannel.prepend RoomStreamsAreAuthorized
+end

--- a/saas/test/channels/room_streams_channel_test.rb
+++ b/saas/test/channels/room_streams_channel_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+# The room is resolved from the stream name's GlobalID, and in SaaS that goes
+# through the tenanted locator — so the authorization has to hold up inside a
+# tenant, and a name minted in one workspace must not resolve in another.
+class SaasRoomStreamsChannelTest < ActionCable::Channel::TestCase
+  tests RoomStreamsChannel
+
+  setup do
+    @workspace = Workspace.create_with_database!(name: "Streams Test", creator: global_identities(:alice))
+    @membership = global_identities(:alice).workspace_memberships.find_by(tenant: @workspace.external_id.to_s)
+    @user = @membership.user
+
+    ApplicationRecord.with_tenant(tenant) do
+      @room = Rooms::Open.find_by(name: "General")
+      @room.memberships.grant_to(@user)
+      @signed_stream_name = Turbo::StreamsChannel.signed_stream_name([ @room, :messages ])
+    end
+  end
+
+  teardown do
+    @workspace&.destroy_with_database! if @workspace && Workspace.exists?(id: @workspace.id)
+  end
+
+  test "a member subscribes to their room's message stream" do
+    stub_connection current_user: @user, current_tenant: tenant
+
+    subscribe signed_stream_name: @signed_stream_name
+
+    assert subscription.confirmed?
+  end
+
+  test "a non-member in the same workspace is rejected" do
+    outsider = ApplicationRecord.with_tenant(tenant) do
+      secret = Rooms::Closed.create!(name: "Secret", creator: @user)
+      [ Turbo::StreamsChannel.signed_stream_name([ secret, :messages ]), secret ]
+    end
+
+    ApplicationRecord.with_tenant(tenant) { outsider.last.memberships.where(user: @user).delete_all }
+
+    stub_connection current_user: @user, current_tenant: tenant
+    subscribe signed_stream_name: outsider.first
+
+    assert subscription.rejected?
+  end
+
+  test "a stream name from another workspace does not resolve" do
+    other = Workspace.create_with_database!(name: "Other WS", creator: global_identities(:bob))
+    other_signed = ApplicationRecord.with_tenant(other.external_id.to_s) do
+      Turbo::StreamsChannel.signed_stream_name([ Rooms::Open.find_by(name: "General"), :messages ])
+    end
+
+    stub_connection current_user: @user, current_tenant: tenant
+    subscribe signed_stream_name: other_signed
+
+    assert subscription.rejected?
+  ensure
+    other&.destroy_with_database! if other && Workspace.exists?(id: other.id)
+  end
+
+  private
+    def tenant
+      @workspace.external_id.to_s
+    end
+end

--- a/test/channels/room_streams_channel_test.rb
+++ b/test/channels/room_streams_channel_test.rb
@@ -95,6 +95,21 @@ class RoomStreamsChannelTest < ActionCable::Channel::TestCase
     assert subscription.rejected?
   end
 
+  # What counts as a room stream is read off the name, not matched against a list
+  # of known suffixes, so a stream nobody has written yet is already covered.
+
+  test "a room stream with a suffix this channel has never seen is still guarded" do
+    signed = Turbo::StreamsChannel.signed_stream_name([ @room, :some_future_suffix ])
+
+    stub_connection current_user: users(:rachel)
+    subscribe signed_stream_name: signed
+    assert subscription.rejected?, "an outsider must not reach a new room stream either"
+
+    stub_connection current_user: users(:kevin)
+    subscribe signed_stream_name: signed
+    assert subscription.confirmed?
+  end
+
   # The three-segment stream carries one person's own state — their bookmark
   # marks — so sharing the room isn't enough.
 

--- a/test/channels/room_streams_channel_test.rb
+++ b/test/channels/room_streams_channel_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+
+# A room's message stream is authorized when the subscription is made, not just
+# when the stream name is signed — a signed name has no expiry and no owner, so
+# on its own it outlives the access that produced it.
+class RoomStreamsChannelTest < ActionCable::Channel::TestCase
+  tests RoomStreamsChannel
+
+  setup do
+    @room = rooms(:designers)
+    @signed_stream_name = Turbo::StreamsChannel.signed_stream_name([ @room, :messages ])
+  end
+
+  test "a member may subscribe to a room's message stream" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: @signed_stream_name
+
+    assert subscription.confirmed?
+    assert_has_stream Turbo.signed_stream_verifier.verified(@signed_stream_name)
+  end
+
+  test "someone who was never a member may not subscribe" do
+    stub_connection current_user: users(:rachel)
+
+    subscribe signed_stream_name: @signed_stream_name
+
+    assert subscription.rejected?
+  end
+
+  test "a revoked member may not resubscribe with a name harvested while a member" do
+    stub_connection current_user: users(:kevin)
+    subscribe signed_stream_name: @signed_stream_name
+    assert subscription.confirmed?, "kevin must start out able to subscribe"
+
+    @room.memberships.revoke_from [ users(:kevin) ]
+
+    stub_connection current_user: users(:kevin)
+    subscribe signed_stream_name: @signed_stream_name
+
+    assert subscription.rejected?
+  end
+
+  test "an unsigned stream name is rejected" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: Turbo::StreamsChannel.send(:stream_name_from, [ @room, :messages ])
+
+    assert subscription.rejected?
+  end
+
+  test "a tampered stream name is rejected" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: @signed_stream_name + "0"
+
+    assert subscription.rejected?
+  end
+
+  # Sub-rooms derive access from their parent, so the check has to follow the
+  # same rule the controllers do rather than demand a membership row.
+
+  test "a forum member may subscribe to a post they've never followed" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to users(:kevin)
+    post = Current.set(user: users(:jz)) { forum.post!(title: "Hello", body: "World") }
+
+    stub_connection current_user: users(:kevin)
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name([ post, :messages ])
+
+    assert subscription.confirmed?
+  end
+
+  test "an outsider may not subscribe to a post's message stream" do
+    forum = rooms(:help_desk)
+    post = Current.set(user: users(:jz)) { forum.post!(title: "Hello", body: "World") }
+
+    stub_connection current_user: users(:rachel)
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name([ post, :messages ])
+
+    assert subscription.rejected?
+  end
+
+  test "a forum member may subscribe to the gallery's post stream, an outsider may not" do
+    forum = rooms(:help_desk)
+    forum.memberships.grant_to users(:kevin)
+    signed = Turbo::StreamsChannel.signed_stream_name([ forum, :posts ])
+
+    stub_connection current_user: users(:kevin)
+    subscribe signed_stream_name: signed
+    assert subscription.confirmed?
+
+    stub_connection current_user: users(:rachel)
+    subscribe signed_stream_name: signed
+    assert subscription.rejected?
+  end
+
+  # The three-segment stream carries one person's own state — their bookmark
+  # marks — so sharing the room isn't enough.
+
+  test "a user-scoped room stream belongs to its owner alone" do
+    signed = Turbo::StreamsChannel.signed_stream_name([ users(:kevin), @room, :messages ])
+
+    stub_connection current_user: users(:kevin)
+    subscribe signed_stream_name: signed
+    assert subscription.confirmed?
+
+    stub_connection current_user: users(:jz)
+    subscribe signed_stream_name: signed
+    assert subscription.rejected?, "jz shares the room but not kevin's bookmark state"
+  end
+end

--- a/test/channels/turbo_streams_channel_authorization_test.rb
+++ b/test/channels/turbo_streams_channel_authorization_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+# Naming RoomStreamsChannel in the view only changes what honest clients do — the
+# subscriber picks the channel in its subscribe frame. So the stock channel has to
+# turn room stream names away itself, or the authorization there is decorative.
+class TurboStreamsChannelAuthorizationTest < ActionCable::Channel::TestCase
+  tests Turbo::StreamsChannel
+
+  test "a room's message stream can't be reached through the stock channel" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name([ rooms(:designers), :messages ])
+
+    assert subscription.rejected?, "even a member has to come through RoomStreamsChannel"
+  end
+
+  test "a forum's post stream can't be reached through the stock channel" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name([ rooms(:help_desk), :posts ])
+
+    assert subscription.rejected?
+  end
+
+  test "the sidebar's room stream still works on the stock channel" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name([ users(:kevin), :rooms ])
+
+    assert subscription.confirmed?
+  end
+
+  test "a membership stream still works on the stock channel" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name(memberships(:kevin_designers))
+
+    assert subscription.confirmed?
+  end
+end

--- a/test/channels/turbo_streams_channel_authorization_test.rb
+++ b/test/channels/turbo_streams_channel_authorization_test.rb
@@ -37,4 +37,12 @@ class TurboStreamsChannelAuthorizationTest < ActionCable::Channel::TestCase
 
     assert subscription.confirmed?
   end
+
+  test "the account-wide room stream still works on the stock channel" do
+    stub_connection current_user: users(:kevin)
+
+    subscribe signed_stream_name: Turbo::StreamsChannel.signed_stream_name([ accounts(:signal), :rooms ])
+
+    assert subscription.confirmed?
+  end
 end

--- a/test/controllers/rooms/access_controller_test.rb
+++ b/test/controllers/rooms/access_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Rooms::AccessControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in :david
+  end
+
+  test "opening a closed room converts it in place" do
+    patch room_access_url(rooms(:designers)), params: { open: "1" }
+
+    assert_redirected_to edit_rooms_open_url(rooms(:designers))
+    assert_equal "Rooms::Open", Room.find(rooms(:designers).id).type
+  end
+
+  test "closing an open room converts it in place" do
+    patch room_access_url(rooms(:pets)), params: { open: "0" }
+
+    assert_redirected_to edit_rooms_closed_url(rooms(:pets))
+    assert_equal "Rooms::Closed", Room.find(rooms(:pets).id).type
+  end
+
+  test "a direct room has no access toggle to flip" do
+    patch room_access_url(rooms(:david_and_kevin)), params: { open: "1" }
+
+    assert_response :forbidden
+    assert_equal "Rooms::Direct", Room.find(rooms(:david_and_kevin).id).type
+  end
+
+  test "a forum has no access toggle to flip" do
+    rooms(:help_desk).memberships.grant_to(users(:david))
+
+    patch room_access_url(rooms(:help_desk)), params: { open: "1" }
+
+    assert_response :forbidden
+    assert_equal "Rooms::Forum", Room.find(rooms(:help_desk).id).type
+  end
+
+  test "a chat thread has no access toggle to flip" do
+    sign_in :kevin
+    message = rooms(:designers).messages.create!(creator: users(:kevin), body: "private")
+    thread = Rooms::Thread.find_or_create_for(message, creator: users(:kevin))
+
+    patch room_access_url(thread), params: { open: "1" }
+
+    assert_response :forbidden
+    assert_equal "Rooms::Thread", Room.find(thread.id).type
+    assert_not Room.browsable_by(users(:rachel)).exists?(id: thread.id)
+  end
+
+  test "a non-member can't reach the toggle" do
+    sign_in :rachel
+
+    assert_raises ActiveRecord::RecordNotFound do
+      patch room_access_url(rooms(:designers)), params: { open: "1" }
+    end
+
+    assert_equal "Rooms::Closed", Room.find(rooms(:designers).id).type
+  end
+end

--- a/test/controllers/rooms/closeds_controller_test.rb
+++ b/test/controllers/rooms/closeds_controller_test.rb
@@ -151,4 +151,25 @@ class Rooms::ClosedsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to room_url(room)
     assert_equal "Kevin's Updated Room", room.reload.name
   end
+
+  test "a direct room can't be converted into a closed room" do
+    sign_in :kevin
+    direct = Rooms::Direct.create_for({ creator: users(:kevin) }, users: [ users(:kevin), users(:jz) ])
+
+    put rooms_closed_url(direct), params: { room: { name: "Seized" } }
+
+    assert_redirected_to root_url
+    assert_equal "Rooms::Direct", Room.find(direct.id).type
+  end
+
+  test "a chat thread can't be converted into a closed room" do
+    sign_in :kevin
+    message = rooms(:designers).messages.create!(creator: users(:kevin), body: "private")
+    thread = Rooms::Thread.find_or_create_for(message, creator: users(:kevin))
+
+    put rooms_closed_url(thread), params: { room: { name: "Seized" } }
+
+    assert_redirected_to root_url
+    assert_equal "Rooms::Thread", Room.find(thread.id).type
+  end
 end

--- a/test/controllers/rooms/opens_controller_test.rb
+++ b/test/controllers/rooms/opens_controller_test.rb
@@ -195,4 +195,45 @@ class Rooms::OpensControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to room_url(room)
     assert_equal "Kevin's Updated Room", room.reload.name
   end
+
+  # Only open and closed rooms are in reach here. Every case below is a room its
+  # creator administers, so the permission check passes and the room type is the
+  # only thing standing between a private conversation and the whole account.
+
+  test "a direct room can't be promoted to an open room by a participant" do
+    sign_in :kevin
+    direct = Rooms::Direct.create_for({ creator: users(:kevin) }, users: [ users(:kevin), users(:jz) ])
+
+    put rooms_open_url(direct), params: { room: { name: "Leaked" } }
+
+    assert_redirected_to root_url
+    assert_equal "Rooms::Direct", Room.find(direct.id).type
+    assert_not Room.browsable_by(users(:rachel)).exists?(id: direct.id)
+  end
+
+  test "a direct room can't be promoted to an open room by an administrator" do
+    put rooms_open_url(rooms(:david_and_kevin)), params: { room: { name: "Leaked" } }
+
+    assert_redirected_to root_url
+    assert_equal "Rooms::Direct", Room.find(rooms(:david_and_kevin).id).type
+  end
+
+  test "a chat thread can't be promoted out of its closed room into an open one" do
+    sign_in :kevin
+    message = rooms(:designers).messages.create!(creator: users(:kevin), body: "private")
+    thread = Rooms::Thread.find_or_create_for(message, creator: users(:kevin))
+
+    put rooms_open_url(thread), params: { room: { name: "Leaked" } }
+
+    assert_redirected_to root_url
+    assert_equal "Rooms::Thread", Room.find(thread.id).type
+    assert_not Room.browsable_by(users(:rachel)).exists?(id: thread.id)
+  end
+
+  test "a forum can't be converted into an open room" do
+    put rooms_open_url(rooms(:help_desk)), params: { room: { name: "Leaked" } }
+
+    assert_redirected_to root_url
+    assert_equal "Rooms::Forum", Room.find(rooms(:help_desk).id).type
+  end
 end

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -365,6 +365,40 @@ class RoomTest < ActiveSupport::TestCase
     assert_equal room.object_id, result.object_id
   end
 
+  # The type invariant behind the access toggle. Controllers scope their lookups
+  # too, but the rule lives on the record so no route around them can widen a
+  # private conversation's audience.
+
+  test "a direct room can't change its type" do
+    direct = rooms(:david_and_kevin)
+
+    assert_not direct.becomes!(Rooms::Open).save
+    assert_equal "Rooms::Direct", Room.find(direct.id).type
+  end
+
+  test "a chat thread can't change its type" do
+    parent = rooms(:designers).messages.create!(creator: users(:kevin), body: "private")
+    thread = Rooms::Thread.create!(parent_message: parent, creator: users(:kevin))
+
+    assert_not thread.becomes!(Rooms::Open).save
+    assert_equal "Rooms::Thread", Room.find(thread.id).type
+  end
+
+  test "a forum can't change its type" do
+    forum = rooms(:help_desk)
+
+    assert_not forum.becomes!(Rooms::Closed).save
+    assert_equal "Rooms::Forum", Room.find(forum.id).type
+  end
+
+  test "open and closed rooms still convert into each other" do
+    assert rooms(:pets).becomes!(Rooms::Closed).save
+    assert_equal "Rooms::Closed", Room.find(rooms(:pets).id).type
+
+    assert rooms(:designers).becomes!(Rooms::Open).save
+    assert_equal "Rooms::Open", Room.find(rooms(:designers).id).type
+  end
+
   test "post_welcome_message creates a welcome message" do
     room = rooms(:hq)
     user = users(:kevin)


### PR DESCRIPTION
Two authorization gaps in room access, each covered by tests that fail without the fix.

Both were found by checking Sabha against https://github.com/basecamp/once-campfire/pull/232, which fixes the same two classes of issue upstream. Neither fix ports across directly: the scoping gap is wider here because Sabha has six room types rather than three, and two of them derive access from a parent instead of a membership row. That PR's third finding — activity announced on one global unread-rooms stream — has a different shape in Sabha and is not addressed here.

### Room administration was resolved without regard to room type

`RoomsController#set_room` resolved any room the user could reach, and the namespaced controllers inherited it unchanged. Since `can_administer?` grants on `administrator? || creator`, anyone who created a room — including their own direct room, or a thread they opened inside a closed room — cleared the permission check in *every* namespace, not just their own. Both the `/rooms/opens` edit form and the public/private toggle call `becomes!`, so either one could convert a direct room or a sub-room into a browsable open room and republish a private conversation to the whole account.

Each namespace now answers `serves?` for the room types it's actually about, asked after both the membership lookup and the parent-derived sub-room fallback, since either can surface a room the namespace has no business touching. The public/private toggle refuses a room that doesn't have one. And the rule that only open and closed rooms convert now lives on `Room` as a validation, so any future route to a type change has to get past it as well.

### Room message streams were authorized only by their signature

Messages were delivered over Turbo's stock channel, which verifies the signature on the stream name and nothing more. That name carries no expiry and no binding to a user, so revoking a membership didn't stop delivery — the client replays its subscription onto the next socket — and the name works for whoever holds it.

Room streams now go through `RoomStreamsChannel`, which derives the room from the verified stream name rather than taking it as a parameter, and checks access with `reachable_room` — the same derived-access rule that already governs typing and presence, so a forum member still reaches a post they never followed while a stale row stops granting access once the parent is gone.

`RoomStreamsAreAuthorized` is prepended onto `Turbo::StreamsChannel` so the stock channel turns these names away. Without it the check would be decorative: the subscriber names its own channel in the subscribe frame, so leaving the stock channel open leaves the old path open. Streams already bound to a user or the account — the sidebar, the inbox, a membership — pass through untouched.

Three stream shapes are covered: `<room>:messages`, `<room>:posts`, and `<user>:<room>:messages`, the last of which carries one person's own bookmark state and so is checked against its owner rather than just the room.

### Notes

Both modes are covered. In SaaS the lookup runs inside tenant context, and a stream name minted in another workspace is refused by the tenanted locator — rescued into a plain reject rather than an exception.

**Tests:** `bin/rails test` 1823 runs / 5980 assertions / 0 failures; `SAAS=true bin/rails test saas/test/` 305 runs / 902 assertions / 0 failures; `bin/rubocop` clean across 725 files. Every new test was confirmed to fail without its fix.

System tests could not be run — all 11 error at sign-in on `main` as well, so that's pre-existing and the browser path is unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
