### PR TITLE
dep: update Rails to 3df2cbea (edge) with compatibility fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Rails
-gem "rails", github: "rails/rails", ref: "cfa4e1b475472c7980a42dd810f237951db5108a"
+gem "rails", github: "rails/rails", ref: "3df2cbea2027026a29edb92cbb7e336a63e35444"
 gem "bootsnap", require: false
 
 # Drivers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: cfa4e1b475472c7980a42dd810f237951db5108a
-  ref: cfa4e1b475472c7980a42dd810f237951db5108a
+  revision: 3df2cbea2027026a29edb92cbb7e336a63e35444
+  ref: 3df2cbea2027026a29edb92cbb7e336a63e35444
   specs:
     actioncable (8.2.0.alpha)
       actionpack (= 8.2.0.alpha)
@@ -55,11 +55,12 @@ GIT
       activesupport (= 8.2.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.11)
+      herb (>= 0.10)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.7)
     activejob (8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
-      globalid (>= 0.3.6)
+      globalid (>= 1.4.0)
     activemodel (8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
     activerecord (8.2.0.alpha)
@@ -71,7 +72,7 @@ GIT
       activejob (= 8.2.0.alpha)
       activerecord (= 8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
-      marcel (~> 1.0)
+      marcel (~> 2.0)
     activesupport (8.2.0.alpha)
       base64
       bigdecimal
@@ -83,6 +84,7 @@ GIT
       logger (>= 1.4.2)
       minitest (>= 5.1)
       psych (>= 4)
+      ractor-dispatch (>= 0.2.0)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
@@ -209,6 +211,11 @@ GEM
       bigdecimal
       rake (~> 13.3)
     hashdiff (1.2.1)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -257,7 +264,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.2.1)
+    marcel (2.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
@@ -326,6 +333,7 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
+    ractor-dispatch (0.2.0)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -578,6 +586,11 @@ CHECKSUMS
   google-protobuf (4.36.1-arm64-darwin) sha256=4d82184f4582dfa123f9793cd7a73beca9b0d3f0d3717948c4120b6cc0d50f2d
   google-protobuf (4.36.1-x86_64-linux-gnu) sha256=e735a3f3d6596b1010013c2030778bc030770e659106fe7e4ae0f07631b551cb
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  herb (0.10.3-aarch64-linux-gnu) sha256=1eaea87e6577557492a1b0ddaae989fba8a8ddd382e888ee5f939ce6ded06eb8
+  herb (0.10.3-arm-linux-gnu) sha256=d5f007b665a705b5566f1068b54e1600d5ffe6cb0b7d274e27dd7ed5918ca54e
+  herb (0.10.3-arm-linux-musl) sha256=09a0979f64ee3aff0b25a345c2cecd15992a0532295fd00249d73f13a3e313b1
+  herb (0.10.3-arm64-darwin) sha256=1a5bef57d925d775496328e7a01a9c1260e1d83bed8038b60a4f8c81b12c15a3
+  herb (0.10.3-x86_64-linux-gnu) sha256=cbb49b66f2bdc92d17109d1ea9452e88ba6a8ae52e9ddd5279deff83dcc4c66d
   httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   image_processing (2.0.3) sha256=793e33f38470edd0a2d6bfd00acf8cb239c76284ba2e3dfb76633ac2b457f23a
@@ -597,7 +610,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
-  marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  marcel (2.1.0) sha256=f8b0327111dc7e516331eeefe052e981ce50e2bd826c1042a53cdf047fcc3512
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
@@ -634,6 +647,7 @@ CHECKSUMS
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  ractor-dispatch (0.2.0) sha256=5fe3eb85c202ac33910b0ada80a15f7a2e9504a057cf91d90ce80a73608492b2
   rails (8.2.0.alpha)
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: cfa4e1b475472c7980a42dd810f237951db5108a
-  ref: cfa4e1b475472c7980a42dd810f237951db5108a
+  revision: 3df2cbea2027026a29edb92cbb7e336a63e35444
+  ref: 3df2cbea2027026a29edb92cbb7e336a63e35444
   specs:
     actioncable (8.2.0.alpha)
       actionpack (= 8.2.0.alpha)
@@ -55,11 +55,12 @@ GIT
       activesupport (= 8.2.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.11)
+      herb (>= 0.10)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.7)
     activejob (8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
-      globalid (>= 0.3.6)
+      globalid (>= 1.4.0)
     activemodel (8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
     activerecord (8.2.0.alpha)
@@ -71,7 +72,7 @@ GIT
       activejob (= 8.2.0.alpha)
       activerecord (= 8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
-      marcel (~> 1.0)
+      marcel (~> 2.0)
     activesupport (8.2.0.alpha)
       base64
       bigdecimal
@@ -83,6 +84,7 @@ GIT
       logger (>= 1.4.2)
       minitest (>= 5.1)
       psych (>= 4)
+      ractor-dispatch (>= 0.2.0)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
@@ -242,6 +244,11 @@ GEM
       bigdecimal
       rake (~> 13.3)
     hashdiff (1.2.1)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -291,7 +298,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.2.1)
+    marcel (2.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
@@ -366,6 +373,7 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
+    ractor-dispatch (0.2.0)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -636,6 +644,11 @@ CHECKSUMS
   google-protobuf (4.36.1-arm64-darwin) sha256=4d82184f4582dfa123f9793cd7a73beca9b0d3f0d3717948c4120b6cc0d50f2d
   google-protobuf (4.36.1-x86_64-linux-gnu) sha256=e735a3f3d6596b1010013c2030778bc030770e659106fe7e4ae0f07631b551cb
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  herb (0.10.3-aarch64-linux-gnu) sha256=1eaea87e6577557492a1b0ddaae989fba8a8ddd382e888ee5f939ce6ded06eb8
+  herb (0.10.3-arm-linux-gnu) sha256=d5f007b665a705b5566f1068b54e1600d5ffe6cb0b7d274e27dd7ed5918ca54e
+  herb (0.10.3-arm-linux-musl) sha256=09a0979f64ee3aff0b25a345c2cecd15992a0532295fd00249d73f13a3e313b1
+  herb (0.10.3-arm64-darwin) sha256=1a5bef57d925d775496328e7a01a9c1260e1d83bed8038b60a4f8c81b12c15a3
+  herb (0.10.3-x86_64-linux-gnu) sha256=cbb49b66f2bdc92d17109d1ea9452e88ba6a8ae52e9ddd5279deff83dcc4c66d
   httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   image_processing (2.0.3) sha256=793e33f38470edd0a2d6bfd00acf8cb239c76284ba2e3dfb76633ac2b457f23a
@@ -656,7 +669,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
-  marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  marcel (2.1.0) sha256=f8b0327111dc7e516331eeefe052e981ce50e2bd826c1042a53cdf047fcc3512
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
@@ -698,6 +711,7 @@ CHECKSUMS
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  ractor-dispatch (0.2.0) sha256=5fe3eb85c202ac33910b0ada80a15f7a2e9504a057cf91d90ce80a73608492b2
   rails (8.2.0.alpha)
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,8 +2,10 @@ class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  # Most jobs are safe to ignore if the underlying records are no longer available.
+  # Discard only the missing-record case so a transient deserialization failure
+  # (e.g. a brief DB outage) still retries rather than silently vanishing.
+  # discard_on ActiveJob::DeserializationError::RecordNotFound
 
   # Discard jobs targeting a deleted workspace (tenant DB no longer exists)
   discard_on "ActiveRecord::Tenanted::TenantDoesNotExistError" if defined?(ActiveRecord::Tenanted)

--- a/app/jobs/bot/webhook_job.rb
+++ b/app/jobs/bot/webhook_job.rb
@@ -3,7 +3,7 @@ class Bot::WebhookJob < ApplicationJob
   # GlobalID arguments then fail to deserialize. Discard rather than retry —
   # the records aren't coming back — so the queue closes cleanly instead of
   # recording a failed execution nothing can act on.
-  discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   # Retry transient network failures (connection drops, DNS hiccups, SSL
   # renegotiation) and HTTP-level delivery failures (a bot endpoint returning

--- a/app/jobs/broadcast_inbox_threads_job.rb
+++ b/app/jobs/broadcast_inbox_threads_job.rb
@@ -1,8 +1,7 @@
 class BroadcastInboxThreadsJob < ApplicationJob
   queue_as :default
 
-  rescue_from ActiveJob::DeserializationError do
-  end
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   def perform(thread_id:, parent_message_id:, message_id:, creator_id:)
     thread = Room.find_by(id: thread_id)

--- a/app/jobs/broadcast_mentionee_sidebar_updates_job.rb
+++ b/app/jobs/broadcast_mentionee_sidebar_updates_job.rb
@@ -4,8 +4,7 @@ class BroadcastMentioneeSidebarUpdatesJob < ApplicationJob
 
   queue_as :default
 
-  rescue_from ActiveJob::DeserializationError do
-  end
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   def perform(message_id:)
     message = Message.find_by(id: message_id)

--- a/app/jobs/broadcast_unread_notifications_job.rb
+++ b/app/jobs/broadcast_unread_notifications_job.rb
@@ -1,8 +1,7 @@
 class BroadcastUnreadNotificationsJob < ApplicationJob
   queue_as :default
 
-  rescue_from ActiveJob::DeserializationError do
-  end
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   def perform(message_id:, ignore_if_older_message: false)
     message = Message.find_by(id: message_id)

--- a/app/jobs/create_thread_reply_notifications_job.rb
+++ b/app/jobs/create_thread_reply_notifications_job.rb
@@ -1,8 +1,7 @@
 class CreateThreadReplyNotificationsJob < ApplicationJob
   queue_as :default
 
-  rescue_from ActiveJob::DeserializationError do
-  end
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   # thread_id is the room a reply lives in — a chat thread or a forum post.
   def perform(message_id:, thread_id:, creator_id:)

--- a/app/jobs/forum_deactivation_job.rb
+++ b/app/jobs/forum_deactivation_job.rb
@@ -2,9 +2,9 @@ class ForumDeactivationJob < ApplicationJob
   queue_as :default
 
   # The forum was hard-destroyed before this ran — nothing left to cascade, so
-  # swallow the error rather than retry a job that can never succeed.
-  rescue_from ActiveJob::DeserializationError do
-  end
+  # discard rather than retry a job that can never succeed. A transient
+  # deserialization failure still retries.
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   # Soft-deletes a deleted forum's posts — their messages, memberships, and
   # notifications — off the request path. Rooms::Forum#deactivate cuts access

--- a/app/jobs/forum_reactivation_job.rb
+++ b/app/jobs/forum_reactivation_job.rb
@@ -2,9 +2,9 @@ class ForumReactivationJob < ApplicationJob
   queue_as :default
 
   # The forum was hard-destroyed before this ran — nothing left to restore, so
-  # swallow the error rather than retry a job that can never succeed.
-  rescue_from ActiveJob::DeserializationError do
-  end
+  # discard rather than retry a job that can never succeed. A transient
+  # deserialization failure still retries.
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   # Restores the posts a forum's deletion cascaded — and only those, so a post
   # deleted on its own stays deleted. Rooms::Forum#reactivate brings the

--- a/app/jobs/notification/bundle_delivery_job.rb
+++ b/app/jobs/notification/bundle_delivery_job.rb
@@ -6,7 +6,7 @@ class Notification::BundleDeliveryJob < ApplicationJob
   # transient infrastructure flakes that Solid Queue should retry.
   TerminalError = Class.new(StandardError)
 
-  discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError::RecordNotFound
   # The bundle is already canceled by the time we raise TerminalError. Discard
   # so Solid Queue closes the job cleanly instead of recording a failed
   # execution that operators would investigate (the work is done).

--- a/app/jobs/notification/dispatch_job.rb
+++ b/app/jobs/notification/dispatch_job.rb
@@ -2,7 +2,7 @@
 # push, missed-notification email bundle candidates). One job per message; the
 # boost path is the only call site that uses `only:`.
 class Notification::DispatchJob < ApplicationJob
-  discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   def perform(message, only: nil, actor: nil)
     return if DemoMode.enabled?

--- a/app/jobs/room_update_broadcast_job.rb
+++ b/app/jobs/room_update_broadcast_job.rb
@@ -1,8 +1,9 @@
 class RoomUpdateBroadcastJob < ApplicationJob
   queue_as :default
 
-  rescue_from ActiveJob::DeserializationError do
-  end
+  # The room was destroyed before this ran — nothing left to broadcast. Drop
+  # only that case; a transient deserialization failure should still retry.
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   retry_on ActiveRecord::Deadlocked, wait: :polynomially_longer, attempts: 3
 

--- a/app/jobs/room_update_broadcast_job.rb
+++ b/app/jobs/room_update_broadcast_job.rb
@@ -4,7 +4,7 @@ class RoomUpdateBroadcastJob < ApplicationJob
   rescue_from ActiveJob::DeserializationError do
   end
 
-  retry_on ActiveRecord::Deadlocked, wait: :exponentially, attempts: 3
+  retry_on ActiveRecord::Deadlocked, wait: :polynomially_longer, attempts: 3
 
   def perform(room)
     return unless room.active?

--- a/app/jobs/storage/materialize_job.rb
+++ b/app/jobs/storage/materialize_job.rb
@@ -2,7 +2,7 @@ class Storage::MaterializeJob < ApplicationJob
   queue_as :default
   limits_concurrency to: 1, key: ->(owner) { owner }
 
-  discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   def perform(owner)
     owner.materialize_storage

--- a/app/jobs/storage/reconcile_job.rb
+++ b/app/jobs/storage/reconcile_job.rb
@@ -4,7 +4,7 @@ class Storage::ReconcileJob < ApplicationJob
   queue_as :default
   limits_concurrency to: 1, key: ->(owner) { owner }
 
-  discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError::RecordNotFound
 
   retry_on ReconcileAborted, wait: 1.minute, attempts: 3
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -17,3 +17,30 @@ if Rails.env.production? && ENV["SENTRY_DSN"].present?
     ]
   end
 end
+
+# Rails extracted WebSocket handling into ActionCable::Server::Socket, which calls
+# connection.handle_open / handle_close *publicly* — and AnyCable's "next" connection
+# driver (selected once ActionCable::Server::Socket exists) does the same, calling
+# conn.handle_open with an explicit receiver. sentry-rails (through 7.0.0) still prepends
+# these onto the connection as *private*, so the external call raises NoMethodError and
+# every WebSocket connection dies. Restore public visibility on Sentry's module until
+# sentry-ruby adapts. This runs in every environment because the prepend is registered by
+# sentry-rails' railtie, not by Sentry.init. Registered from after_initialize so our
+# on_load hook queues after sentry-rails' own (on_load callbacks fire in registration order).
+#
+# Still unfixed as of sentry-rails 7.0.0 — tracked at
+# https://github.com/getsentry/sentry-ruby/issues/2975. The guard below makes this a no-op
+# once the methods ship public, so it's safe to leave until then.
+Rails.application.config.after_initialize do
+  ActiveSupport.on_load(:action_cable_connection) do
+    if defined?(Sentry::Rails::ActionCableExtensions::Connection)
+      Sentry::Rails::ActionCableExtensions::Connection.class_eval do
+        # Guard per method: a future sentry-rails rename would make `public` on a missing
+        # method raise NameError at boot. Only flip methods that actually exist.
+        %i[ handle_open handle_close ].each do |method|
+          public method if method_defined?(method) || private_method_defined?(method)
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,2 +1,2 @@
-# Used to match JavaScripts (new Date).getTime() for sorting
-Time::DATE_FORMATS[:epoch] = ->(time) { (time.to_f * 1000).to_i }
+# Used to match JavaScript's (new Date).getTime() for sorting
+ActiveSupport::TimeFormats.register(:epoch, ->(time) { (time.to_f * 1000).to_i })

--- a/saas/app/jobs/workspace/snapshot_job.rb
+++ b/saas/app/jobs/workspace/snapshot_job.rb
@@ -4,7 +4,7 @@ class Workspace
   class SnapshotJob < ApplicationJob
     queue_as :default
 
-    discard_on ActiveJob::DeserializationError
+    discard_on ActiveJob::DeserializationError::RecordNotFound
 
     def perform(workspace)
       workspace.refresh_snapshot!

--- a/saas/test/channels/bot_events_channel_test.rb
+++ b/saas/test/channels/bot_events_channel_test.rb
@@ -62,15 +62,9 @@ class SaasBotEventsChannelTest < ActionCable::Channel::TestCase
         legacy_stream   = "bot_events:#{bot_a.id}"
 
         assert_has_stream expected_stream
-        assert_no_streams_match foreign_stream
-        assert_no_streams_match legacy_stream
+        assert_has_no_stream foreign_stream
+        assert_has_no_stream legacy_stream
       end
     end
   end
-
-  private
-    def assert_no_streams_match(name)
-      assert_not subscription.streams.include?(name),
-        "expected channel not to subscribe to #{name.inspect} but it did"
-    end
 end


### PR DESCRIPTION
Advance the `rails/rails` main pin from `cfa4e1b4` (Apr 18) to `3df2cbea` (Sep 2) and adapt to the edge-API changes that landed in between. Both lockfiles are synced. Forced transitive bump: marcel 1.2.1 → 2.1.0 (activestorage now requires `~> 2.0`), plus new deps `herb` and `ractor-dispatch`.

## Edge-API fixes

- **ActiveJob `retry_on` validation.** ActiveJob now rejects the never-supported `:exponentially` symbol at class-load time. `RoomUpdateBroadcastJob` → `:polynomially_longer`, matching every other job.

- **Action Cable channel-test API.** `#streams` is now private, with a public `#stream_names` added. `BotEventsChannelTest`'s hand-rolled `assert_no_streams_match` was just `assert_has_no_stream`; switched to the public assertion.

- **Sentry + Action Cable WebSocket breakage.** Rails extracted WebSocket handling into `ActionCable::Server::Socket`, which calls `connection.handle_open`/`handle_close` *publicly* — and AnyCable's "next" connection driver (selected once `Server::Socket` exists) does the same via `conn.handle_open`. `sentry-rails` still prepends these onto the connection as *private*, so the external call raises `NoMethodError` and **every WebSocket connection dies** in both modes. No unit test covers a live cable connect, so this is invisible to the suite. The initializer now restores public visibility on Sentry's module until sentry-ruby adapts (tracked at getsentry/sentry-ruby#2975); the guard makes it a no-op once the fix ships.

- **ActiveSupport `Time::DATE_FORMATS` deprecation.** Migrated the `:epoch` format to `ActiveSupport::TimeFormats.register`.

## Job hardening

Rails' new `ActiveJob::DeserializationError::RecordNotFound` (backed by globalid 1.4.0's `Locator.fetch`) distinguishes a genuinely missing record from a transient deserialization failure. Every job previously treated *any* deserialization error as "drop the job" — 7 via an empty `rescue_from` swallow, 6 via a broad `discard_on` — silently discarding work on a brief DB blip. All narrowed to `RecordNotFound`, so a missing record still drops but a transient failure retries. Nothing raises the base `DeserializationError` manually, and a missing tenant is handled separately via `TenantDoesNotExistError`, so the narrowing is safe. Split into its own commit for independent review.

## Testing

- Self-hosted: `bin/rails test` — green.
- SaaS: `SAAS=true bin/rails test saas/test/` — green.
