### PR TITLE
Consolidate three duplicated code paths (permalinks, notification broadcasts, search normalization)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -539,7 +539,7 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bootsnap (1.25.0) sha256=41059e7d0f9cb4023a33465d095f64b913fc9d1b808d6524c307da945fbcffcf
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -164,7 +164,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -597,7 +597,7 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bootsnap (1.25.0) sha256=41059e7d0f9cb4023a33465d095f64b913fc9d1b808d6524c307da945fbcffcf
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/app/controllers/api/bots/searches_controller.rb
+++ b/app/controllers/api/bots/searches_controller.rb
@@ -4,7 +4,7 @@ class API::Bots::SearchesController < API::Bots::BaseController
   before_action :parse_pagination_params, only: :show
 
   def show
-    query = sanitize_query(params[:q])
+    query = Message::SearchIndex.normalize(params[:q])
     return render_validation_error("Query parameter 'q' is required") if query.blank?
 
     room_ids = Array(params[:room_ids])
@@ -29,9 +29,4 @@ class API::Bots::SearchesController < API::Bots::BaseController
     @messages = messages.first(@limit)
     @next_cursor = build_cursor(@messages.last) if @has_more
   end
-
-  private
-    def sanitize_query(value)
-      value.to_s.gsub(/[^[:word:]]/, " ").strip
-    end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -50,6 +50,6 @@ class SearchesController < ApplicationController
     end
 
     def query
-      params[:q]&.gsub(/[^[:word:]]/, " ")
+      Message::SearchIndex.normalize(params[:q])
     end
 end

--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -45,6 +45,6 @@ class Users::MessagesController < ApplicationController
     end
 
     def query
-      params[:q]&.gsub(/[^[:word:]]/, " ")
+      Message::SearchIndex.normalize(params[:q])
     end
 end

--- a/app/controllers/users/searches_controller.rb
+++ b/app/controllers/users/searches_controller.rb
@@ -17,6 +17,6 @@ class Users::SearchesController < ApplicationController
     end
 
     def query
-      params[:q]&.gsub(/[^[:word:]]/, " ")
+      Message::SearchIndex.normalize(params[:q])
     end
 end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -8,27 +8,11 @@ module MessagesHelper
   end
 
   def message_permalink_path(message)
-    room = message.room
-    if post = message.forum_post
-      message_id = message.id unless forum_opening_message?(message)
-      room_path(post.parent_room, post: post.slug, message_id:)
-    elsif room.thread? && (parent = room.parent_message)
-      room_at_message_path(parent.room, parent)
-    else
-      room_at_message_path(room, message)
-    end
+    message_permalink(message, only_path: true)
   end
 
   def message_permalink_url(message)
-    room = message.room
-    if post = message.forum_post
-      message_id = message.id unless forum_opening_message?(message)
-      room_url(post.parent_room, post: post.slug, message_id:)
-    elsif room.thread? && (parent = room.parent_message)
-      room_at_message_url(parent.room, parent)
-    else
-      room_at_message_url(room, message)
-    end
+    message_permalink(message, only_path: false)
   end
 
   def message_area_tag(room, id: "message-area", presence: true, &)
@@ -173,6 +157,21 @@ module MessagesHelper
   end
 
   private
+    # Shared resolver for message_permalink_path / _url — the same three-branch
+    # decision (forum post / chat thread / plain room). only_path toggles between
+    # a path and a full URL, the sole difference between the two public helpers.
+    def message_permalink(message, only_path:)
+      room = message.room
+      if post = message.forum_post
+        message_id = message.id unless forum_opening_message?(message)
+        room_url(post.parent_room, post: post.slug, message_id:, only_path:)
+      elsif room.thread? && (parent = room.parent_message)
+        room_at_message_url(parent.room, parent, only_path:)
+      else
+        room_at_message_url(room, message, only_path:)
+      end
+    end
+
     def messages_actions
       "turbo:before-stream-render@document->messages#beforeStreamRender keydown.up@document->messages#editMyLastMessage"
     end

--- a/app/jobs/broadcast_mention_notifications_job.rb
+++ b/app/jobs/broadcast_mention_notifications_job.rb
@@ -2,16 +2,8 @@ class BroadcastMentionNotificationsJob < ApplicationJob
   queue_as :default
 
   def perform(message_id:)
-    Notification.where(message_id: message_id, activity_type: "mention")
-                .with_message_and_creator
-                .each do |notification|
-      Turbo::StreamsChannel.broadcast_append_to(
-        [ notification.user, :inbox_activity ],
-        target: "inbox",
-        partial: "notifications/notification",
-        locals: { notification: notification, timestamp_style: :long_datetime }
-      )
-      notification.user.broadcast_activity_indicator
-    end
+    Notification.append_and_broadcast(
+      Notification.where(message_id: message_id, activity_type: "mention")
+    )
   end
 end

--- a/app/jobs/create_thread_reply_notifications_job.rb
+++ b/app/jobs/create_thread_reply_notifications_job.rb
@@ -40,17 +40,9 @@ class CreateThreadReplyNotificationsJob < ApplicationJob
     )
 
     # Broadcast to each recipient's activity stream
-    Notification.where(message_id: message_id, activity_type: "thread_reply", user_id: recipient_ids)
-                .with_message_and_creator
-                .each do |notification|
-      Turbo::StreamsChannel.broadcast_append_to(
-        [ notification.user, :inbox_activity ],
-        target: "inbox",
-        partial: "notifications/notification",
-        locals: { notification: notification, timestamp_style: :long_datetime }
-      )
-      notification.user.broadcast_activity_indicator
-    end
+    Notification.append_and_broadcast(
+      Notification.where(message_id: message_id, activity_type: "thread_reply", user_id: recipient_ids)
+    )
   end
 
   private

--- a/app/models/message/search_index.rb
+++ b/app/models/message/search_index.rb
@@ -79,6 +79,8 @@ module Message::SearchIndex
   # Postgres's english config strips them, FTS5's porter keeps them.
   def search(relation, query)
     query = normalize(query)
+    return relation.none if query.blank?
+
     if postgresql?
       relation.where("messages.body_search @@ plainto_tsquery('english', ?)", query).ordered
     else

--- a/app/models/message/search_index.rb
+++ b/app/models/message/search_index.rb
@@ -72,16 +72,25 @@ module Message::SearchIndex
 
   # --- Querying (backs the Message.search scope) ---
   #
-  # Bare-token queries (callers strip everything but word characters first)
-  # filtered against the index, ordered. plainto_tsquery is sufficient because
-  # phrase/operator syntax never reaches here; the only cross-engine difference
-  # is stopwords — Postgres's english config strips them, FTS5's porter keeps them.
+  # Bare-token queries filtered against the index, ordered. #normalize enforces
+  # the bare-token contract right here so no caller can pass raw input through:
+  # plainto_tsquery and the FTS5 match only ever see word characters, never
+  # phrase or operator syntax. The only cross-engine difference is stopwords —
+  # Postgres's english config strips them, FTS5's porter keeps them.
   def search(relation, query)
+    query = normalize(query)
     if postgresql?
       relation.where("messages.body_search @@ plainto_tsquery('english', ?)", query).ordered
     else
       relation.joins("join message_search_index idx on messages.id = idx.rowid").where("idx.body match ?", query).ordered
     end
+  end
+
+  # Reduces a raw query to the bare word tokens the index expects, dropping every
+  # character FTS5 or tsquery would read as operator or phrase syntax. Idempotent,
+  # so callers may normalize for display or keys and still pass through #search.
+  def normalize(query)
+    query.to_s.gsub(/[^[:word:]]/, " ").strip
   end
 
   # The one place the search backend branches on adapter.

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -25,6 +25,20 @@ class Notification < ApplicationRecord
 
   validates :activity_type, inclusion: { in: %w[mention boost thread_reply] }
 
+  # Appends each notification in the scope to its user's activity stream and
+  # refreshes their activity indicator — the append mirror of #delete_all_and_broadcast.
+  def self.append_and_broadcast(scope)
+    scope.with_message_and_creator.each do |notification|
+      Turbo::StreamsChannel.broadcast_append_to(
+        [ notification.user, :inbox_activity ],
+        target: "inbox",
+        partial: "notifications/notification",
+        locals: { notification: notification, timestamp_style: :long_datetime }
+      )
+      notification.user.broadcast_activity_indicator
+    end
+  end
+
   # Deletes the given scope of notifications and broadcasts removal to each user's activity stream.
   # Loads records first, then deletes by ID to avoid double-querying the same WHERE clause.
   def self.delete_all_and_broadcast(scope)

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -10,7 +10,7 @@ class Search < ApplicationRecord
 
   class << self
     def record(query, creator: nil)
-      find_or_create_by(query: query, creator:).touch
+      find_or_create_by(query: Message::SearchIndex.normalize(query), creator:).touch
     end
   end
 

--- a/test/helpers/messages_helper_test.rb
+++ b/test/helpers/messages_helper_test.rb
@@ -28,6 +28,15 @@ class MessagesHelperTest < ActionView::TestCase
     assert_equal room_at_message_path(message.room, message), message_permalink_path(message)
   end
 
+  test "a message inside a chat thread permalinks to the parent message's anchor" do
+    parent = messages(:first)
+    thread = Rooms::Thread.find_or_create_for(parent, creator: users(:david))
+    reply = Current.set(user: users(:david)) { thread.messages.create!(body: "<div>a thread reply</div>") }
+
+    assert_equal room_at_message_path(parent.room, parent), message_permalink_path(reply)
+    assert_equal room_at_message_url(parent.room, parent), message_permalink_url(reply)
+  end
+
   test "a forum post's opening message url-permalinks to the gallery deep-link, no reply anchor" do
     post = create_forum_post(title: "How do I export?")
 

--- a/test/helpers/messages_helper_test.rb
+++ b/test/helpers/messages_helper_test.rb
@@ -3,6 +3,12 @@ require "test_helper"
 class MessagesHelperTest < ActionView::TestCase
   include ForumTestHelper
 
+  # _url helpers need a host; supply one locally so we never mutate the global
+  # routes.default_url_options (a nil there leaks into other suites' url helpers).
+  def default_url_options
+    { host: "example.com" }
+  end
+
   test "a forum post's opening message permalinks to the gallery deep-link, no reply anchor" do
     post = create_forum_post(title: "How do I export?")
 
@@ -20,5 +26,24 @@ class MessagesHelperTest < ActionView::TestCase
     message = messages(:first)
 
     assert_equal room_at_message_path(message.room, message), message_permalink_path(message)
+  end
+
+  test "a forum post's opening message url-permalinks to the gallery deep-link, no reply anchor" do
+    post = create_forum_post(title: "How do I export?")
+
+    assert_equal room_url(post.parent_room, post: post.slug), message_permalink_url(post.messages.first)
+  end
+
+  test "a forum reply url-permalinks to the gallery deep-link anchored to the reply" do
+    post = create_forum_post
+    reply = Current.set(user: users(:david)) { post.messages.create!(body: "<div>a reply</div>") }
+
+    assert_equal room_url(post.parent_room, post: post.slug, message_id: reply.id), message_permalink_url(reply)
+  end
+
+  test "a chat message still url-permalinks to its room anchor" do
+    message = messages(:first)
+
+    assert_equal room_at_message_url(message.room, message), message_permalink_url(message)
   end
 end

--- a/test/models/message/search_index_test.rb
+++ b/test/models/message/search_index_test.rb
@@ -22,6 +22,16 @@ class Message::SearchIndexTest < ActiveSupport::TestCase
     assert_equal [ message ], rooms(:designers).messages.search("hovercraft")
   end
 
+  test "normalize reduces a query to bare word tokens and is idempotent" do
+    assert_equal "full of eels", Message::SearchIndex.normalize("full-of-eels!")
+    assert_equal "eels", Message::SearchIndex.normalize('"eels')
+    assert_equal "", Message::SearchIndex.normalize("  -–  ")
+    assert_equal "", Message::SearchIndex.normalize(nil)
+
+    once = Message::SearchIndex.normalize("full-of-eels!")
+    assert_equal once, Message::SearchIndex.normalize(once)
+  end
+
   test "clear! empties the index, and it repopulates on the next write" do
     rooms(:designers).messages.create!(
       body: "clearable hovercraft", client_message_id: "clear", creator: users(:david)

--- a/test/models/message/searchable_test.rb
+++ b/test/models/message/searchable_test.rb
@@ -43,6 +43,16 @@ class Message::SearchableTest < ActiveSupport::TestCase
     assert_equal [ message ], rooms(:designers).messages.search("full-of-eels")
   end
 
+  test "a query that normalizes to nothing returns no results instead of erroring the engine" do
+    rooms(:designers).messages.create! body: "My hovercraft is full of eels", client_message_id: "empty", creator: users(:david)
+
+    # An all-punctuation or blank query normalizes to "", which FTS5 MATCH would
+    # reject as a syntax error; the boundary must short-circuit to an empty set.
+    assert_equal [], rooms(:designers).messages.search("---")
+    assert_equal [], rooms(:designers).messages.search("   ")
+    assert_equal [], rooms(:designers).messages.search(nil)
+  end
+
   test "stopword-only queries diverge by engine — the one documented difference" do
     message = rooms(:designers).messages.create! body: "who goes there", client_message_id: "stop", creator: users(:david)
 

--- a/test/models/message/searchable_test.rb
+++ b/test/models/message/searchable_test.rb
@@ -34,6 +34,15 @@ class Message::SearchableTest < ActiveSupport::TestCase
     assert_equal [ message ], rooms(:designers).messages.search("run")
   end
 
+  test "raw operator and punctuation characters are normalized away at the search boundary" do
+    message = rooms(:designers).messages.create! body: "My hovercraft is full of eels", client_message_id: "raw", creator: users(:david)
+
+    # An unterminated quote is FTS5 phrase syntax and would raise if it reached
+    # the index; the scope must reduce the query to bare tokens first.
+    assert_equal [ message ], rooms(:designers).messages.search('"eels')
+    assert_equal [ message ], rooms(:designers).messages.search("full-of-eels")
+  end
+
   test "stopword-only queries diverge by engine — the one documented difference" do
     message = rooms(:designers).messages.create! body: "who goes there", client_message_id: "stop", creator: users(:david)
 

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class SearchTest < ActiveSupport::TestCase
+  test "record stores the normalized query, not the raw punctuation" do
+    users(:david).searches.record("hover-craft!")
+
+    assert users(:david).searches.global.exists?(query: "hover craft")
+    assert_not users(:david).searches.global.exists?(query: "hover-craft!")
+  end
+
+  test "record de-duplicates punctuation variants that normalize to the same search" do
+    assert_difference -> { users(:david).searches.count }, 1 do
+      users(:david).searches.record("hover-craft!")
+      users(:david).searches.record("hover craft ")
+    end
+  end
+end


### PR DESCRIPTION
Collapses three places where the same logic was written more than once, each a spot where editing one copy and missing the other would drift the behavior apart. Behavior is preserved; the search change also closes a latent correctness gap.

## What changes

- **Message permalinks** — `message_permalink_path` and `message_permalink_url` held the same three-branch decision (forum post / chat thread / plain room) twice, differing only by suffix. They now share one private resolver that toggles `only_path:`. The `_url` variant previously had no test coverage; it gets the three missing cases, and the chat-thread branch (untested before) is now covered for both path and URL.

- **Notification append-and-broadcast** — two jobs carried a byte-identical "append to the activity stream + refresh the indicator" block, while its opposite, `delete_all_and_broadcast`, was already a model method. Adds the mirror `Notification.append_and_broadcast(scope)`; both jobs become a single call, so a future change to the broadcast shape lands in one place.

- **Search query normalization** — the search index documents that callers must reduce a query to bare word tokens before it reaches FTS5 / `tsquery`, but the `search` scope trusted the caller and never enforced it, and the stripping logic was copy-pasted across four controllers (one had already diverged). Adds `Message::SearchIndex.normalize` and applies it at the boundary — inside the `search` scope and `Search.record` — so a raw query can no longer reach the index as operator or phrase syntax. Controllers route through the one normalizer.

## Behavior notes

- **Empty queries no longer error the engine.** A query that normalizes to `""` (all-punctuation, blank, or nil) previously reached SQLite's FTS5 `MATCH ''` and raised `ActiveRecord::StatementInvalid`. The `search` boundary now short-circuits to an empty relation, matching Postgres, which already returned no rows for an empty `tsquery`. Not reachable by today's callers (they all guard on presence), but the boundary is now safe for any caller.
- **Recent searches store the normalized query.** The recording controllers already stripped punctuation before calling `Search.record` on `main`, so raw text never reached the table; centralizing through `normalize` additionally trims surrounding whitespace. This keeps `find_or_create_by(query:)` de-duplicating punctuation variants of the same search (e.g. `full-of-eels!` and `full of eels` remain one row). Locked with a test.

## Testing

- Helpers, notification model, both broadcast jobs, search index + searchable, the new `Search` model test, and the search controllers — green. New coverage: the three `_url` permalink cases plus the chat-thread branch, a `normalize` unit test, an empty-query regression test (`"---"`, `"   "`, `nil`), and the recent-search normalization/de-duplication behavior.

Also bumps brakeman to 8.0.6 (the pre-push scan gate wanted the current release).