### PR TITLE
Lint channels against AnyCable's constraints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,24 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+# The socket lives in anycable-go, not in Rails, so three ActionCable habits stop
+# working here: channel instance variables don't survive between commands, a Ruby
+# block passed to stream_from never runs, and periodic timers have no process to
+# tick in. Each fails silently at runtime — these cops catch them at lint time.
+require:
+  - anycable/rails/rubocop
+
+# They ship scoped to "**/channels/**/*.rb", which also sweeps in test/channels —
+# where an @ivar is a fixture held across a test, not state a channel expects to
+# survive an RPC. Narrow them to the channels that actually run on the socket.
+AnyCable/InstanceVars: &anycable_channels
+  Include:
+    - 'app/channels/**/*.rb'
+    - 'saas/app/channels/**/*.rb'
+
+AnyCable/StreamFrom: *anycable_channels
+AnyCable/PeriodicalTimers: *anycable_channels
+
 AllCops:
   Exclude:
     - 'db/migrate/**/*'

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,15 +1,20 @@
 class RoomChannel < ApplicationCable::Channel
   def subscribed
-    if @room = find_room
-      stream_for @room
+    if room
+      stream_for room
     else
       reject
     end
   end
 
   private
+    # Memoized for the length of one command, never across them. Every command
+    # arrives as its own RPC with a fresh channel object, so the next one resolves
+    # the room again — and re-checks access while it's there, which is why holding
+    # it wouldn't be an improvement. AnyCable/InstanceVars can't tell the two
+    # apart, so the exemption is here rather than on the whole file.
     def room
-      @room ||= find_room
+      @room ||= find_room # rubocop:disable AnyCable/InstanceVars
     end
 
     def find_room

--- a/app/channels/typing_notifications_channel.rb
+++ b/app/channels/typing_notifications_channel.rb
@@ -1,7 +1,7 @@
 class TypingNotificationsChannel < RoomChannel
   def subscribed
-    if @room = find_room
-      stream_for @room, whisper: true
+    if room
+      stream_for room, whisper: true
     else
       reject
     end


### PR DESCRIPTION
The socket lives in `anycable-go`, not in Rails, so three ordinary ActionCable habits quietly stop working: channel instance variables don't survive between commands, a Ruby block passed to `stream_from` never runs, and periodic timers have no process to tick in. All three fail silently at runtime — nothing raises, the behaviour just isn't there. AnyCable ships cops for exactly these, and we weren't running them.

Enabling them found five offenses, all in `RoomChannel` and its subclass `TypingNotificationsChannel`, both assigning `@room` in `subscribed`. That state was already dead — every command arrives as its own RPC with a fresh channel object, so nothing that reads it later ever saw it. It wasn't a live bug only because `RoomChannel#room` memoizes and silently re-resolves. `subscribed` now goes through `room` like every other caller, which is also the safer shape: `find_room` re-checks access on each command rather than trusting a value cached at subscribe time.

The memoization itself keeps a scoped exemption. The cop can't tell memoizing *within* one command from relying on state *across* commands, and only the second is broken; dropping it would double a query on `PresenceChannel#membership`, `room_presence_stream`, and both typing `start`/`stop`, which are the busiest paths we have.

The cops ship scoped to `**/channels/**/*.rb`, which also sweeps in `test/channels` — 41 of the 46 initial offenses were test files where `@room` is an ordinary fixture ivar, not state a channel expects to survive an RPC. Narrowed to the channels that actually run on the socket.

**Verified by planting violations** rather than trusting a clean run: `@thing = current_user`, `periodically every: 3.seconds`, and `stream_from "x" do |msg|` each get caught by their respective cop.

**Tests:** `bin/rails test` 1794 runs / 0 failures; `SAAS=true bin/rails test saas/test/` 302 runs / 0 failures; `bin/rubocop` clean across 718 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
