### PR TITLE
feat(desktop): add protocol v1 manifest catalog and claims

### DIFF
--- a/app/controllers/api/desktop/base_controller.rb
+++ b/app/controllers/api/desktop/base_controller.rb
@@ -1,0 +1,38 @@
+class API::Desktop::BaseController < ApplicationController
+  skip_forgery_protection
+  include DesktopClientDetection
+
+  skip_before_action :require_workspace_membership, raise: false
+
+  before_action :require_supported_protocol_major
+
+  private
+    def protocol_major
+      request.headers["Sabha-Desktop-Protocol-Major"]&.to_i
+    end
+
+    def require_supported_protocol_major
+      return if protocol_major == Desktop::ClientManifest::PROTOCOL_MAJOR
+
+      render json: Desktop::ClientManifest.unsupported(protocol_major), status: :unsupported_media_type
+    end
+
+    def request_authentication
+      render json: { error: "Unauthorized" }, status: :unauthorized
+    end
+
+    def require_authentication
+      restore_authentication || bot_authentication || request_authentication
+      return if performed?
+
+      deny_inactive_workspace_user if Current.user.present?
+    end
+
+    def signed_in_for_desktop_api?
+      if Sabha.saas?
+        Current.global_identity.present?
+      else
+        Current.user.present?
+      end
+    end
+end

--- a/app/controllers/api/desktop/destinations_controller.rb
+++ b/app/controllers/api/desktop/destinations_controller.rb
@@ -1,0 +1,15 @@
+class API::Desktop::DestinationsController < API::Desktop::BaseController
+  before_action :require_desktop_catalog_authentication
+
+  def show
+    render json: Desktop::DestinationCatalog.new(request: request).as_json
+  end
+
+  private
+    def require_desktop_catalog_authentication
+      require_authentication
+      return if performed?
+
+      head :unauthorized unless signed_in_for_desktop_api?
+    end
+end

--- a/app/controllers/api/desktop/manifests_controller.rb
+++ b/app/controllers/api/desktop/manifests_controller.rb
@@ -1,0 +1,7 @@
+class API::Desktop::ManifestsController < API::Desktop::BaseController
+  allow_unauthenticated_access
+
+  def show
+    render json: Desktop::ClientManifest.new(request: request).as_json
+  end
+end

--- a/app/controllers/api/desktop/session_claims_controller.rb
+++ b/app/controllers/api/desktop/session_claims_controller.rb
@@ -1,0 +1,51 @@
+class API::Desktop::SessionClaimsController < ApplicationController
+  skip_forgery_protection
+  include DesktopClientDetection
+
+  allow_unauthenticated_access
+
+  rate_limit to: 10, within: 1.minute, only: :create, with: -> { render json: { error: "Too many requests" }, status: :too_many_requests }
+
+  def create
+    claim = redeem_claim!
+    establish_session_from_claim!(claim)
+    render json: { return_path: claim.return_path }
+  rescue Desktop::SessionClaim::Error, Desktop::GlobalSessionClaim::Error
+    render json: { error: "Invalid or expired claim" }, status: :forbidden
+  end
+
+  private
+    def redeem_claim!
+      if Sabha.saas?
+        Desktop::GlobalSessionClaim.redeem!(
+          token: params[:token],
+          nonce: params[:nonce],
+          origin: params[:origin]
+        )
+      else
+        Desktop::SessionClaim.redeem!(
+          token: params[:token],
+          nonce: params[:nonce],
+          origin: params[:origin]
+        )
+      end
+    end
+
+    def establish_session_from_claim!(claim)
+      if Sabha.saas?
+        global_session = claim.global_identity.global_sessions.create!(
+          user_agent: request.user_agent,
+          ip_address: request.remote_ip
+        )
+        cookies.signed.permanent[:global_session_token] = {
+          value: global_session.token,
+          httponly: true,
+          secure: Rails.env.production?,
+          same_site: :lax
+        }
+        Current.global_session = global_session
+      else
+        start_new_session_for(claim.user)
+      end
+    end
+end

--- a/app/controllers/concerns/desktop_client_detection.rb
+++ b/app/controllers/concerns/desktop_client_detection.rb
@@ -1,0 +1,13 @@
+module DesktopClientDetection
+  extend ActiveSupport::Concern
+
+  DESKTOP_CLIENT_HEADER = "Sabha-Desktop-Client"
+
+  included do
+    helper_method :desktop_client? if respond_to?(:helper_method)
+  end
+
+  def desktop_client?
+    request.headers[DESKTOP_CLIENT_HEADER].present?
+  end
+end

--- a/app/controllers/concerns/desktop_handoff.rb
+++ b/app/controllers/concerns/desktop_handoff.rb
@@ -1,0 +1,48 @@
+module DesktopHandoff
+  extend ActiveSupport::Concern
+
+  SESSION_KEY = "desktop_handoff"
+
+  private
+
+    def desktop_handoff_requested?
+      params[:desktop_handoff].present? &&
+        params[:desktop_nonce].present? &&
+        params[:desktop_origin].present?
+    end
+
+    def store_desktop_handoff_context
+      return unless desktop_handoff_requested?
+
+      session[SESSION_KEY] = {
+        "nonce" => params[:desktop_nonce].to_s,
+        "origin" => params[:desktop_origin].to_s,
+        "return_path" => params[:return_to].presence || default_desktop_return_path
+      }
+    end
+
+    def default_desktop_return_path
+      Sabha.saas? ? saas_root_path : root_path
+    end
+
+    def desktop_handoff_context
+      session[SESSION_KEY]
+    end
+
+    def clear_desktop_handoff_context
+      session.delete(SESSION_KEY)
+    end
+
+    def redirect_to_desktop_claim!(claim)
+      redirect_to desktop_claim_url(claim), allow_other_host: true
+    end
+
+    def desktop_claim_url(claim)
+      query = {
+        token: claim.raw_token,
+        origin: claim.origin,
+        nonce: claim.nonce
+      }
+      "sabha://session-claim?#{query.to_query}"
+    end
+end

--- a/app/controllers/sso/callbacks_controller.rb
+++ b/app/controllers/sso/callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Sso::CallbacksController < Sso::BaseController
+  include DesktopHandoff
+
   rate_limit to: 10, within: 1.minute, only: :show, with: -> { head :too_many_requests }
 
   def show
@@ -34,12 +36,25 @@ class Sso::CallbacksController < Sso::BaseController
     end
 
     def sign_in_via_sso(payload, return_path)
+      handoff = desktop_handoff_context
+
       newly_bootstrapped = FirstRun.auto_bootstrap_from_sso(payload)
       pending_join_code = session.delete(:pending_join_code)
       user = User.sign_in_with_sso!(payload)
       redeem_pending_join_code!(user, pending_join_code)
       start_new_session_for user
       flash[:notice] = welcome_message(user) if newly_bootstrapped || user.previously_new_record?
+
+      if handoff.present?
+        claim = Desktop::SessionClaim.issue!(
+          user: user,
+          nonce: handoff["nonce"],
+          origin: handoff["origin"],
+          return_path: handoff["return_path"]
+        )
+        return redirect_to_desktop_claim!(claim)
+      end
+
       redirect_to safe_return_path(return_path)
     end
 

--- a/app/controllers/sso/handshakes_controller.rb
+++ b/app/controllers/sso/handshakes_controller.rb
@@ -1,6 +1,10 @@
 class Sso::HandshakesController < Sso::BaseController
+  include DesktopHandoff
+
   def new
     return sso_misconfigured unless sso_configured?
+
+    store_desktop_handoff_context
 
     nonce = SingleSignOnNonce.issue!(return_path: sso_return_path)
     session[SESSION_NONCE_KEY] = nonce

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include RoomsHelper
+  include DesktopClientDetection
 
   def page_title_tag
     tag.title page_title
@@ -38,7 +39,7 @@ module ApplicationHelper
   end
 
   def body_classes
-    [ @body_class, admin_body_class, account_logo_body_class, workspace_selector_body_class, workspace_banner_body_class ].compact.join(" ")
+    [ @body_class, admin_body_class, account_logo_body_class, workspace_selector_body_class, workspace_banner_body_class, desktop_client_body_class ].compact.join(" ")
   end
 
   def link_back
@@ -86,6 +87,10 @@ module ApplicationHelper
 
     def workspace_banner_body_class
       "has-workspace-banner" if Sabha.saas? && Current.workspace.present?
+    end
+
+    def desktop_client_body_class
+      "desktop-client" if desktop_client?
     end
 
     # Extracts a back path from the referer if it matches a known inbox/search page.

--- a/app/models/desktop/client_manifest.rb
+++ b/app/models/desktop/client_manifest.rb
@@ -10,7 +10,8 @@ module Desktop
       {
         protocol_major: PROTOCOL_MAJOR,
         product: product_identity,
-        sign_in_path: sign_in_path
+        sign_in_path: sign_in_path,
+        destinations_path: "/api/desktop/destinations"
       }
     end
 
@@ -29,8 +30,13 @@ module Desktop
       def product_identity
         {
           name: Branding.app_name,
-          short_name: Branding.app_short_name
+          short_name: Branding.app_short_name,
+          slug: product_slug
         }
+      end
+
+      def product_slug
+        Branding.app_short_name.to_s.parameterize.presence || "sabha"
       end
 
       def sign_in_path

--- a/app/models/desktop/client_manifest.rb
+++ b/app/models/desktop/client_manifest.rb
@@ -1,0 +1,46 @@
+module Desktop
+  class ClientManifest
+    PROTOCOL_MAJOR = 1
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def as_json
+      {
+        protocol_major: PROTOCOL_MAJOR,
+        product: product_identity,
+        sign_in_path: sign_in_path
+      }
+    end
+
+    def self.unsupported(requested_major)
+      {
+        error: "unsupported_protocol_major",
+        requested_major: requested_major,
+        supported_major: PROTOCOL_MAJOR,
+        upgrade_url: "https://github.com/sabha-co/sabha-desktop/releases"
+      }
+    end
+
+    private
+      attr_reader :request
+
+      def product_identity
+        {
+          name: Branding.app_name,
+          short_name: Branding.app_short_name
+        }
+      end
+
+      def sign_in_path
+        if Sabha.saas?
+          "/session/new"
+        elsif Account.sso_auth? || FirstRun.should_auto_bootstrap?
+          "/session/sso"
+        else
+          "/session/new"
+        end
+      end
+  end
+end

--- a/app/models/desktop/destination_catalog.rb
+++ b/app/models/desktop/destination_catalog.rb
@@ -1,0 +1,46 @@
+module Desktop
+  class DestinationCatalog
+    def initialize(request:)
+      @request = request
+    end
+
+    def as_json
+      {
+        protocol_major: ClientManifest::PROTOCOL_MAJOR,
+        destinations: destinations
+      }
+    end
+
+    private
+      attr_reader :request
+
+      def destinations
+        if Sabha.saas?
+          Saas.new(request: request).destinations
+        else
+          [ self_hosted_destination ]
+        end
+      end
+
+      def self_hosted_destination
+        account = Current.account
+        {
+          id: "default",
+          name: account.name,
+          logo_url: account_logo_url,
+          base_path: "/",
+          cable_path: "/api/cable"
+        }
+      end
+
+      def account_logo_url
+        return unless Current.account&.logo&.attached?
+
+        Rails.application.routes.url_helpers.account_logo_url(
+          size: "small",
+          host: request.host,
+          protocol: request.protocol
+        )
+      end
+  end
+end

--- a/app/models/desktop/destination_catalog.rb
+++ b/app/models/desktop/destination_catalog.rb
@@ -7,29 +7,29 @@ module Desktop
     def as_json
       {
         protocol_major: ClientManifest::PROTOCOL_MAJOR,
-        destinations: destinations
+        peers: peers
       }
     end
 
     private
       attr_reader :request
 
-      def destinations
+      def peers
         if Sabha.saas?
-          Saas.new(request: request).destinations
+          Saas.new(request: request).peers
         else
-          [ self_hosted_destination ]
+          [ self_hosted_peer ]
         end
       end
 
-      def self_hosted_destination
+      def self_hosted_peer
         account = Current.account
         {
           id: "default",
           name: account.name,
           logo_url: account_logo_url,
-          base_path: "/",
-          cable_path: "/api/cable"
+          workspace_url: "#{request.base_url}/",
+          cable_url: "#{request.base_url}/api/cable"
         }
       end
 

--- a/app/models/desktop/session_claim.rb
+++ b/app/models/desktop/session_claim.rb
@@ -1,0 +1,62 @@
+class Desktop::SessionClaim < ApplicationRecord
+  self.table_name = "desktop_session_claims"
+
+  class Error < StandardError; end
+  class Invalid < Error; end
+  class Replayed < Error; end
+
+  ACTIVE_TTL = 5.minutes
+
+  belongs_to :user
+
+  validates :token_digest, :nonce, :origin, :return_path, :expires_at, presence: true
+
+  scope :valid, -> { where(used_at: nil, expires_at: Time.current..) }
+
+  def self.issue!(user:, nonce:, origin:, return_path:)
+    raw_token = SecureRandom.urlsafe_base64(32)
+    claim = create!(
+      user: user,
+      token_digest: digest(raw_token),
+      nonce: nonce,
+      origin: origin,
+      return_path: return_path,
+      expires_at: ACTIVE_TTL.from_now
+    )
+    claim.raw_token = raw_token
+    claim
+  end
+
+  def self.redeem!(token:, nonce:, origin:)
+    raise Invalid, "claim token missing" if token.blank?
+
+    transaction do
+      record = valid.lock.find_by(token_digest: digest(token))
+      raise Invalid, "claim not found or expired" if record.blank?
+      raise Replayed, "claim already used" if record.used_at.present?
+      raise Invalid, "claim origin mismatch" unless record.origin == origin
+      raise Invalid, "claim nonce mismatch" unless record.nonce == nonce
+
+      record.use!
+      record
+    end
+  end
+
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token)
+  end
+
+  def self.purge_expired
+    where(expires_at: ...Time.current).delete_all
+  end
+
+  attr_accessor :raw_token
+
+  def use!
+    update!(used_at: Time.current)
+  end
+
+  def used?
+    used_at.present?
+  end
+end

--- a/app/views/users/sidebars/_bell.html.erb
+++ b/app/views/users/sidebars/_bell.html.erb
@@ -1,3 +1,4 @@
+<% unless desktop_client? %>
 <span class="button_to_change_notifying" id="notification_bell_container" hidden
     data-controller="notifications" data-notifications-subscriptions-url-value="<%= user_push_subscriptions_path %>" data-notifications-attention-class="btn--pulsing">
   <%= turbo_frame_tag "global_notifications" do %>
@@ -32,4 +33,5 @@
       </form>
     </div>
   </dialog>
-</span> 
+</span>
+<% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,12 @@ Rails.application.routes.draw do
   # sibling of the short-lived `jid` token minted into the layout.
   namespace :api, defaults: { format: :json } do
     resource :cable, only: :show
+
+    namespace :desktop do
+      resource :manifest, only: :show
+      resource :destinations, only: :show
+      resource :session_claim, only: :create
+    end
   end
 
   # Bot API — authenticate with `Authorization: Bearer <bot_key>`.

--- a/db/migrate/20260904183000_create_desktop_session_claims.rb
+++ b/db/migrate/20260904183000_create_desktop_session_claims.rb
@@ -1,0 +1,18 @@
+class CreateDesktopSessionClaims < ActiveRecord::Migration[8.2]
+  def change
+    create_table :desktop_session_claims do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token_digest, null: false
+      t.string :nonce, null: false
+      t.string :origin, null: false
+      t.string :return_path, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+
+      t.timestamps
+    end
+
+    add_index :desktop_session_claims, :token_digest, unique: true
+    add_index :desktop_session_claims, :expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_16_000001) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_04_183000) do
   create_table "account_join_codes", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "code", null: false
@@ -133,6 +133,21 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_16_000001) do
     t.index ["booster_id"], name: "index_boosts_on_booster_id"
     t.index ["message_id", "booster_id", "content"], name: "index_boosts_on_message_booster_content", unique: true
     t.index ["message_id", "created_at"], name: "index_boosts_on_message_created"
+  end
+
+  create_table "desktop_session_claims", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "token_digest", null: false
+    t.string "nonce", null: false
+    t.string "origin", null: false
+    t.string "return_path", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_desktop_session_claims_on_expires_at"
+    t.index ["token_digest"], name: "index_desktop_session_claims_on_token_digest", unique: true
+    t.index ["user_id"], name: "index_desktop_session_claims_on_user_id"
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -401,6 +416,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_16_000001) do
   add_foreign_key "bookmarks", "messages"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "boosts", "messages"
+  add_foreign_key "desktop_session_claims", "users"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users", column: "creator_id"
   add_foreign_key "notification_bundle_items", "messages", on_delete: :cascade
@@ -422,9 +438,4 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_16_000001) do
   add_foreign_key "users", "badges"
   add_foreign_key "webhooks", "users"
 
-  # The full-text search index is intentionally not dumped here — it is
-  # engine-specific (an FTS5 virtual table on SQLite, a tsvector column + GIN
-  # index on Postgres) and a single schema file can't hold both. It is
-  # provisioned by Message::SearchIndex (run from db:prepare and the test schema
-  # load), and a SchemaDumper filter keeps it out of future dumps.
 end

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -276,6 +276,12 @@ docker compose exec web bin/rails runner "puts ActiveRecord::Base.connection.exe
 
 ---
 
+## Desktop client API
+
+Self-hosted Sabha installs expose the desktop compatibility endpoints documented in [features/DESKTOP.md](./features/DESKTOP.md). No extra configuration is required beyond a reachable HTTPS origin. The native Sabha desktop client probes `GET /api/desktop/manifest` before sign-in.
+
+---
+
 ## Server Requirements
 
 | Resource | Minimum | Recommended |

--- a/docs/features/DESKTOP.md
+++ b/docs/features/DESKTOP.md
@@ -24,8 +24,8 @@ Unauthenticated probe used when a member adds a server origin. Returns protocol 
 
 Authenticated catalog after sign-in.
 
-- Self-hosted mode returns exactly one branded destination for the community with `/api/cable` as the cable-discovery path.
-- SaaS mode returns ordered active workspace memberships only. Each peer includes a tenant-scoped cable path such as `/api/cable?wid=1000001`.
+- Self-hosted mode returns exactly one branded peer with `workspace_url` and `cable_url` (`/api/cable` on the origin).
+- SaaS mode returns ordered active workspace memberships only. Each peer includes a tenant-scoped `cable_url` such as `/api/cable?wid=1000001`.
 
 ### Session claims
 

--- a/docs/features/DESKTOP.md
+++ b/docs/features/DESKTOP.md
@@ -1,0 +1,56 @@
+# Sabha desktop protocol
+
+Sabha exposes a versioned desktop compatibility contract so the native Sabha desktop client can discover compatible servers, authenticate through existing Sabha flows, enumerate destination peers, and complete system-browser SSO safely.
+
+## Protocol major 1
+
+All desktop API requests must send the `Sabha-Desktop-Protocol-Major` header. Major version `1` is the only supported version today. Unsupported majors receive HTTP 415 with upgrade guidance.
+
+Desktop layout hooks use the non-authoritative `Sabha-Desktop-Client` request header. Browser requests without that header keep the existing workspace selector and WebPush enrollment UI.
+
+## Endpoints
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/desktop/manifest` | None | Product identity and server-owned sign-in entry |
+| GET | `/api/desktop/destinations` | Session | Ordered workspace peers and cable-discovery paths |
+| POST | `/api/desktop/session_claim` | None | Redeem a one-time desktop SSO claim |
+
+### Manifest
+
+Unauthenticated probe used when a member adds a server origin. Returns protocol major, product name, and a sign-in path. Never returns member records.
+
+### Destinations
+
+Authenticated catalog after sign-in.
+
+- Self-hosted mode returns exactly one branded destination for the community with `/api/cable` as the cable-discovery path.
+- SaaS mode returns ordered active workspace memberships only. Each peer includes a tenant-scoped cable path such as `/api/cable?wid=1000001`.
+
+### Session claims
+
+One-time credentials for system-browser SSO return. Claims store only a SHA256 digest of the bearer token, expire after five minutes, and redeem transactionally once into the initiating origin's session partition.
+
+Self-hosted claims live in `desktop_session_claims`. SaaS claims live in the untenanted `desktop_global_session_claims` table.
+
+## Desktop SSO handoff
+
+When the desktop client opens an external sign-in flow, pass these query parameters on the handshake URL:
+
+- `desktop_handoff=1`
+- `desktop_nonce` — client-generated binding nonce
+- `desktop_origin` — initiating server origin URL
+- `return_to` — optional in-app return path after redeem
+
+After successful SSO, Sabha redirects to `sabha://session-claim?...` with a one-time token. The desktop client redeems it via `POST /api/desktop/session_claim`.
+
+Password, email-code, and ordinary browser SSO flows without desktop handoff parameters are unchanged.
+
+## Client detection
+
+Send `Sabha-Desktop-Client: 1` on desktop-embedded page loads. Sabha suppresses the in-page SaaS workspace rail and sidebar WebPush enrollment UI for those requests while preserving the ordinary Hotwire interface.
+
+## Related docs
+
+- [Deployment](../DEPLOYMENT.md) — desktop API availability on self-hosted installs
+- [Multi-tenant deployment](../multi-tenant/DEPLOYMENT.md) — SaaS untenanted claim storage

--- a/docs/multi-tenant/DEPLOYMENT.md
+++ b/docs/multi-tenant/DEPLOYMENT.md
@@ -16,6 +16,7 @@ Multi-tenant mode enables:
 - **Shared authentication** - Users authenticate once, access multiple workspaces
 - **Path-based routing** - URLs include workspace ID (e.g., `/1000001/rooms/general`)
 - **Cross-workspace sessions** - Single sign-on across all workspaces
+- **Desktop client support** - Untenanted desktop session claims and global destination catalog for the Sabha desktop app
 
 ---
 

--- a/saas/app/controllers/saas/single_sign_ons_controller.rb
+++ b/saas/app/controllers/saas/single_sign_ons_controller.rb
@@ -2,13 +2,28 @@
 
 module Saas
   class SingleSignOnsController < BaseController
+    include ::DesktopHandoff
+
     allow_unauthenticated_access
 
     before_action :set_sso_request
+    before_action :store_desktop_handoff_context, only: :show
 
     def show
       unless signed_in?
         return redirect_to new_session_path(return_to: request.fullpath), alert: "Please sign in to continue"
+      end
+
+      handoff = desktop_handoff_context
+      clear_desktop_handoff_context
+      if handoff.present?
+        claim = Desktop::GlobalSessionClaim.issue!(
+          global_identity: current_global_identity,
+          nonce: handoff["nonce"],
+          origin: handoff["origin"],
+          return_path: handoff["return_path"]
+        )
+        return redirect_to_desktop_claim!(claim)
       end
 
       sso, sig = Sso::Payload.encode(sso_response_payload, @sso_client.secret)

--- a/saas/app/helpers/workspace_selector_helper.rb
+++ b/saas/app/helpers/workspace_selector_helper.rb
@@ -3,6 +3,7 @@
 require "zlib"
 
 module WorkspaceSelectorHelper
+  include DesktopClientDetection
   # Gradient pairs: [from_color, to_color] — rich, vibrant combinations (OKLch)
   WORKSPACE_GRADIENTS = [
     [ "oklch(40% 0.17 310)", "oklch(65% 0.20 300)" ], # Purple
@@ -26,6 +27,8 @@ module WorkspaceSelectorHelper
   end
 
   def show_workspace_selector?
+    return false if desktop_client?
+
     # Always show in SaaS mode when user is authenticated
     # Shows empty state on /workspaces/new when user has no workspaces
     Sabha.saas? && Current.global_identity.present?

--- a/saas/app/models/desktop/destination_catalog/saas.rb
+++ b/saas/app/models/desktop/destination_catalog/saas.rb
@@ -1,0 +1,44 @@
+module Desktop
+  class DestinationCatalog
+    class Saas
+      def initialize(request:)
+        @request = request
+      end
+
+      def destinations
+        return [] unless Current.global_identity
+
+        Current.global_identity.workspace_memberships_ordered.user_active.filter_map do |membership|
+          workspace = membership.workspace
+          next unless workspace&.active?
+
+          {
+            id: workspace.external_id.to_s,
+            name: workspace.name,
+            logo_url: logo_url_for(workspace),
+            base_path: workspace.slug,
+            cable_path: cable_path_for(workspace)
+          }
+        end
+      end
+
+      private
+        attr_reader :request
+
+        def cable_path_for(workspace)
+          "/api/cable?wid=#{workspace.external_id}"
+        end
+
+        def logo_url_for(workspace)
+          return unless workspace.has_logo?
+
+          Rails.application.routes.url_helpers.account_logo_url(
+            size: "small",
+            host: request.host,
+            protocol: request.protocol,
+            script_name: workspace.slug
+          )
+        end
+    end
+  end
+end

--- a/saas/app/models/desktop/destination_catalog/saas.rb
+++ b/saas/app/models/desktop/destination_catalog/saas.rb
@@ -5,7 +5,7 @@ module Desktop
         @request = request
       end
 
-      def destinations
+      def peers
         return [] unless Current.global_identity
 
         Current.global_identity.workspace_memberships_ordered.user_active.filter_map do |membership|
@@ -16,8 +16,8 @@ module Desktop
             id: workspace.external_id.to_s,
             name: workspace.name,
             logo_url: logo_url_for(workspace),
-            base_path: workspace.slug,
-            cable_path: cable_path_for(workspace)
+            workspace_url: workspace_url_for(workspace),
+            cable_url: cable_url_for(workspace)
           }
         end
       end
@@ -25,8 +25,13 @@ module Desktop
       private
         attr_reader :request
 
-        def cable_path_for(workspace)
-          "/api/cable?wid=#{workspace.external_id}"
+        def workspace_url_for(workspace)
+          slug = workspace.slug.to_s.delete_prefix("/")
+          "#{request.base_url}/#{slug}"
+        end
+
+        def cable_url_for(workspace)
+          "#{request.base_url}/api/cable?wid=#{workspace.external_id}"
         end
 
         def logo_url_for(workspace)

--- a/saas/app/models/desktop/global_session_claim.rb
+++ b/saas/app/models/desktop/global_session_claim.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Desktop::GlobalSessionClaim < UntenantedRecord
+  self.table_name = "desktop_global_session_claims"
+
+  class Error < StandardError; end
+  class Invalid < Error; end
+  class Replayed < Error; end
+
+  ACTIVE_TTL = 5.minutes
+
+  belongs_to :global_identity
+
+  validates :token_digest, :nonce, :origin, :return_path, :expires_at, presence: true
+
+  scope :valid, -> { where(used_at: nil, expires_at: Time.current..) }
+
+  def self.issue!(global_identity:, nonce:, origin:, return_path:)
+    raw_token = SecureRandom.urlsafe_base64(32)
+    claim = create!(
+      global_identity: global_identity,
+      token_digest: digest(raw_token),
+      nonce: nonce,
+      origin: origin,
+      return_path: return_path,
+      expires_at: ACTIVE_TTL.from_now
+    )
+    claim.raw_token = raw_token
+    claim
+  end
+
+  def self.redeem!(token:, nonce:, origin:)
+    raise Invalid, "claim token missing" if token.blank?
+
+    transaction do
+      record = valid.lock.find_by(token_digest: digest(token))
+      raise Invalid, "claim not found or expired" if record.blank?
+      raise Replayed, "claim already used" if record.used_at.present?
+      raise Invalid, "claim origin mismatch" unless record.origin == origin
+      raise Invalid, "claim nonce mismatch" unless record.nonce == nonce
+
+      record.use!
+      record
+    end
+  end
+
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token)
+  end
+
+  def self.purge_expired
+    where(expires_at: ...Time.current).delete_all
+  end
+
+  attr_accessor :raw_token
+
+  def use!
+    update!(used_at: Time.current)
+  end
+
+  def used?
+    used_at.present?
+  end
+end

--- a/saas/db/untenanted_migrate/20260904183000_create_desktop_global_session_claims.rb
+++ b/saas/db/untenanted_migrate/20260904183000_create_desktop_global_session_claims.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateDesktopGlobalSessionClaims < ActiveRecord::Migration[8.2]
+  def change
+    create_table :desktop_global_session_claims do |t|
+      t.references :global_identity, null: false, foreign_key: true
+      t.string :token_digest, null: false
+      t.string :nonce, null: false
+      t.string :origin, null: false
+      t.string :return_path, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+
+      t.timestamps
+    end
+
+    add_index :desktop_global_session_claims, :token_digest, unique: true
+    add_index :desktop_global_session_claims, :expires_at
+  end
+end

--- a/saas/db/untenanted_schema.rb
+++ b/saas/db/untenanted_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_08_000001) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_04_183000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,21 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_08_000001) do
     t.index ["code"], name: "index_auth_codes_on_code", unique: true
     t.index ["expires_at"], name: "index_auth_codes_on_expires_at"
     t.index ["global_identity_id"], name: "index_auth_codes_on_global_identity_id"
+  end
+
+  create_table "desktop_global_session_claims", force: :cascade do |t|
+    t.bigint "global_identity_id", null: false
+    t.string "token_digest", null: false
+    t.string "nonce", null: false
+    t.string "origin", null: false
+    t.string "return_path", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_desktop_global_session_claims_on_expires_at"
+    t.index ["global_identity_id"], name: "index_desktop_global_session_claims_on_global_identity_id"
+    t.index ["token_digest"], name: "index_desktop_global_session_claims_on_token_digest", unique: true
   end
 
   create_table "global_identities", force: :cascade do |t|
@@ -110,6 +125,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_08_000001) do
   end
 
   add_foreign_key "auth_codes", "global_identities"
+  add_foreign_key "desktop_global_session_claims", "global_identities"
   add_foreign_key "global_sessions", "global_identities"
   add_foreign_key "workspace_memberships", "global_identities"
   add_foreign_key "workspace_snapshots", "workspaces"

--- a/saas/test/controllers/api/desktop/destinations_controller_test.rb
+++ b/saas/test/controllers/api/desktop/destinations_controller_test.rb
@@ -17,9 +17,9 @@ module Saas
 
       assert_response :success
       body = JSON.parse(response.body)
-      ids = body["destinations"].map { |d| d["id"] }
+      ids = body["peers"].map { |d| d["id"] }
       assert_equal [ "1000001", "1000003" ], ids
-      assert_equal "/api/cable?wid=1000001", body["destinations"].first["cable_path"]
+      assert_includes body["peers"].first["cable_url"], "/api/cable?wid=1000001"
       refute_includes ids, "1000004"
     end
 

--- a/saas/test/controllers/api/desktop/destinations_controller_test.rb
+++ b/saas/test/controllers/api/desktop/destinations_controller_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+
+module Saas
+  class API::Desktop::DestinationsSaasControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      [ workspaces(:acme), workspaces(:shared), workspaces(:suspended) ].each do |workspace|
+        tenant_id = workspace.external_id.to_s
+        ApplicationRecord.create_tenant(tenant_id) unless ApplicationRecord.tenant_exist?(tenant_id)
+      end
+      sign_in_global_identity(global_identities(:alice))
+    end
+
+    test "returns ordered active workspace peers with tenant cable paths" do
+      get "/api/desktop/destinations", headers: desktop_headers
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      ids = body["destinations"].map { |d| d["id"] }
+      assert_equal [ "1000001", "1000003" ], ids
+      assert_equal "/api/cable?wid=1000001", body["destinations"].first["cable_path"]
+      refute_includes ids, "1000004"
+    end
+
+    test "is unauthorized without a global session" do
+      reset!
+
+      get "/api/desktop/destinations", headers: desktop_headers
+
+      assert_response :unauthorized
+    end
+
+    private
+      def desktop_headers
+        { "Sabha-Desktop-Protocol-Major" => "1" }
+      end
+  end
+end

--- a/saas/test/controllers/api/desktop/session_claims_controller_test.rb
+++ b/saas/test/controllers/api/desktop/session_claims_controller_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+
+module Saas
+  class API::Desktop::SessionClaimsSaasControllerTest < ActionDispatch::IntegrationTest
+    test "redeems a valid global claim once and establishes a global session" do
+      identity = global_identities(:alice)
+      claim = Desktop::GlobalSessionClaim.issue!(
+        global_identity: identity,
+        nonce: "saas-nonce",
+        origin: "https://www.example.com",
+        return_path: "/workspaces"
+      )
+
+      post "/api/desktop/session_claim",
+        params: { token: claim.raw_token, nonce: "saas-nonce", origin: "https://www.example.com" },
+        headers: desktop_headers
+
+      assert_response :success
+      assert_equal "/workspaces", JSON.parse(response.body)["return_path"]
+      assert cookies[:global_session_token].present?
+      assert claim.reload.used?
+    end
+
+    test "rejects a replayed global claim" do
+      identity = global_identities(:alice)
+      claim = Desktop::GlobalSessionClaim.issue!(
+        global_identity: identity,
+        nonce: "replay-nonce",
+        origin: "https://www.example.com",
+        return_path: "/"
+      )
+      params = { token: claim.raw_token, nonce: "replay-nonce", origin: "https://www.example.com" }
+
+      post "/api/desktop/session_claim", params: params, headers: desktop_headers
+      assert_response :success
+
+      post "/api/desktop/session_claim", params: params, headers: desktop_headers
+      assert_response :forbidden
+    end
+
+    private
+      def desktop_headers
+        { "Sabha-Desktop-Protocol-Major" => "1", "Sabha-Desktop-Client" => "1" }
+      end
+  end
+end

--- a/saas/test/controllers/desktop_rendering_test.rb
+++ b/saas/test/controllers/desktop_rendering_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Saas
+  class DesktopRenderingTest < ActionDispatch::IntegrationTest
+    setup do
+      workspace = workspaces(:acme)
+      tenant_id = workspace.external_id.to_s
+      ApplicationRecord.create_tenant(tenant_id) unless ApplicationRecord.tenant_exist?(tenant_id)
+      sign_in_global_identity(global_identities(:alice))
+    end
+
+    test "desktop client requests omit the in-page workspace selector" do
+      workspace_get "/", workspace: workspaces(:acme), headers: { "Sabha-Desktop-Client" => "1" }
+
+      assert_response :success
+      assert_select "aside.workspace-selector", count: 0
+    end
+
+    test "browser requests still render the workspace selector" do
+      workspace_get "/", workspace: workspaces(:acme)
+
+      assert_response :success
+      assert_select "aside.workspace-selector", count: 1
+    end
+  end
+end

--- a/saas/test/controllers/saas/desktop_handoff_test.rb
+++ b/saas/test/controllers/saas/desktop_handoff_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module Saas
+  class DesktopHandoffTest < ActionDispatch::IntegrationTest
+    setup do
+      @original_clients = ENV["SSO_PROVIDER_CLIENTS"]
+      @original_return_host = ENV["SSO_CLOUD_RETURN_HOST"]
+      @original_return_path = ENV["SSO_CLOUD_RETURN_PATH"]
+      @original_secret = ENV["SSO_CLOUD_SECRET"]
+
+      ENV["SSO_PROVIDER_CLIENTS"] = "cloud"
+      ENV["SSO_CLOUD_RETURN_HOST"] = "cloud.sabha.co"
+      ENV["SSO_CLOUD_RETURN_PATH"] = "/session/sso/callback"
+      ENV["SSO_CLOUD_SECRET"] = "cloud-sso-secret"
+    end
+
+    teardown do
+      restore_env("SSO_PROVIDER_CLIENTS", @original_clients)
+      restore_env("SSO_CLOUD_RETURN_HOST", @original_return_host)
+      restore_env("SSO_CLOUD_RETURN_PATH", @original_return_path)
+      restore_env("SSO_CLOUD_SECRET", @original_secret)
+    end
+
+    test "signed-in desktop handoff on session sso returns a one-time claim deep link" do
+      identity = global_identities(:alice)
+      sign_in_global_identity(identity)
+      sso, sig = provider_request
+
+      assert_difference -> { Desktop::GlobalSessionClaim.count }, 1 do
+        get "/session/sso",
+          params: {
+            sso: sso,
+            sig: sig,
+            desktop_handoff: "1",
+            desktop_nonce: "cloud-nonce",
+            desktop_origin: "https://www.example.com",
+            return_to: "/workspaces"
+          }
+      end
+
+      assert_redirected_to %r{\Asabha://session-claim\?}
+      claim = Desktop::GlobalSessionClaim.last
+      assert_equal identity, claim.global_identity
+      assert_equal "cloud-nonce", claim.nonce
+      assert_equal "https://www.example.com", claim.origin
+    end
+
+    private
+      def provider_request(attributes = {})
+        Sso::Payload.encode({
+          nonce: "provider-nonce",
+          return_sso_url: "https://cloud.sabha.co/session/sso/callback"
+        }.merge(attributes), ENV["SSO_CLOUD_SECRET"])
+      end
+
+      def restore_env(key, value)
+        if value.nil?
+          ENV.delete(key)
+        else
+          ENV[key] = value
+        end
+      end
+  end
+end

--- a/test/controllers/api/desktop/destinations_controller_test.rb
+++ b/test/controllers/api/desktop/destinations_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class API::Desktop::DestinationsControllerTest < ActionDispatch::IntegrationTest
+  setup { host! "once.sabha.test" }
+
+  test "returns one branded destination with cable discovery path when signed in" do
+    sign_in :david
+
+    get "/api/desktop/destinations", headers: desktop_headers
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 1, body["protocol_major"]
+    assert_equal 1, body["destinations"].length
+
+    destination = body["destinations"].first
+    assert_equal "default", destination["id"]
+    assert_equal Account.sole.name, destination["name"]
+    assert_equal "/", destination["base_path"]
+    assert_equal "/api/cable", destination["cable_path"]
+  end
+
+  test "is unauthorized without a session" do
+    get "/api/desktop/destinations", headers: desktop_headers
+
+    assert_response :unauthorized
+    refute JSON.parse(response.body).key?("destinations")
+  end
+
+  private
+    def desktop_headers
+      { "Sabha-Desktop-Protocol-Major" => "1" }
+    end
+end

--- a/test/controllers/api/desktop/destinations_controller_test.rb
+++ b/test/controllers/api/desktop/destinations_controller_test.rb
@@ -11,20 +11,20 @@ class API::Desktop::DestinationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal 1, body["protocol_major"]
-    assert_equal 1, body["destinations"].length
+    assert_equal 1, body["peers"].length
 
-    destination = body["destinations"].first
-    assert_equal "default", destination["id"]
-    assert_equal Account.sole.name, destination["name"]
-    assert_equal "/", destination["base_path"]
-    assert_equal "/api/cable", destination["cable_path"]
+    peer = body["peers"].first
+    assert_equal "default", peer["id"]
+    assert_equal Account.sole.name, peer["name"]
+    assert peer["workspace_url"].end_with?("/")
+    assert peer["cable_url"].end_with?("/api/cable")
   end
 
   test "is unauthorized without a session" do
     get "/api/desktop/destinations", headers: desktop_headers
 
     assert_response :unauthorized
-    refute JSON.parse(response.body).key?("destinations")
+    refute JSON.parse(response.body).key?("peers")
   end
 
   private

--- a/test/controllers/api/desktop/manifests_controller_test.rb
+++ b/test/controllers/api/desktop/manifests_controller_test.rb
@@ -10,6 +10,9 @@ class API::Desktop::ManifestsControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_equal 1, body["protocol_major"]
     assert_equal Branding.app_name, body.dig("product", "name")
+    assert_equal Branding.app_short_name, body.dig("product", "short_name")
+    assert_equal Branding.app_short_name.to_s.parameterize.presence || "sabha", body.dig("product", "slug")
+    assert_equal "/api/desktop/destinations", body["destinations_path"]
     assert body["sign_in_path"].present?
     refute body.key?("destinations")
     refute body.key?("members")

--- a/test/controllers/api/desktop/manifests_controller_test.rb
+++ b/test/controllers/api/desktop/manifests_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class API::Desktop::ManifestsControllerTest < ActionDispatch::IntegrationTest
+  setup { host! "once.sabha.test" }
+
+  test "returns protocol version 1 product identity and sign-in path without authentication" do
+    get "/api/desktop/manifest", headers: desktop_headers
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 1, body["protocol_major"]
+    assert_equal Branding.app_name, body.dig("product", "name")
+    assert body["sign_in_path"].present?
+    refute body.key?("destinations")
+    refute body.key?("members")
+  end
+
+  test "refuses unsupported protocol majors with upgrade guidance" do
+    get "/api/desktop/manifest", headers: { "Sabha-Desktop-Protocol-Major" => "99" }
+
+    assert_response :unsupported_media_type
+    body = JSON.parse(response.body)
+    assert_equal "unsupported_protocol_major", body["error"]
+    assert_equal 1, body["supported_major"]
+    assert body["upgrade_url"].present?
+  end
+
+  private
+    def desktop_headers
+      { "Sabha-Desktop-Protocol-Major" => "1" }
+    end
+end

--- a/test/controllers/api/desktop/session_claims_controller_test.rb
+++ b/test/controllers/api/desktop/session_claims_controller_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class API::Desktop::SessionClaimsControllerTest < ActionDispatch::IntegrationTest
+  setup { host! "once.sabha.test" }
+
+  test "redeems a valid claim once and establishes a session" do
+    user = users(:david)
+    claim = Desktop::SessionClaim.issue!(
+      user: user,
+      nonce: "nonce-abc",
+      origin: "https://once.sabha.test",
+      return_path: "/chat"
+    )
+
+    post "/api/desktop/session_claim",
+      params: { token: claim.raw_token, nonce: "nonce-abc", origin: "https://once.sabha.test" },
+      headers: desktop_headers
+
+    assert_response :success
+    assert_equal "/chat", JSON.parse(response.body)["return_path"]
+    assert parsed_cookies.signed[:session_token]
+    assert claim.reload.used?
+  end
+
+  test "rejects a replayed claim" do
+    user = users(:david)
+    claim = Desktop::SessionClaim.issue!(
+      user: user,
+      nonce: "nonce-replay",
+      origin: "https://once.sabha.test",
+      return_path: "/"
+    )
+    params = { token: claim.raw_token, nonce: "nonce-replay", origin: "https://once.sabha.test" }
+
+    post "/api/desktop/session_claim", params: params, headers: desktop_headers
+    assert_response :success
+
+    post "/api/desktop/session_claim", params: params, headers: desktop_headers
+    assert_response :forbidden
+  end
+
+  test "does not persist the raw bearer token" do
+    user = users(:david)
+    claim = Desktop::SessionClaim.issue!(
+      user: user,
+      nonce: "nonce-digest",
+      origin: "https://once.sabha.test",
+      return_path: "/"
+    )
+
+    assert claim.raw_token.present?
+    assert_equal Desktop::SessionClaim.digest(claim.raw_token), claim.token_digest
+    refute Desktop::SessionClaim.column_names.include?("token")
+  end
+
+  private
+    def desktop_headers
+      { "Sabha-Desktop-Protocol-Major" => "1", "Sabha-Desktop-Client" => "1" }
+    end
+end

--- a/test/controllers/desktop_rendering_test.rb
+++ b/test/controllers/desktop_rendering_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class DesktopRenderingTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "once.sabha.test"
+    sign_in :david
+  end
+
+  test "desktop client requests omit webpush enrollment ui" do
+    get user_sidebar_url(user_id: "me"), headers: { "Sabha-Desktop-Client" => "1" }
+
+    assert_response :success
+    assert_select "#notification_bell_container", count: 0
+  end
+
+  test "browser requests still render webpush enrollment ui" do
+    get user_sidebar_url(user_id: "me")
+
+    assert_response :success
+    assert_select "#notification_bell_container", count: 1
+  end
+end

--- a/test/controllers/sso/desktop_handoff_test.rb
+++ b/test/controllers/sso/desktop_handoff_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class Sso::DesktopHandoffTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "once.sabha.test"
+    ENV["AUTH_METHOD"] = "sso"
+    ENV["SSO_PROVIDER_URL"] = "https://sso.example.com/session/sso"
+    ENV["SSO_SECRET"] = "test-sso-secret"
+  end
+
+  teardown do
+    ENV.delete("AUTH_METHOD")
+    ENV.delete("SSO_PROVIDER_URL")
+    ENV.delete("SSO_SECRET")
+  end
+
+  test "successful sso callback with desktop handoff redirects to a one-time claim deep link" do
+    get sso_handshake_url,
+      params: {
+        desktop_handoff: "1",
+        desktop_nonce: "handoff-nonce",
+        desktop_origin: "https://once.sabha.test",
+        return_to: "/chat"
+      }
+    assert_response :success
+
+    nonce = session["single_sign_on_nonce"]
+    payload = {
+      nonce: nonce,
+      external_id: single_sign_on_records(:david).external_id,
+      email: users(:david).email_address,
+      name: users(:david).name
+    }
+    sso, sig = Sso::Payload.encode(payload, ENV["SSO_SECRET"])
+
+    assert_difference -> { Desktop::SessionClaim.count }, 1 do
+      get sso_callback_url, params: { sso: sso, sig: sig }
+    end
+
+    assert_redirected_to %r{\Asabha://session-claim\?}
+    claim = Desktop::SessionClaim.last
+    assert_equal "handoff-nonce", claim.nonce
+    assert_equal "https://once.sabha.test", claim.origin
+    assert_equal "/chat", claim.return_path
+  end
+
+  test "browser sso without desktop handoff still sets a session cookie" do
+    get sso_handshake_url
+    assert_response :success
+
+    nonce = session["single_sign_on_nonce"]
+    payload = {
+      nonce: nonce,
+      external_id: single_sign_on_records(:david).external_id,
+      email: users(:david).email_address,
+      name: users(:david).name
+    }
+    sso, sig = Sso::Payload.encode(payload, ENV["SSO_SECRET"])
+
+    get sso_callback_url, params: { sso: sso, sig: sig }
+
+    assert_redirected_to root_url
+    assert parsed_cookies.signed[:session_token]
+    assert_empty Desktop::SessionClaim.valid
+  end
+end


### PR DESCRIPTION
## Why

The Sabha desktop shell needs a server-owned protocol surface before it can discover sign-in paths, enumerate workspace destinations, and redeem one-time SSO session claims. This PR adds protocol major 1 to `sabha` so the Electron client (PR-U3+) can negotiate compatibility, fetch catalogs, and establish isolated destination sessions without changing existing browser auth semantics.

## Scope

- **`GET /api/desktop/manifest`** — unauthenticated probe returning protocol major, product identity, and sign-in path
- **`GET /api/desktop/destinations`** — authenticated destination catalog (single branded origin self-hosted; ordered active workspaces in SaaS)
- **`POST /api/desktop/session_claim`** — one-time claim redeem with SHA256 digest storage (AuthToken pattern); no raw token persisted
- **SSO desktop handoff** — self-hosted SSO callback and SaaS `/session/sso` issue `sabha://session-claim` deep links after successful auth
- **Desktop layout detection** — `Sabha-Desktop-Client` header hides in-page SaaS workspace rail and WebPush enrollment UI; browser behavior unchanged
- **Migrations** — `desktop_session_claims` (tenant DB) and `desktop_global_session_claims` (untenanted SaaS DB)
- **Docs** — `docs/features/DESKTOP.md` plus deployment notes

## Tradeoffs

- Desktop client detection uses an explicit request header rather than User-Agent sniffing, keeping browser behavior unchanged when the header is absent
- Session claims are one-time and short-lived (5 minutes) rather than long-lived refresh tokens, trading convenience for replay resistance
- SSO handoff context is captured before `reset_session` in the callback so claim issuance survives session fixation prevention
- WebPush bell omission lives in the bell partial (driven by `desktop_client?`) rather than the sidebar shell, because `assert_select` requires DOM absence not CSS hiding

## Blast Radius

- New `/api/desktop/*` routes only; existing `/api/cable` and bot API untouched
- `AuthToken` / `AuthCode` semantics unchanged — claims are a separate model with digest-only storage
- SSO and browser sign-in paths unchanged when desktop handoff params are absent
- SaaS workspace selector and self-hosted WebPush UI still render for normal browser requests
- Two new tables with TTL-friendly indexes; no backfill required

## Verification

**Self-hosted**
```
bin/rails test test/controllers/api/desktop/ test/controllers/sso/desktop_handoff_test.rb test/controllers/desktop_rendering_test.rb
```
11 runs, 47 assertions, 0 failures

**SaaS**
```
SAAS=true bin/rails test saas/test/controllers/api/desktop/ saas/test/controllers/desktop_rendering_test.rb saas/test/controllers/saas/desktop_handoff_test.rb
```
7 runs, 22 assertions, 0 failures


Made with [Cursor](https://cursor.com)