### PR TITLE
Let agents finish an email-code sign-in without touching mail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Sabha is a Ruby on Rails chat application using Hotwire/Turbo, AnyCable-Go, Tail
 - `bin/rails test` — run self-hosted tests.
 - `bin/rails test test/models/user_test.rb` — run one self-hosted test file.
 - `SAAS=true bin/rails test saas/test/` — run SaaS test suite.
+- `bin/latest-otp [email]` — development only: print the newest unused, unexpired sign-in code from the database (`AuthToken`, or `AuthCode` with `SAAS=true`) so an agent can finish an email-code sign-in without reading mail. Self-hosted defaults to password auth, and the seed accounts `ashwin@sabha.co` (administrator), `jason@sabha.co`, and `david@sabha.co` all use the password `password`.
 - `pnpm run build:css:watch` — rebuild Tailwind CSS continuously.
 - Enable SaaS with `bin/rails saas:enable && bundle install && bin/rails saas:setup`; disable it with `bin/rails saas:disable && bundle install`.
 - When changing gems in `Gemfile`, also run `BUNDLE_GEMFILE=Gemfile.saas bundle install` to keep both lockfiles synchronized.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Sabha is a Ruby on Rails chat application using Hotwire/Turbo, AnyCable-Go, Tail
 - `bin/rails test` — run self-hosted tests.
 - `bin/rails test test/models/user_test.rb` — run one self-hosted test file.
 - `SAAS=true bin/rails test saas/test/` — run SaaS test suite.
-- `bin/latest-otp [email]` — development only: print the newest unused, unexpired sign-in code from the database (`AuthToken`, or `AuthCode` with `SAAS=true`) so an agent can finish an email-code sign-in without reading mail. Self-hosted defaults to password auth, and the seed accounts `ashwin@sabha.co` (administrator), `jason@sabha.co`, and `david@sabha.co` all use the password `password`.
+- `bin/latest-otp [email]` — development only: print the newest unused, unexpired sign-in code from the database (`AuthToken`, or `AuthCode` with `SAAS=true`) so an agent can finish an email-code sign-in without reading mail. Submit the address on the sign-in page from a headless browser (Ferrum, Playwright, Puppeteer), run the script, and paste the code into the first code cell. Development mail previews in a browser tab for a person, but a code requested from a headless browser is only written under `tmp/letter_opener`, so an agent signing in never pops a tab in front of whoever is at the machine. Self-hosted defaults to password auth, and the seed accounts `ashwin@sabha.co` (administrator), `jason@sabha.co`, and `david@sabha.co` all use the password `password`.
 - `pnpm run build:css:watch` — rebuild Tailwind CSS continuously.
 - Enable SaaS with `bin/rails saas:enable && bundle install && bin/rails saas:setup`; disable it with `bin/rails saas:disable && bundle install`.
 - When changing gems in `Gemfile`, also run `BUNDLE_GEMFILE=Gemfile.saas bundle install` to keep both lockfiles synchronized.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ bin/latest-otp jason@sabha.co   # newest unused, unexpired code for that address
 SAAS=true bin/latest-otp        # SaaS: newest valid AuthCode as "email<TAB>code"
 ```
 
-Paste it into the first code cell (the field spreads a paste across all six) and click Verify. Codes are one-shot and expire after 15 minutes. Development mail previews in a browser tab for a person, but a code requested from a headless browser (Ferrum, Playwright, Puppeteer) is only written under `tmp/letter_opener`, so an agent signing in never pops a tab in front of whoever is at the machine. Read codes from the database, not the mail files.
+Paste it into the first code cell (the field spreads a paste across all six) and click Verify. Codes are one-shot and expire after 15 minutes. Development mail previews in a browser tab for a person, but a code requested from a headless browser (Ferrum, Playwright, Puppeteer) is only written under `tmp/letter_opener`, so an agent signing in never pops a tab in front of whoever is at the machine. Read codes from the database, not the mail files. The code also appears in `log/development.log` at debug level, as part of the rendered mail; treat that as a fallback, since the log holds every code ever sent and the mail is delivered by a background job after the redirect.
 
 ### SaaS Dual Database Setup
 - **Untenanted (PostgreSQL):** `GlobalIdentity`, `Workspace`, `WorkspaceMembership`, `GlobalSession`. Models inherit from `UntenantedRecord`. Migrations in `saas/db/untenanted_migrate/`, schema in `saas/db/untenanted_schema.rb`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,16 @@ SAAS=true bin/rails test saas/test/      # SaaS test suite
 
 After implementing changes, run the relevant test suite to verify. For SaaS changes, run both.
 
+### Signing in as an agent
+Self-hosted defaults to `AUTH_METHOD=password`. Seed accounts from `bin/rails db:seed` are `ashwin@sabha.co` (administrator), `jason@sabha.co`, and `david@sabha.co`, all with password `password`; use them for UI work and role switching. When a task needs the email-code flow (the OTP screen, the code mail, or any SaaS sign-in, which is OTP-only), submit the email on the sign-in page, then read the code from the database instead of the mail:
+
+```bash
+bin/latest-otp jason@sabha.co   # newest unused, unexpired code for that address
+SAAS=true bin/latest-otp        # SaaS: newest valid AuthCode as "email<TAB>code"
+```
+
+Paste it into the first code cell (the field spreads a paste across all six) and click Verify. Codes are one-shot and expire after 15 minutes. Never open the letter_opener window: development mail pops it in a browser an agent can't read reliably.
+
 ### SaaS Dual Database Setup
 - **Untenanted (PostgreSQL):** `GlobalIdentity`, `Workspace`, `WorkspaceMembership`, `GlobalSession`. Models inherit from `UntenantedRecord`. Migrations in `saas/db/untenanted_migrate/`, schema in `saas/db/untenanted_schema.rb`.
 - **Tenanted (SQLite per workspace):** All app models (`User`, `Room`, `Message`, etc.) inherit from `ApplicationRecord`. Each workspace gets its own SQLite database at `storage/workspaces/{env}/{tenant}/db/main.sqlite3`. Standard migrations in `db/migrate/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ bin/latest-otp jason@sabha.co   # newest unused, unexpired code for that address
 SAAS=true bin/latest-otp        # SaaS: newest valid AuthCode as "email<TAB>code"
 ```
 
-Paste it into the first code cell (the field spreads a paste across all six) and click Verify. Codes are one-shot and expire after 15 minutes. Never open the letter_opener window: development mail pops it in a browser an agent can't read reliably.
+Paste it into the first code cell (the field spreads a paste across all six) and click Verify. Codes are one-shot and expire after 15 minutes. Development mail previews in a browser tab for a person, but a code requested from a headless browser (Ferrum, Playwright, Puppeteer) is only written under `tmp/letter_opener`, so an agent signing in never pops a tab in front of whoever is at the machine. Read codes from the database, not the mail files.
 
 ### SaaS Dual Database Setup
 - **Untenanted (PostgreSQL):** `GlobalIdentity`, `Workspace`, `WorkspaceMembership`, `GlobalSession`. Models inherit from `UntenantedRecord`. Migrations in `saas/db/untenanted_migrate/`, schema in `saas/db/untenanted_schema.rb`.

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -16,7 +16,7 @@ class AuthTokensController < ApplicationController
     session[:otp_email_address] = params[:email_address]
 
     auth_token = @user.auth_tokens.create!(expires_at: 15.minutes.from_now)
-    auth_token.deliver_later
+    auth_token.deliver_later(automated: platform.automated?)
 
     redirect_to new_auth_tokens_validations_path
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
+  # Set on mail a script asked for (a headless browser signing in, say) so the
+  # development preview can stay out of the browser of the person at the desk.
+  AUTOMATED_CLIENT_HEADER = "X-Sabha-Automated-Client"
+
   default from: -> { Branding.mailer_from },
           "X-SES-DISABLE-TRACKING" => "true"
   layout "mailer"
@@ -16,6 +20,10 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   private
+    def mark_automated_client(automated)
+      headers[AUTOMATED_CLIENT_HEADER] = "true" if automated
+    end
+
     def skip_in_demo_mode
       mail.perform_deliveries = false if DemoMode.enabled?
     end

--- a/app/mailers/auth_token_mailer.rb
+++ b/app/mailers/auth_token_mailer.rb
@@ -1,6 +1,7 @@
 class AuthTokenMailer < ApplicationMailer
-  def otp(auth_token)
+  def otp(auth_token, automated: false)
     @otp_code = auth_token.code
+    mark_automated_client(automated)
 
     mail(to: auth_token.user.email_address, subject: "Your sign-in code for #{Branding.contextual_app_name}")
   end

--- a/app/models/application_platform.rb
+++ b/app/models/application_platform.rb
@@ -38,6 +38,12 @@ class ApplicationPlatform < PlatformAgent
     ios? || android?
   end
 
+  # A browser driven by a script rather than a person: headless Chrome (Ferrum,
+  # Cuprite, Playwright, Puppeteer) and the WebDriver family all say so.
+  def automated?
+    match?(/HeadlessChrome|Puppeteer|Playwright|Selenium|WebDriver/i)
+  end
+
   def desktop?
     !mobile?
   end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -18,8 +18,8 @@ class AuthToken < ApplicationRecord
 
   scope :valid, -> { where(used_at: nil, expires_at: Time.current..) }
 
-  def deliver_later
-    AuthTokenMailer.otp(self).deliver_later
+  def deliver_later(automated: false)
+    AuthTokenMailer.otp(self, automated: automated).deliver_later
   end
 
   def use!

--- a/bin/latest-otp
+++ b/bin/latest-otp
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Print the newest unused, unexpired sign-in code so an agent (or a person at a
+# terminal) can finish an email-code sign-in without opening the mail.
+# Development and test only; it reads the local database, never production.
+#
+#   bin/latest-otp <email>   prints the six-character code for that address
+#   bin/latest-otp           prints "<email>\t<code>" for the newest valid code
+#
+# Self-hosted reads AuthToken. SaaS (SAAS=true) reads AuthCode on the untenanted
+# database. Exit 1 when there is no valid code: request one first by submitting
+# the email on the sign-in page.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec bin/rails runner - "$@" <<'RUBY'
+abort "latest-otp: development and test only" unless Rails.env.development? || Rails.env.test?
+
+email = ARGV.first.to_s.strip.downcase.presence
+
+if Sabha.saas?
+  scope = AuthCode.active.joins(:global_identity)
+  scope = scope.where(global_identities: { email_address: email }) if email
+  row = scope.order(id: :desc).first
+  found = row && [ row.global_identity.email_address, row.code ]
+else
+  scope = AuthToken.valid.joins(:user)
+  scope = scope.where(users: { email_address: email }) if email
+  row = scope.order(id: :desc).first
+  found = row && [ row.user.email_address, row.code ]
+end
+
+unless found
+  who = email || "any address"
+  abort "latest-otp: no unused, unexpired code for #{who}. Submit the email on the sign-in page first."
+end
+
+puts email ? found.last : found.join("\t")
+RUBY

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,11 +37,18 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
-  # Configure Action Mailer for development with letter_opener
+  # Mail previews open in the browser as usual, except mail that a script asked
+  # for (an agent signing in through a headless browser), which is only written
+  # under tmp/letter_opener so it never pops a tab in front of a person.
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  config.after_initialize do
+    require "rails_ext/letter_opener_quiet_for_automated_clients"
+    ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::QuietForAutomatedClients
+  end
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load

--- a/config/initializers/00_boot_mode.rb
+++ b/config/initializers/00_boot_mode.rb
@@ -51,9 +51,10 @@ Rails.application.config.after_initialize do
   end
 
   if Rails.env.local?
-    puts ""
-    puts "  Sabha running in #{mode} mode"
-    puts ""
+    # stderr, so scripts that capture stdout (bin/latest-otp, runner one-liners) stay clean
+    $stderr.puts ""
+    $stderr.puts "  Sabha running in #{mode} mode"
+    $stderr.puts ""
   else
     Rails.logger.info "[Sabha] Running in #{mode} mode"
   end

--- a/lib/rails_ext/letter_opener_quiet_for_automated_clients.rb
+++ b/lib/rails_ext/letter_opener_quiet_for_automated_clients.rb
@@ -1,0 +1,16 @@
+# letter_opener that keeps the browser closed for mail an automated client
+# asked for. The mailer marks such mail with ApplicationMailer::AUTOMATED_CLIENT_HEADER;
+# everything else previews in a tab exactly as the gem does.
+require "letter_opener"
+
+module LetterOpener
+  class QuietForAutomatedClients < DeliveryMethod
+    def deliver!(mail)
+      return super unless mail[ApplicationMailer::AUTOMATED_CLIENT_HEADER]
+
+      validate_mail!(mail)
+      location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr(".", "_")}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
+      Message.rendered_messages(mail, location: location, message_template: settings[:message_template])
+    end
+  end
+end

--- a/saas/app/controllers/saas/base_controller.rb
+++ b/saas/app/controllers/saas/base_controller.rb
@@ -18,6 +18,7 @@ module Saas
 
     include Saas::Authentication
     include SetCurrentRequest
+    include SetPlatform
 
     # Include core helpers for consistent UI (icon_tag, translation_button, etc.)
     helper ApplicationHelper

--- a/saas/app/controllers/saas/registrations_controller.rb
+++ b/saas/app/controllers/saas/registrations_controller.rb
@@ -28,12 +28,12 @@ module Saas
       if global_identity
         # Name intentionally ignored for existing accounts (anti-enumeration)
         auth_code = global_identity.auth_codes.create!(purpose: :sign_in)
-        auth_code.deliver_later
+        auth_code.deliver_later(automated: platform.automated?)
       else
         # New account - create and send verification code
         global_identity = GlobalIdentity.create!(name: params[:name], email_address: params[:email_address], terms_of_service: params[:terms_of_service])
         auth_code = global_identity.auth_codes.create!(purpose: :sign_up)
-        auth_code.deliver_later
+        auth_code.deliver_later(automated: platform.automated?)
       end
 
       # Don't reveal whether email exists (prevent email enumeration)

--- a/saas/app/controllers/saas/sessions_controller.rb
+++ b/saas/app/controllers/saas/sessions_controller.rb
@@ -27,7 +27,7 @@ module Saas
       if global_identity
         # Existing account - send auth code
         auth_code = global_identity.auth_codes.create!(purpose: :sign_in)
-        auth_code.deliver_later
+        auth_code.deliver_later(automated: platform.automated?)
       end
       # Don't reveal whether email exists (prevent email enumeration)
       # Show same message regardless of whether account exists

--- a/saas/app/mailers/auth_code_mailer.rb
+++ b/saas/app/mailers/auth_code_mailer.rb
@@ -9,8 +9,9 @@ class AuthCodeMailer < ApplicationMailer
   #
   # Used for sign-in, sign-up, and email change verification
 
-  def code(auth_code)
+  def code(auth_code, automated: false)
     @auth_code = auth_code
+    mark_automated_client(automated)
     @code = auth_code.code
     @global_identity = auth_code.global_identity
 

--- a/saas/app/models/auth_code.rb
+++ b/saas/app/models/auth_code.rb
@@ -37,8 +37,8 @@ class AuthCode < UntenantedRecord
     global_identity.tap { destroy }
   end
 
-  def deliver_later
-    AuthCodeMailer.code(self).deliver_later
+  def deliver_later(automated: false)
+    AuthCodeMailer.code(self, automated: automated).deliver_later
   end
 
   def expired?

--- a/saas/test/controllers/saas/sessions_controller_test.rb
+++ b/saas/test/controllers/saas/sessions_controller_test.rb
@@ -55,6 +55,15 @@ module Saas
       assert_equal "If this email is registered, you'll receive a sign-in code", flash[:notice]
     end
 
+    test "a code requested from a headless browser is marked as automated" do
+      perform_enqueued_jobs do
+        post session_path, params: { email_address: global_identities(:alice).email_address },
+          headers: { "User-Agent" => "Mozilla/5.0 HeadlessChrome/128.0.0.0 Safari/537.36" }
+      end
+
+      assert_equal "true", ActionMailer::Base.deliveries.last[ApplicationMailer::AUTOMATED_CLIENT_HEADER].value
+    end
+
     test "create does not create identity for unknown email (prevents enumeration)" do
       # Login should NOT create new identities - that's what registration is for
       assert_no_difference "GlobalIdentity.count" do

--- a/test/controllers/auth_tokens_controller_test.rb
+++ b/test/controllers/auth_tokens_controller_test.rb
@@ -24,6 +24,24 @@ class AuthTokensControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_auth_tokens_validations_url
   end
 
+  test "a code requested from a headless browser is marked as automated" do
+    perform_enqueued_jobs do
+      post auth_tokens_url, params: { email_address: users(:david).email_address },
+        headers: { "User-Agent" => "Mozilla/5.0 HeadlessChrome/128.0.0.0 Safari/537.36" }
+    end
+
+    assert_equal "true", ActionMailer::Base.deliveries.last[ApplicationMailer::AUTOMATED_CLIENT_HEADER].value
+  end
+
+  test "a code requested from a desktop browser is not marked as automated" do
+    perform_enqueued_jobs do
+      post auth_tokens_url, params: { email_address: users(:david).email_address },
+        headers: { "User-Agent" => "Mozilla/5.0 Chrome/128.0.0.0 Safari/537.36" }
+    end
+
+    assert_nil ActionMailer::Base.deliveries.last[ApplicationMailer::AUTOMATED_CLIENT_HEADER]
+  end
+
   test "create with unknown email redirects with error" do
     post auth_tokens_url, params: { email_address: "unknown@example.com" }
 

--- a/test/models/application_platform_test.rb
+++ b/test/models/application_platform_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class ApplicationPlatformTest < ActiveSupport::TestCase
+  test "a headless browser is an automated client" do
+    headless = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/128.0.0.0 Safari/537.36"
+
+    assert ApplicationPlatform.new(headless).automated?
+  end
+
+  test "a desktop browser is not an automated client" do
+    chrome = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
+
+    assert_not ApplicationPlatform.new(chrome).automated?
+  end
+end


### PR DESCRIPTION
## Why

Agents working on Sabha in development need to sign in through the email-code flow, self-hosted or SaaS. Until now the only place the code appeared was the letter_opener preview, which pops a tab in the browser of whoever is sitting at the machine and is unreliable for an agent to read.

## What changes

- `bin/latest-otp [email]` prints the newest unused, unexpired sign-in code straight from the database (`AuthToken`, or `AuthCode` with `SAAS=true`). Development and test only. The boot-mode banner moves to stderr so the script's stdout is just the code.
- A code requested from a headless browser (Ferrum, Playwright, Puppeteer, WebDriver) is marked as automated on the way out: the platform detects it from the user agent, the OTP controllers pass it to the model's delivery, and the mailer stamps a header so the fact survives the background job.
- In development, letter_opener still previews every mail in a tab for a person, but mail carrying that header is only written under `tmp/letter_opener`. An agent signing in never interrupts the human, and the human's own flow is unchanged.
- CLAUDE.md and AGENTS.md document the flow: submit the address from a headless browser, run the script, paste the code into the first code cell.

## Verified

- Development, with Launchy in dry-run so a launch shows as output: the automated mail produced no launch, the human mail launched the preview, both files were written.
- Tests cover the platform check, the self-hosted OTP controller (header present for a headless UA, absent for a desktop one), and the SaaS sessions controller.

One known limit: an agent driving a real Chrome through a browser extension is indistinguishable from the person, so that path still opens the tab. Every headless route stays quiet, and `bin/latest-otp` works either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)