### PR TITLE
Defer direct message creation until the first message is sent

### DIFF
--- a/app/controllers/autocompletable/users_controller.rb
+++ b/app/controllers/autocompletable/users_controller.rb
@@ -29,8 +29,18 @@ class Autocompletable::UsersController < ApplicationController
     end
 
     def users_scope
-      base = room ? room.mentionable_users : User.all
-      base.active.without_default_names.recent_posters_first(room&.id).with_attached_avatar
+      mentionable_base.active.without_default_names.recent_posters_first(room&.id).with_attached_avatar
+    end
+
+    # A provisional DM has no room yet, so its composer scopes the mention picker to
+    # the chosen recipients via user_ids — matching what room.mentionable_users
+    # returns once the DM exists. Without it the picker falls back to every user and
+    # lets you "mention" a non-member, rendering a mention that never notifies them.
+    def mentionable_base
+      return room.mentionable_users if room
+      return User.where(id: params[:user_ids]) if params[:user_ids].present?
+
+      User.all
     end
 
     def add_everyone_mention_if_applicable(users)

--- a/app/controllers/rooms/directs_controller.rb
+++ b/app/controllers/rooms/directs_controller.rb
@@ -1,4 +1,6 @@
 class Rooms::DirectsController < RoomsController
+  include ActiveStorage::SetCurrent, NotifyBots
+
   skip_before_action :set_room, only: %i[ edit destroy ]
   skip_before_action :ensure_can_administer, only: %i[ destroy ]
 
@@ -7,17 +9,37 @@ class Rooms::DirectsController < RoomsController
   before_action :ensure_permission_to_create_direct_messages, only: %i[ new create ]
 
   def new
-    @room = Rooms::Direct.new
+    # With recipients chosen, this doubles as the provisional compose surface: it
+    # writes nothing, so a started-but-abandoned conversation leaves no room, no
+    # memberships, and never touches the other person's sidebar. A cached "Message
+    # X" link can outlive the empty state, so if a DM already exists, show it
+    # rather than a provisional surface that would hide the conversation.
+    return @room = Rooms::Direct.new if selected_users_ids.none?
+
+    if existing = Rooms::Direct.for(selected_users)
+      redirect_to room_url(existing)
+    else
+      @recipients = selected_users
+    end
   end
 
   def create
-    @room = Rooms::Direct.find_or_create_for(selected_users)
+    # The first message materializes the DM (Rooms::Direct.message_to) and only
+    # then broadcasts it into the recipient's sidebar — no unsolicited empty
+    # conversation. Broadcasting mirrors MessagesController#create so the first
+    # message reaches the recipient the same way every later one does.
+    @message = Rooms::Direct.message_to(selected_users, creator: Current.user, message_params: message_params)
 
-    if @room.persisted?
-      redirect_to room_url(@room)
-    else
-      redirect_to new_rooms_direct_path, alert: "Could not create conversation"
-    end
+    @message.broadcast_create
+    @message.broadcast_mentionee_sidebar_updates
+    notify_bots(@message, :created)
+
+    redirect_to room_url(@message.room)
+  rescue ActiveRecord::RecordInvalid, Rooms::Direct::BlankMessageError
+    # A blank or invalid first message created nothing (the transaction rolled back
+    # the just-opened DM). Re-render the provisional surface so the composer stays.
+    @recipients = selected_users
+    render :new, status: :unprocessable_entity
   end
 
   def edit
@@ -49,6 +71,10 @@ class Rooms::DirectsController < RoomsController
 
     def selected_users_ids
       params.fetch(:user_ids, [])
+    end
+
+    def message_params
+      params.require(:message).permit(:body, :attachment, :client_message_id)
     end
 
     def ensure_permission_to_create_direct_messages

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,6 @@
 module UsersHelper
-  def button_to_direct_room_with(user)
-    button_to rooms_directs_path(user_ids: [ user.id ]), class: "btn btn--primary full-width txt--large" do
+  def link_to_direct_room_with(user)
+    link_to new_rooms_direct_path(user_ids: [ user.id ]), class: "btn btn--primary full-width txt--large", data: { turbo_frame: "_top" } do
       image_tag("messages.svg")
     end
   end

--- a/app/models/rooms/direct.rb
+++ b/app/models/rooms/direct.rb
@@ -1,20 +1,65 @@
 # Rooms for direct message chats between users. These act as a singleton, so a single set of users will
 # always refer to the same direct room.
 class Rooms::Direct < Room
+  class BlankMessageError < StandardError; end
+
   after_create_commit :broadcast_to_sidebar
   after_create_commit :ensure_members_hash
 
   class << self
+    # A conversation exists only once someone sends something, so opening the
+    # compose surface (Rooms::DirectsController#new) writes nothing — this finder
+    # resolves the existing DM for a user set without creating one, and also
+    # covers the stale-link case where a cached "Message X" link is followed after
+    # the DM already exists.
+    def for(users)
+      find_by(members_hash: members_hash_for(users))
+    end
+
     def find_or_create_for(users)
       hash = members_hash_for(users)
-      find_by(members_hash: hash) || create_for({ members_hash: hash }, users: users)
-    rescue ActiveRecord::RecordNotUnique
-      find_by!(members_hash: hash)
+      find_by(members_hash: hash) || create_racing(users, hash)
+    end
+
+    # Materializes the DM lazily, on its first message, and returns that message: a
+    # DM only exists once someone actually sends something, so opening the compose
+    # surface writes nothing (see Rooms::DirectsController#new) and never prepends
+    # an empty conversation into the recipient's sidebar. Room + first message live
+    # in one transaction so a blank first send rolls back a *just-created* DM rather
+    # than leaving an empty room behind — a DM that already existed is left intact,
+    # we simply don't add the invalid message to it.
+    def message_to(users, creator:, message_params:)
+      transaction do
+        room = find_or_create_for(users)
+        message = room.messages.create_with_attachment!(message_params.merge(creator: creator))
+
+        # Messages carry no body-presence validation, so a blank body with no
+        # attachment would otherwise leave an empty DM behind — the exact thing
+        # lazy materialization exists to prevent. Roll the just-opened DM back.
+        raise BlankMessageError if message.plain_text_body.blank?
+
+        message
+      end
     end
 
     def members_hash_for(users)
       Digest::MD5.hexdigest(users.map(&:id).sort.join(","))
     end
+
+    private
+      # The create branch of find_or_create_for, isolated in a savepoint
+      # (requires_new) so a lost race on the unique members_hash index rolls back
+      # only this attempt. Without the savepoint, create_for's transaction would
+      # join an enclosing one (message_to's) and — on PostgreSQL — the failed
+      # INSERT would abort that whole transaction, so the recovering find_by! would
+      # raise InFailedSqlTransaction instead of returning the row the winner created.
+      def create_racing(users, hash)
+        transaction(requires_new: true) do
+          create_for({ members_hash: hash }, users: users)
+        end
+      rescue ActiveRecord::RecordNotUnique
+        find_by!(members_hash: hash)
+      end
   end
 
   def default_involvement(user: nil)

--- a/app/views/inboxes/direct_messages/index.html.erb
+++ b/app/views/inboxes/direct_messages/index.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :messages do %>
   <% if Current.user.can_create_direct_messages? %>
-    <%= form_with url: rooms_directs_path, class: "dm-compose" do |form| %>
+    <%= form_with url: new_rooms_direct_path, method: :get, class: "dm-compose", data: { turbo_frame: "_top" } do |form| %>
       <section class="autocomplete__container dm-compose__container">
         <div class="autocomplete__input input flex flex-wrap position-relative"
             data-controller="autocomplete" data-autocomplete-url-value="<%= autocompletable_users_path %>">

--- a/app/views/rooms/_composer_fields.html.erb
+++ b/app/views/rooms/_composer_fields.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form:, autocomplete_room:, label:, send_label:, body_id: nil, toolbar_toggle: false, hint_transition: "none", attachments: true) -%>
+<%# locals: (form:, autocomplete_room: nil, label:, send_label:, body_id: nil, toolbar_toggle: false, hint_transition: "none", attachments: true, mention_user_ids: nil) -%>
 <%# The shared input row for every chat composer — the main room composer, a
     thread reply, and a provisional (not-yet-created) thread reply. Callers supply
     the form builder plus the bits that vary: the room to autocomplete @-mentions
@@ -20,7 +20,7 @@
                data: {
                  controller: "rich-autocomplete",
                  action: rich_text_data_actions,
-                 rich_autocomplete_url_value: autocompletable_users_path(room_id: autocomplete_room.id),
+                 rich_autocomplete_url_value: autocompletable_users_path(room_id: autocomplete_room&.id, user_ids: mention_user_ids),
                  permitted_attachment_types: "application/vnd.actiontext.opengraph-embed",
                  composer_target: "text" } } %>
           <% body_options[:id] = body_id if body_id %>

--- a/app/views/rooms/directs/_header.html.erb
+++ b/app/views/rooms/directs/_header.html.erb
@@ -1,0 +1,29 @@
+<%# locals: (title:, room: nil, membership: nil) -%>
+<%# The DM surface header — shared by the live conversation (rooms/show/_nav) and
+    the provisional compose surface (rooms/directs/new). With a persisted room the
+    title links to its settings and the edit + involvement controls show; the
+    provisional surface (room: nil) has nothing to edit or follow yet. %>
+<% content_for :nav do %>
+  <%= account_logo_tag if Current.account.logo.attached? %>
+  <%= link_back_to_or_referrer inbox_direct_messages_path %>
+
+  <% heading = tag.h1 class: "room__contents txt-medium overflow-ellipsis" do %>
+    <span class="for-screen-reader">Direct message with</span>
+    <%= title %>
+  <% end %>
+
+  <% if room %>
+    <%= link_to heading, edit_room_path(room), class: "btn btn--reversed btn--faux room--current" %>
+    <%= link_to_edit_room(room) %>
+
+    <% unless hotwire_native_app? %>
+      <div class="flex gap-half align-center navbar-actions">
+        <%= turbo_frame_tag dom_id(room, :involvement) do %>
+          <%= button_to_change_involvement(room, membership.involvement) %>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="btn btn--reversed btn--faux room--current"><%= heading %></div>
+  <% end %>
+<% end %>

--- a/app/views/rooms/directs/_provisional_composer.html.erb
+++ b/app/views/rooms/directs/_provisional_composer.html.erb
@@ -1,0 +1,32 @@
+<%# locals: (recipients:) -%>
+<%# The composer for a DM that doesn't exist yet: sending the first message
+    materializes the conversation (Rooms::DirectsController#create) and redirects
+    to the real room. There's no room to stream to yet, so no typing indicator and
+    no optimistic insert (the composer controller skips it without a messages
+    outlet) — just a plain submit that carries the recipients.
+    Attachments are disabled until the room exists (the upload path needs a
+    room-scoped message stream); start with a text message, then attach files in
+    the real composer. %>
+<% content_for :footer do %>
+  <div class="composer flex align-end gap position-relative">
+    <%= form_with model: Message.new, url: rooms_directs_path, id: "composer",
+          class: "margin-block flex-item-grow contain",
+          data: {
+            controller: "composer drop-target",
+            action: composer_data_actions(connection_monitor: false),
+            composer_toolbar_class: "composer--rich-text",
+            composer_direct_upload_url_value: rails_direct_uploads_url } do |form| %>
+      <% recipients.without(Current.user).each do |recipient| %>
+        <%= hidden_field_tag "user_ids[]", recipient.id %>
+      <% end %>
+
+      <%# Mentions resolve against the chosen recipients (the future DM members), not
+          every user — so you can't mention someone who won't be in the conversation. %>
+      <%= render "rooms/composer_fields", form: form,
+            label: "Write a message", send_label: "Send Message", attachments: false,
+            mention_user_ids: recipients.map(&:id) %>
+
+      <%= form.hidden_field :client_message_id, data: { composer_target: "clientid" } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/rooms/directs/new.html.erb
+++ b/app/views/rooms/directs/new.html.erb
@@ -1,25 +1,54 @@
-<turbo-frame id="direct_rooms_control" target="_top">
-  <div class="directs directs--new flex flex-column gap">
-    <%= form_with model: @room, class: "flex gap flex-item-grow", data: {
-          controller: "form", action: "keydown.esc->form#cancel" } do |form| %>
-      <%= link_to user_sidebar_path, class: "btn flex-item-no-shrink d-hotwire-native-none", data: { turbo_frame: "user_sidebar", form_target: "cancel" } do %>
-        <%= icon_tag "arrow-left" %>
-        <span class="for-screen-reader">Cancel changes</span>
+<%# @recipients is set only once names are chosen (Rooms::DirectsController#new): a
+    provisional compose surface that writes nothing until the first message is sent.
+    Otherwise this is the sidebar "New DM" picker, whose submit reveals this same
+    surface for the chosen users rather than creating the room. %>
+<% if @recipients %>
+  <% others = @recipients.without(Current.user) %>
+  <% names = others.map(&:name).to_sentence %>
+  <% @page_title = names %>
+  <% @body_class = "sidebar" %>
+
+  <%= render "rooms/directs/header", title: names, room: nil %>
+
+  <% content_for :sidebar, sidebar_turbo_frame_tag(src: user_sidebar_path) %>
+
+  <div id="message-area" class="message-area" contents>
+    <div class="messages flex flex-column align-center gap txt-align-center pad" aria-live="polite">
+      <% others.each do |recipient| %>
+        <div class="avatar avatar--large"><%= avatar_image_tag(recipient, alt: "") %></div>
       <% end %>
-
-      <section class="autocomplete__container unpad input input--actor">
-        <div class="autocomplete__input input flex flex-wrap position-relative flex-item-grow"
-            data-controller="autocomplete" data-autocomplete-url-value="<%= autocompletable_users_path %>">
-          <%= render "users/autocompletables/user_select", form: form, placeholder: nil %>
-        </div>
-      </section>
-
-      <%= button_tag class: "btn btn--reversed flex-item-no-shrink", type: "submit" do %>
-        <%= icon_tag "check" %>
-        <span class="for-screen-reader">Start direct message</span>
-      <% end %>
-    <% end %>
-
-    <span class="txt-small translucent pad-inline-half center">Type names to start a conversation…</span>
+      <p class="txt-medium txt-muted margin-none">
+        This is the start of your conversation with <%= names %>.
+      </p>
+    </div>
   </div>
-</turbo-frame>
+
+  <%= render "rooms/directs/provisional_composer", recipients: @recipients %>
+<% else %>
+  <turbo-frame id="direct_rooms_control" target="_top">
+    <div class="directs directs--new flex flex-column gap">
+      <%= form_with url: new_rooms_direct_path, method: :get,
+            class: "flex gap flex-item-grow",
+            data: { turbo_frame: "_top", controller: "form", action: "keydown.esc->form#cancel" } do |form| %>
+        <%= link_to user_sidebar_path, class: "btn flex-item-no-shrink d-hotwire-native-none", data: { turbo_frame: "user_sidebar", form_target: "cancel" } do %>
+          <%= icon_tag "arrow-left" %>
+          <span class="for-screen-reader">Cancel changes</span>
+        <% end %>
+
+        <section class="autocomplete__container unpad input input--actor">
+          <div class="autocomplete__input input flex flex-wrap position-relative flex-item-grow"
+              data-controller="autocomplete" data-autocomplete-url-value="<%= autocompletable_users_path %>">
+            <%= render "users/autocompletables/user_select", form: form, placeholder: nil %>
+          </div>
+        </section>
+
+        <%= button_tag class: "btn btn--reversed flex-item-no-shrink", type: "submit" do %>
+          <%= icon_tag "check" %>
+          <span class="for-screen-reader">Start direct message</span>
+        <% end %>
+      <% end %>
+
+      <span class="txt-small translucent pad-inline-half center">Type names to start a conversation…</span>
+    </div>
+  </turbo-frame>
+<% end %>

--- a/app/views/rooms/show/_nav.html.erb
+++ b/app/views/rooms/show/_nav.html.erb
@@ -1,37 +1,35 @@
-<% content_for :nav do %>
-  <%= account_logo_tag if Current.account.logo.attached? %>
+<% if room.direct? %>
+  <%= render "rooms/directs/header", title: room_display_name(room), room: room, membership: @membership %>
+<% else %>
+  <% content_for :nav do %>
+    <%= account_logo_tag if Current.account.logo.attached? %>
 
-  <% if room.thread? %>
-    <%= link_back_to_or_referrer room_at_message_path(room.parent_message.room, room.parent_message) %>
-  <% elsif room.direct? %>
-    <%= link_back_to_or_referrer inbox_direct_messages_path %>
-  <% end %>
+    <% if room.thread? %>
+      <%= link_back_to_or_referrer room_at_message_path(room.parent_message.room, room.parent_message) %>
+    <% end %>
 
-  <%= link_to edit_room_path(room), class: "btn btn--reversed btn--faux room--current" do %>
-    <h1 class="room__contents txt-medium overflow-ellipsis">
-      <% if room.direct? %>
-        <span class="for-screen-reader">Direct message with</span>
-      <% end %>
-
-      <% if room.thread? %>
-        🧵 <%= room_display_name(room.parent_message.room) %>
-      <% else %>
-        <%= room_type_indicator(room) %> <%= room_display_name(room) %>
-      <% end %>
-    </h1>
-  <% end %>
-
-  <% unless room.thread? %>
-    <%= link_to_edit_room(room) %>
-  <% end %>
-
-  <% unless hotwire_native_app? %>
-    <div class="flex gap-half align-center navbar-actions">
-      <% unless room.thread? %>
-        <%= turbo_frame_tag dom_id(room, :involvement) do %>
-          <%= button_to_change_involvement(room, @membership.involvement) %>
+    <%= link_to edit_room_path(room), class: "btn btn--reversed btn--faux room--current" do %>
+      <h1 class="room__contents txt-medium overflow-ellipsis">
+        <% if room.thread? %>
+          🧵 <%= room_display_name(room.parent_message.room) %>
+        <% else %>
+          <%= room_type_indicator(room) %> <%= room_display_name(room) %>
         <% end %>
-      <% end %>
-    </div>
+      </h1>
+    <% end %>
+
+    <% unless room.thread? %>
+      <%= link_to_edit_room(room) %>
+    <% end %>
+
+    <% unless hotwire_native_app? %>
+      <div class="flex gap-half align-center navbar-actions">
+        <% unless room.thread? %>
+          <%= turbo_frame_tag dom_id(room, :involvement) do %>
+            <%= button_to_change_involvement(room, @membership.involvement) %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/_quick_profile.html.erb
+++ b/app/views/users/_quick_profile.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
     <% if user.active? %>
-      <%= button_to_direct_room_with user %>
+      <%= link_to_direct_room_with user %>
     <% end %>
 
   <% elsif user.active? %>
@@ -63,7 +63,7 @@
         <span>View profile</span>
       <% end %>
       <% if user != Current.user && Current.user.can_direct_message?(user) %>
-        <%= link_to rooms_directs_path(user_ids: [user.id]), class: "btn btn--reversed txt-small", data: { turbo_frame: "_top", turbo_method: :post } do %>
+        <%= link_to new_rooms_direct_path(user_ids: [user.id]), class: "btn btn--reversed txt-small", data: { turbo_frame: "_top" } do %>
           <%= icon_tag "messages" %>
           <span>Direct message</span>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,7 +34,7 @@
 
     <% if @user.active? %>
       <div class="flex justify-center">
-        <%= button_to_direct_room_with @user %>
+        <%= link_to_direct_room_with @user %>
       </div>
     <% end %>
 
@@ -86,7 +86,7 @@
     <% can_dm = Current.user.can_direct_message?(@user) %>
     <% if can_dm %>
       <div class="flex justify-center">
-        <%= link_to rooms_directs_path(user_ids: [@user.id]), class: "btn btn--reversed", data: { turbo_frame: "_top", turbo_method: :post } do %>
+        <%= link_to new_rooms_direct_path(user_ids: [@user.id]), class: "btn btn--reversed", data: { turbo_frame: "_top" } do %>
           <%= icon_tag "messages" %>
           <span>Message <%= @user.name.split.first %></span>
         <% end %>

--- a/test/controllers/autocompletable/users_controller_test.rb
+++ b/test/controllers/autocompletable/users_controller_test.rb
@@ -67,6 +67,18 @@ class Autocompletable::UsersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "user_ids scopes suggestions to the chosen recipients (provisional DM mention picker)" do
+    # A provisional DM has no room yet, so its composer scopes @-mentions to the
+    # recipients. A non-recipient must not surface — selecting one would render a
+    # mention that never notifies them once the DM is created.
+    get autocompletable_users_url(user_ids: [ users(:jz).id ], format: :json), params: { query: "" }
+
+    assert_response :success
+    ids = response.parsed_body.map { |u| u["value"] }
+    assert_includes ids, users(:jz).id
+    assert_not_includes ids, users(:kevin).id
+  end
+
   test "blank query returns recent users (mention picker default)" do
     get autocompletable_users_url(format: :json), params: { query: "" }
 

--- a/test/controllers/rooms/directs_controller_test.rb
+++ b/test/controllers/rooms/directs_controller_test.rb
@@ -5,19 +5,84 @@ class Rooms::DirectsControllerTest < ActionDispatch::IntegrationTest
     sign_in :david
   end
 
-  test "create" do
-    post rooms_directs_url, params: { user_ids: [ users(:jz).id ] }
+  # ===================
+  # New action tests
+  # ===================
 
-    room = Room.last
+  test "new without user_ids renders the picker" do
+    get new_rooms_direct_url
+    assert_response :success
+    assert_select "turbo-frame#direct_rooms_control"
+  end
+
+  test "new with user_ids renders a provisional compose surface and writes nothing" do
+    assert_no_difference [ -> { Rooms::Direct.count }, -> { Membership.count }, -> { Message.count } ] do
+      get new_rooms_direct_url(user_ids: [ users(:jz).id ])
+    end
+
+    assert_response :success
+    assert_select "form#composer[action=?]", rooms_directs_path
+  end
+
+  test "new with user_ids for an existing DM redirects to it (stale link)" do
+    existing = rooms(:david_and_kevin)
+
+    assert_no_difference -> { Rooms::Direct.count } do
+      get new_rooms_direct_url(user_ids: [ users(:kevin).id ])
+    end
+
+    assert_redirected_to room_url(existing)
+  end
+
+  test "new does not push an unsolicited conversation into the recipient's sidebar" do
+    jz_stream = "#{users(:jz).to_gid_param}:rooms"
+
+    assert_broadcasts jz_stream, 0 do
+      get new_rooms_direct_url(user_ids: [ users(:jz).id ])
+    end
+  end
+
+  # ===================
+  # Create action tests
+  # ===================
+
+  test "create materializes the DM with its first message and redirects to it" do
+    assert_difference [ -> { Rooms::Direct.count }, -> { Message.count } ], 1 do
+      post rooms_directs_url, params: { user_ids: [ users(:jz).id ], message: { body: "First message" } }
+    end
+
+    room = Rooms::Direct.last
     assert_redirected_to room_url(room)
     assert room.users.include?(users(:david))
     assert room.users.include?(users(:jz))
+    assert_equal "First message", room.messages.sole.plain_text_body
   end
 
-  test "create only once per user set" do
-    assert_difference -> { Room.all.count }, +1 do
-      post rooms_directs_url, params: { user_ids: [ users(:jz).id ] }
-      post rooms_directs_url, params: { user_ids: [ users(:jz).id ] }
+  test "create without a message is rejected and materializes nothing" do
+    # A DM only exists once someone sends a message, so create requires one.
+    # (The provisional composer always sends one; a bodyless POST is malformed and
+    # Rails maps ParameterMissing to a 400.)
+    assert_no_difference -> { Rooms::Direct.count } do
+      assert_raises ActionController::ParameterMissing do
+        post rooms_directs_url, params: { user_ids: [ users(:jz).id ] }
+      end
+    end
+  end
+
+  test "create with a blank message materializes nothing" do
+    # Messages have no body-presence validation, so a blank body would otherwise
+    # leave an empty DM behind — the transaction rolls it back instead.
+    assert_no_difference [ -> { Rooms::Direct.count }, -> { Message.count } ] do
+      post rooms_directs_url, params: { user_ids: [ users(:jz).id ], message: { body: "  " } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "create only materializes one room per user set" do
+    assert_difference -> { Rooms::Direct.count }, +1 do
+      post rooms_directs_url, params: { user_ids: [ users(:jz).id ], message: { body: "one" } }
+      post rooms_directs_url, params: { user_ids: [ users(:jz).id ], message: { body: "two" } }
     end
   end
 
@@ -39,7 +104,7 @@ class Rooms::DirectsControllerTest < ActionDispatch::IntegrationTest
     get new_rooms_direct_url
     assert_response :forbidden
 
-    post rooms_directs_url, params: { user_ids: [ users(:david).id ] }
+    post rooms_directs_url, params: { user_ids: [ users(:david).id ], message: { body: "Hi" } }
     assert_response :forbidden
   end
 
@@ -52,7 +117,7 @@ class Rooms::DirectsControllerTest < ActionDispatch::IntegrationTest
     get new_rooms_direct_url
     assert_response :success
 
-    post rooms_directs_url, params: { user_ids: [ users(:jz).id ] }
-    assert_redirected_to room_url(Room.last)
+    post rooms_directs_url, params: { user_ids: [ users(:jz).id ], message: { body: "Hi" } }
+    assert_redirected_to room_url(Rooms::Direct.last)
   end
 end

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -15,6 +15,19 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show renders the direct-message nav header" do
+    room = rooms(:david_and_kevin)
+
+    get room_url(room)
+
+    assert_response :success
+    # The recipient titles the conversation, and the header links to the room's
+    # settings — the same header the provisional compose surface renders (room: nil).
+    assert_select "a.room--current[href=?]", edit_rooms_direct_path(room) do
+      assert_select "h1.room__contents", text: /#{users(:kevin).name}/
+    end
+  end
+
   test "composer carries the @everyone confirm threshold, member count, and cap flag" do
     room = rooms(:pets)
 

--- a/test/models/rooms/direct_test.rb
+++ b/test/models/rooms/direct_test.rb
@@ -19,6 +19,58 @@ class Rooms::DirectTest < ActiveSupport::TestCase
     assert room.memberships.all? { |m| m.involved_in_everything? }
   end
 
+  # Lazy materialization — a DM exists only once someone sends something.
+
+  test "message_to materializes the DM lazily with its first message" do
+    jz, rachel = users(:jz), users(:rachel)
+    Current.user = jz
+
+    message = nil
+    assert_difference -> { Rooms::Direct.count }, 1 do
+      message = Rooms::Direct.message_to([ jz, rachel ], creator: jz, message_params: { body: "First message" })
+    end
+
+    assert_equal "First message", message.plain_text_body
+    assert message.room.users.include?(jz)
+    assert message.room.users.include?(rachel)
+  end
+
+  test "message_to is idempotent — a second message reuses the existing DM" do
+    jz, rachel = users(:jz), users(:rachel)
+    Current.user = jz
+
+    first = Rooms::Direct.message_to([ jz, rachel ], creator: jz, message_params: { body: "one" })
+
+    assert_no_difference -> { Rooms::Direct.count } do
+      second = Rooms::Direct.message_to([ rachel, jz ], creator: rachel, message_params: { body: "two" })
+      assert_equal first.room_id, second.room_id
+    end
+  end
+
+  test "message_to rejects a blank message and materializes nothing" do
+    jz, rachel = users(:jz), users(:rachel)
+    Current.user = jz
+
+    assert_no_difference [ -> { Rooms::Direct.count }, -> { Message.count } ] do
+      assert_raises Rooms::Direct::BlankMessageError do
+        Rooms::Direct.message_to([ jz, rachel ], creator: jz, message_params: { body: "  " })
+      end
+    end
+  end
+
+  test "for finds an existing DM without creating one" do
+    jz, rachel = users(:jz), users(:rachel)
+    Current.user = jz
+
+    assert_nil Rooms::Direct.for([ jz, rachel ])
+
+    existing = Rooms::Direct.find_or_create_for([ jz, rachel ])
+
+    assert_no_difference -> { Rooms::Direct.count } do
+      assert_equal existing, Rooms::Direct.for([ jz, rachel ])
+    end
+  end
+
   test "broadcasts to sidebar for each member on creation" do
     jz = users(:jz)
     rachel = users(:rachel)


### PR DESCRIPTION
Opening or starting a DM used to create the `Rooms::Direct` room and both membership rows before any message was composed — and worse, it prepended the empty conversation into the recipient's sidebar unsolicited. Every "Message X" affordance and the DM picker created the room on click.

This defers creation to the first message: a DM exists only once someone actually sends something. Clicking "Message X" (or picking recipients) now navigates to a provisional compose surface that writes nothing; the room, memberships, and first message are materialized together in one transaction on send. An abandoned compose leaves no room, no memberships, and never touches the other person's sidebar.

This is the direct-message counterpart to the thread-deferral change, and reuses the same shape: a lazy `message_to` materializer, an atomic materialize-on-send with the unique-index race isolated in a savepoint (so the recovery path is Postgres-safe), and a blank-message guard that rolls back a just-created DM rather than orphaning it. The live-conversation nav header and the provisional surface now share one partial instead of duplicating chrome.

**Behavior change:** a started-but-unsent DM no longer appears in either sidebar. The recipient's sidebar lights up only once a real message exists, arriving already marked unread.

**First-message-only tradeoffs:** attachments are disabled in the provisional composer (the upload path needs a room-scoped stream) — send text first, then attach in the real room; and @-mentions in the provisional composer are scoped to the chosen recipients, so you can't mention someone who won't be in the conversation.

The bot API DM endpoint stays eager by design.

## Testing
- Model: atomic materialize + idempotency + blank-message rejection; `Rooms::Direct.for` finds without creating.
- Controller: `new` writes nothing / redirects to an existing DM / renders the picker; `create` materializes + redirects, blank → 422, bodyless → 400; no unsolicited sidebar push on open.
- Added coverage for the shared DM nav header and the recipient-scoped mention picker.
- Full self-hosted suite green; `Rooms::Direct` model tests pass under tenanted (SaaS) mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
