### PR TITLE
Close Cable connections on sign-out

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -147,6 +147,8 @@ module Authentication
     end
 
     def terminate_current_session
+      global_identity = Current.global_identity if Sabha.saas?
+
       if Sabha.saas?
         Current.global_session&.destroy
         cookies.delete(:global_session_token)
@@ -155,6 +157,18 @@ module Authentication
         reset_session
         cookies.delete(:session_token, domain: ENV["COOKIE_DOMAIN"])
       end
+
+      disconnect_remote_connections(global_identity)
+    end
+
+    def disconnect_remote_connections(global_identity)
+      if Sabha.saas?
+        global_identity&.disconnect_remote_connections
+      else
+        Current.user&.disconnect_remote_connections
+      end
+    rescue => error
+      Rails.logger.warn "Could not disconnect remote connections on sign out: #{error.class}"
     end
 
     def authenticated_as(session)

--- a/app/controllers/sso/callbacks_controller.rb
+++ b/app/controllers/sso/callbacks_controller.rb
@@ -53,9 +53,18 @@ class Sso::CallbacksController < Sso::BaseController
     end
 
     def terminate_session_from_cookie
-      find_session_by_cookie&.destroy!
+      session = find_session_by_cookie
+      user = session&.user
+      session&.destroy!
       reset_session
       cookies.delete(:session_token, domain: ENV["COOKIE_DOMAIN"])
+      disconnect_remote_connections(user)
+    end
+
+    def disconnect_remote_connections(user)
+      user&.disconnect_remote_connections
+    rescue => error
+      Rails.logger.warn("[SSO] Failed to close remote connections: #{error.class.name}: #{error.message}")
     end
 
     def redeem_pending_join_code!(user, code)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,6 +200,12 @@ class User < ApplicationRecord
     close_remote_connections reconnect: true
   end
 
+  # Signing out invalidates this session, so a live socket must not reconnect
+  # with its existing JWT.
+  def disconnect_remote_connections
+    close_remote_connections reconnect: false
+  end
+
   def member_of?(room)
     Membership.active.visible.exists?(room_id: room.id, user_id: id)
   end

--- a/saas/app/controllers/concerns/saas/authentication.rb
+++ b/saas/app/controllers/concerns/saas/authentication.rb
@@ -88,9 +88,17 @@ module Saas
 
       # Sign out by destroying the GlobalSession
       def sign_out
+        global_identity = Current.global_identity
         Current.global_session&.destroy
         cookies.delete(:global_session_token)
+        disconnect_remote_connections(global_identity)
         Current.global_session = nil
+      end
+
+      def disconnect_remote_connections(global_identity)
+        global_identity&.disconnect_remote_connections
+      rescue => error
+        Rails.logger.warn "Could not disconnect remote connections on sign out: #{error.class}"
       end
 
       # Store the current URL for redirect after authentication

--- a/saas/app/models/global_identity.rb
+++ b/saas/app/models/global_identity.rb
@@ -119,6 +119,27 @@ class GlobalIdentity < UntenantedRecord
     end
   end
 
+  def disconnect_remote_connections
+    # A global sign-out may arrive through the core session route while that
+    # request is scoped to one workspace. Clear that scope before visiting each
+    # membership so every tenant can be disconnected.
+    ApplicationRecord.prohibit_shard_swapping(false) do
+      ApplicationRecord.without_tenant do
+        workspace_memberships.find_each do |membership|
+          next if membership.user_id.blank?
+
+          ApplicationRecord.with_tenant(membership.tenant) do
+            User.find_by(id: membership.user_id)&.disconnect_remote_connections
+          end
+        rescue ActiveRecord::Tenanted::TenantDoesNotExistError
+          # Workspace database doesn't exist, skip silently
+        rescue => error
+          Rails.logger.warn("[GlobalIdentity#disconnect_remote_connections] Failed for membership #{membership.id} in tenant #{membership.tenant}: #{error.message}")
+        end
+      end
+    end
+  end
+
   def cancel_email_change!
     return unless unconfirmed_email.present?
 

--- a/saas/test/controllers/saas/authentication_test.rb
+++ b/saas/test/controllers/saas/authentication_test.rb
@@ -39,8 +39,11 @@ module Saas
     end
 
     test "sign_out destroys session and clears cookie" do
-      sign_in_global_identity(global_identities(:alice))
+      identity = global_identities(:alice)
+      sign_in_global_identity(identity)
       session_count_before = GlobalSession.count
+
+      GlobalIdentity.any_instance.expects(:disconnect_remote_connections)
 
       delete session_path
 
@@ -49,6 +52,18 @@ module Saas
 
       # Should redirect to login
       assert_redirected_to new_session_path
+    end
+
+    test "sign_out still destroys the session when disconnecting connections fails" do
+      identity = global_identities(:alice)
+      sign_in_global_identity(identity)
+      current_session = GlobalSession.last
+      identity.stubs(:disconnect_remote_connections).raises(RuntimeError, "cable down")
+
+      delete session_path
+
+      assert_redirected_to new_session_path
+      assert_not GlobalSession.exists?(current_session.id)
     end
 
     test "after_authentication_url defaults to root when no return_to" do

--- a/saas/test/models/global_identity_test.rb
+++ b/saas/test/models/global_identity_test.rb
@@ -114,6 +114,36 @@ class GlobalIdentityTest < ActiveSupport::TestCase
     identity&.destroy
   end
 
+  test "disconnect_remote_connections leaves the active tenant and continues after a workspace failure" do
+    identity = GlobalIdentity.create!(name: "Remote Disconnect", email_address: "remote-disconnect@example.com", verified_at: Time.current)
+
+    with_provisioned_workspace(name: "Remote Disconnect A", creator: identity) do |workspace_a|
+      with_provisioned_workspace(name: "Remote Disconnect B", creator: identity) do |workspace_b|
+        memberships = [ workspace_a, workspace_b ].map do |workspace|
+          identity.workspace_memberships.find_by!(tenant: workspace.external_id.to_s)
+        end
+        users = memberships.map do |membership|
+          ApplicationRecord.with_tenant(membership.tenant) { User.find(membership.user_id) }
+        end
+
+        connections = mock("RemoteConnections")
+        connections.expects(:where)
+          .with(current_tenant: memberships.first.tenant, current_user: users.first)
+          .raises(RuntimeError, "cable down")
+        connections.expects(:where)
+          .with(current_tenant: memberships.second.tenant, current_user: users.second)
+          .returns(mock.tap { |connection| connection.expects(:disconnect).with(reconnect: false) })
+        ActionCable.server.stubs(:remote_connections).returns(connections)
+
+        ApplicationRecord.with_tenant(workspace_a.external_id.to_s) do
+          identity.disconnect_remote_connections
+        end
+      end
+    end
+  ensure
+    identity&.destroy
+  end
+
   # join tests
 
   test "join creates a membership and provisions a tenant user" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -58,6 +58,33 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_not Session.exists?(session.id)
   end
 
+  test "destroy closes the signed-out user's live connections" do
+    sign_in :david
+
+    connections = mock("RemoteConnections")
+    connections.expects(:disconnect).with(reconnect: false)
+    ActionCable.server.remote_connections
+      .expects(:where)
+      .with(current_user: users(:david))
+      .returns(connections)
+
+    delete session_url
+
+    assert_redirected_to root_url
+  end
+
+  test "destroy still signs out when the realtime service is unreachable" do
+    sign_in :david
+    session = users(:david).sessions.last
+    ActionCable.server.stubs(:remote_connections).raises(RuntimeError, "cable down")
+
+    delete session_url
+
+    assert_redirected_to root_url
+    assert_not cookies[:session_token].present?
+    assert_not Session.exists?(session.id)
+  end
+
   test "destroy under SSO redirects to signed out page so logout sticks" do
     sign_in :david
 

--- a/test/controllers/sso_controller_test.rb
+++ b/test/controllers/sso_controller_test.rb
@@ -161,6 +161,45 @@ class SsoFlowTest < ActionDispatch::IntegrationTest
     assert_nil parsed_cookies.signed[:session_token]
   end
 
+  test "signed logout payload closes the signed-out user's live connections without reconnecting" do
+    ENV["AUTH_METHOD"] = "password"
+    sign_in :david
+    ENV["AUTH_METHOD"] = "sso"
+
+    get sso_handshake_url
+    nonce = provider_request_payload["nonce"]
+    sso, sig = Sso::Payload.encode({ nonce:, logout: "true" }, ENV["SSO_SECRET"])
+
+    connections = mock("RemoteConnections")
+    connections.expects(:disconnect).with(reconnect: false)
+    ActionCable.server.remote_connections
+      .expects(:where)
+      .with(current_user: users(:david))
+      .returns(connections)
+
+    get sso_callback_url, params: { sso:, sig: }
+
+    assert_response :redirect
+  end
+
+  test "signed logout payload still signs out when realtime service is unreachable" do
+    ENV["AUTH_METHOD"] = "password"
+    sign_in :david
+    session_id = users(:david).sessions.last.id
+    ENV["AUTH_METHOD"] = "sso"
+    ActionCable.server.stubs(:remote_connections).raises(RuntimeError, "cable down")
+
+    get sso_handshake_url
+    nonce = provider_request_payload["nonce"]
+    sso, sig = Sso::Payload.encode({ nonce:, logout: "true" }, ENV["SSO_SECRET"])
+
+    get sso_callback_url, params: { sso:, sig: }
+
+    assert_response :redirect
+    assert_not Session.exists?(session_id)
+    assert_nil parsed_cookies.signed[:session_token]
+  end
+
   test "logout payload with invalid signature does not terminate current session" do
     ENV["AUTH_METHOD"] = "password"
     sign_in :david


### PR DESCRIPTION
## Summary

Signing out now closes active Cable connections for normal, SSO, and SaaS flows. The disconnect does not reconnect the client, so a stale AnyCable JWT cannot restore access after session revocation.

SaaS sign-out visits every workspace membership. A missing tenant database or a real-time disconnect failure does not prevent the sign-out from completing.

## Testing

- `bin/rails test test/controllers/sessions_controller_test.rb test/controllers/sso_controller_test.rb`
- `AUTH_METHOD=otp SAAS=true bin/rails test saas/test/controllers/saas/authentication_test.rb saas/test/models/global_identity_test.rb`
