### PR TITLE
Extract bot event dispatch from controllers

### DIFF
--- a/app/controllers/concerns/notify_bots.rb
+++ b/app/controllers/concerns/notify_bots.rb
@@ -1,33 +1,8 @@
 module NotifyBots
   extend ActiveSupport::Concern
 
-  def notify_bots(item, event)
-    base_url = request.base_url + request.script_name
-    room = item.try(:room) || item.try(:message)&.room
-
-    if room
-      room.bot_memberships_for_events(item, event).each do |membership|
-        bot = membership.user
-
-        broadcast_to_bot_channel(bot, item, event, base_url: base_url)
-
-        if bot.webhook_url.present?
-          reply = membership.receives_mentions? && event == :created
-          bot.deliver_webhook_later(item, event, reply: reply, base_url: base_url)
-        end
-      end
-    else
-      User.active_bots.includes(:webhook).each do |bot|
-        broadcast_to_bot_channel(bot, item, event, base_url: base_url)
-        bot.deliver_webhook_later(item, event, base_url: base_url) if bot.webhook_url.present?
-      end
-    end
-  end
-
   private
-
-  def broadcast_to_bot_channel(bot, item, event, base_url:)
-    payload = Bot::EventPayload.build(item, event, bot: bot, base_url: base_url)
-    ActionCable.server.broadcast(BotEventsChannel.stream_name_for(bot), payload)
-  end
+    def notify_bots(item, event)
+      Bot::Event.new(item, event, base_url: request.base_url + request.script_name).dispatch
+    end
 end

--- a/app/models/bot/event.rb
+++ b/app/models/bot/event.rb
@@ -2,6 +2,10 @@
 # happens and supply the URL context; this class owns who hears about it and how
 # it reaches them. Selection stays on `Room`, payload construction on
 # `Bot::EventPayload`, and HTTP delivery on `Webhook`.
+#
+# In SaaS mode, dispatch must run in the item's tenant context, established by
+# the request, a tenant-aware job, or ApplicationRecord.with_tenant. base_url
+# only supplies URL context; it does not select or switch the database tenant.
 class Bot::Event
   def initialize(item, event, base_url:)
     @item, @event, @base_url = item, event, base_url

--- a/app/models/bot/event.rb
+++ b/app/models/bot/event.rb
@@ -1,0 +1,43 @@
+# Fans an outbound bot event out to its recipients. Callers decide when an event
+# happens and supply the URL context; this class owns who hears about it and how
+# it reaches them. Selection stays on `Room`, payload construction on
+# `Bot::EventPayload`, and HTTP delivery on `Webhook`.
+class Bot::Event
+  def initialize(item, event, base_url:)
+    @item, @event, @base_url = item, event, base_url
+  end
+
+  def dispatch
+    if room
+      room.bot_memberships_for_events(item, event).each do |membership|
+        deliver_to membership.user, reply: accepts_reply?(membership)
+      end
+    else
+      User.active_bots.includes(:webhook).each { |bot| deliver_to bot }
+    end
+  end
+
+  private
+    attr_reader :item, :event, :base_url
+
+    # Account-level events like user changes belong to no room, and reach every
+    # active bot instead.
+    def room
+      @room ||= item.try(:room) || item.try(:message)&.room
+    end
+
+    # :mentions and :everything memberships both accept a reply, and every
+    # :created event qualifies — a new boost as much as a new message. Whether
+    # the bot hears about the event at all is settled upstream by
+    # `bot_memberships_for_events`.
+    def accepts_reply?(membership)
+      membership.receives_mentions? && event == :created
+    end
+
+    def deliver_to(bot, reply: false)
+      ActionCable.server.broadcast BotEventsChannel.stream_name_for(bot),
+        Bot::EventPayload.build(item, event, bot: bot, base_url: base_url)
+
+      bot.deliver_webhook_later item, event, reply: reply, base_url: base_url if bot.webhook_url.present?
+    end
+end

--- a/saas/test/models/bot/event_test.rb
+++ b/saas/test/models/bot/event_test.rb
@@ -1,0 +1,57 @@
+require_relative "../../test_helper"
+
+class SaasBotEventTest < ActiveSupport::TestCase
+  include ActionCable::TestHelper
+
+  test "same-id bots dispatch within their tenant and queued delivery restores its originating tenant" do
+    Resolv.stubs(:getaddresses).returns([ "93.184.216.34" ])
+
+    with_provisioned_workspace(name: "Bot Event A", creator: global_identities(:alice)) do |workspace_a|
+      with_provisioned_workspace(name: "Bot Event B", creator: global_identities(:bob)) do |workspace_b|
+        tenant_a, tenant_b = [ workspace_a, workspace_b ].map { |workspace| workspace.external_id.to_s }
+        bot_id = 424242
+        records = [ tenant_a, tenant_b ].map do |tenant|
+          ApplicationRecord.with_tenant(tenant) do
+            bot = User.create_bot!(id: bot_id, name: "Bot #{tenant}", webhook_url: "https://example.com/hook/#{tenant}")
+            room = bot.rooms.without_threads.first
+            message = room.messages.create!(creator: bot, body: "Message from #{tenant}")
+            [ bot, room, message ]
+          end
+        end
+
+        records.each_with_index do |(bot, room, message), index|
+          tenant, foreign_tenant = index.zero? ? [ tenant_a, tenant_b ] : [ tenant_b, tenant_a ]
+          base_url = "https://chat.example.test/#{tenant}"
+          payload = nil
+
+          ApplicationRecord.with_tenant(tenant) do
+            assert_no_broadcasts "bot_events:#{foreign_tenant}:#{bot_id}" do
+              assert_broadcasts "bot_events:#{tenant}:#{bot_id}", 1 do
+                assert_enqueued_jobs 1, only: Bot::WebhookJob do
+                  Bot::Event.new(message, :updated, base_url: base_url).dispatch
+                end
+              end
+            end
+            payload = JSON.parse(broadcasts("bot_events:#{tenant}:#{bot_id}").last)
+            assert_equal base_url + Rails.application.routes.url_helpers.room_at_message_path(room, message), payload.dig("message", "url")
+            assert_equal base_url + Rails.application.routes.url_helpers.api_bots_room_messages_path(room), payload.dig("room", "messages_url")
+            assert_equal bot.id, payload.dig("user", "id")
+          end
+
+          job = enqueued_jobs.select { |entry| entry[:job] == Bot::WebhookJob }.last
+          assert_equal tenant, job["tenant"]
+          WebMock.stub_request(:post, "https://example.com/hook/#{tenant}")
+            .with(body: payload.to_json).to_return(status: 200)
+
+          # A worker may switch tenants; request-scoped shard locks must not be
+          # carried into this simulation of job execution.
+          ApplicationRecord.with_tenant(foreign_tenant, prohibit_shard_swapping: false) do
+            perform_enqueued_jobs(only: Bot::WebhookJob)
+            assert_equal foreign_tenant, ApplicationRecord.current_tenant
+          end
+          assert_requested :post, "https://example.com/hook/#{tenant}", times: 1
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/concerns/notify_bots_test.rb
+++ b/test/controllers/concerns/notify_bots_test.rb
@@ -53,6 +53,61 @@ class NotifyBotsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "everything involvement still requires a mention for ordinary room creates" do
+    memberships(:bender_watercooler).update!(involvement: :everything)
+
+    assert_no_broadcasts "bot_events:#{@bot.id}" do
+      assert_no_enqueued_jobs only: Bot::WebhookJob do
+        post room_messages_url(@room, format: :turbo_stream), params: { message: {
+          body: "<div>Hello world</div>", client_message_id: SecureRandom.uuid } }
+      end
+    end
+    assert_response :success
+  end
+
+  test "thread mentions do not add parent-only bots to the event audience" do
+    thread = Rooms::Thread.find_or_create_for(messages(:fourth), creator: users(:david))
+    thread.memberships.create!(user: users(:nsa), involvement: :everything)
+    assert_not thread.memberships.exists?(user: @bot)
+
+    assert_no_broadcasts "bot_events:#{@bot.id}" do
+      assert_broadcasts "bot_events:#{users(:nsa).id}", 1 do
+        assert_enqueued_jobs 1, only: Bot::WebhookJob do
+          post room_messages_url(thread, format: :turbo_stream), params: { message: {
+            body: "<div>Hey #{mention_attachment_for(:bender)}</div>", client_message_id: SecureRandom.uuid } }
+        end
+      end
+    end
+    assert_response :success
+  end
+
+  test "REST bot messages still announce to other sub-room bots" do
+    reset!
+    thread = Rooms::Thread.find_or_create_for(messages(:fourth), creator: @bot)
+    thread.memberships.create!(user: users(:nsa), involvement: :everything)
+
+    assert_broadcasts "bot_events:#{users(:nsa).id}", 1 do
+      assert_enqueued_jobs 2, only: Bot::WebhookJob do
+        post api_bots_room_messages_url(thread), params: "Bot reply",
+          headers: bot_headers(@bot).merge("CONTENT_TYPE" => "text/plain")
+      end
+    end
+    assert_response :created
+  end
+
+  test "forum opening posts retain their bot event bypass" do
+    forum = Rooms::Forum.create_for({ name: "Bot forum", creator: users(:david) }, users: [ users(:david), @bot ])
+
+    assert_no_broadcasts "bot_events:#{@bot.id}" do
+      assert_no_enqueued_jobs only: Bot::WebhookJob do
+        post rooms_forum_posts_url(forum), params: { post: {
+          title: "Hello bot", body: "<div>Hey #{mention_attachment_for(:bender)}</div>" } }
+      end
+    end
+    assert_redirected_to room_url(forum)
+    assert_equal 1, forum.posts.count
+  end
+
   test "multiple mentioned bots each receive their own broadcast" do
     bender_stream = "bot_events:#{users(:bender).id}"
     nsa_stream = "bot_events:#{users(:nsa).id}"
@@ -107,6 +162,11 @@ class NotifyBotsTest < ActionDispatch::IntegrationTest
     assert_broadcasts stream, 1 do
       delete message_boost_url(message, boost, format: :turbo_stream)
     end
+
+    payload = JSON.parse(broadcasts(stream).last)
+    assert_equal "boost_deleted", payload["event"]
+    assert_equal({ "id" => boost.id, "body" => "Nice!" }, payload["boost"])
+    assert_equal message.id, payload.dig("message", "id")
   end
 
   # user events (account-level, no room — else branch)

--- a/test/models/bot/event_test.rb
+++ b/test/models/bot/event_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+
+class Bot::EventTest < ActiveSupport::TestCase
+  include ActionCable::TestHelper
+
+  setup do
+    @room = rooms(:watercooler)
+    @bot = users(:bender)
+    @message = @room.messages.create!(creator: users(:david),
+      body: "<div>Hello #{mention_attachment_for(:bender)}</div>")
+    @base_url = "https://chat.example.test/workspace"
+    @stream = BotEventsChannel.stream_name_for(@bot)
+  end
+
+  test "dispatch without a request delivers both transports and captures the webhook before enqueue" do
+    job = assert_enqueued_with(job: Bot::WebhookJob) do
+      assert_broadcasts @stream, 1 do
+        Bot::Event.new(@message, :created, base_url: @base_url).dispatch
+      end
+    end
+
+    webhook, event, raw_payload, room, reply = job.arguments
+    payload = JSON.parse(raw_payload)
+    assert_equal @bot.webhook, webhook
+    assert_equal "message_created", event
+    assert_equal @room, room
+    assert_equal true, reply
+    assert_equal payload, JSON.parse(broadcasts(@stream).last)
+    assert_equal @base_url + Rails.application.routes.url_helpers.room_at_message_path(@room, @message), payload.dig("message", "url")
+    assert_equal @base_url + Rails.application.routes.url_helpers.user_path(users(:david)), payload.dig("user", "url")
+
+    @message.update!(body: "Edited after dispatch")
+    assert_not_equal @message.plain_text_body, payload.dig("message", "body", "plain")
+    assert_equal "Hello @Bender Bot", payload.dig("message", "body", "plain")
+  end
+
+  test "bots without webhooks still receive their payload" do
+    @bot.webhook.destroy!
+
+    assert_no_enqueued_jobs only: Bot::WebhookJob do
+      assert_broadcasts @stream, 1 do
+        Bot::Event.new(@message, :created, base_url: @base_url).dispatch
+      end
+    end
+    assert_equal "message_created", JSON.parse(broadcasts(@stream).last)["event"]
+  end
+
+  test "everything recipients receive sub-room creates without a mention and retain reply permission" do
+    thread = Rooms::Thread.find_or_create_for(messages(:fourth), creator: users(:david))
+    thread.memberships.create!(user: @bot, involvement: :everything)
+    message = thread.messages.create!(creator: users(:david), body: "A thread follow-up")
+
+    job = assert_enqueued_with(job: Bot::WebhookJob) do
+      Bot::Event.new(message, :created, base_url: @base_url).dispatch
+    end
+
+    assert_equal true, job.arguments.last
+    assert_equal({ "id" => thread.id, "parent_message_id" => messages(:fourth).id },
+      JSON.parse(job.arguments[2]).dig("message", "thread"))
+  end
+
+  test "bot-authored direct messages do not require mentions" do
+    room = Rooms::Direct.create_for({ creator: users(:david) }, users: [ users(:david), @bot ])
+    message = room.messages.create!(creator: @bot, body: "Bot-authored direct message")
+
+    assert_broadcasts @stream, 1 do
+      Bot::Event.new(message, :created, base_url: @base_url).dispatch
+    end
+    assert_equal @bot.id, JSON.parse(broadcasts(@stream).last).dig("user", "id")
+  end
+
+  test "updates deliver to existing members without granting webhook reply permission" do
+    assert_enqueued_jobs 2, only: Bot::WebhookJob do
+      Bot::Event.new(@message, :updated, base_url: @base_url).dispatch
+    end
+    jobs = enqueued_jobs.select { |job| job[:job] == Bot::WebhookJob }.map do |job|
+      ActiveJob::Arguments.deserialize(job[:args])
+    end
+    assert_equal [ users(:bender).webhook.id, users(:nsa).webhook.id ].sort, jobs.map { |args| args.first.id }.sort
+    assert jobs.all? { |args| args[1] == "message_updated" && args.last == false }
+  end
+
+  test "account events reach active bots without room memberships" do
+    users(:nsa).update_column(:status, :deactivated)
+    betty = users(:betty)
+    assert_not betty.memberships.exists?
+
+    assert_no_broadcasts BotEventsChannel.stream_name_for(users(:nsa)) do
+      assert_broadcasts BotEventsChannel.stream_name_for(betty), 1 do
+        assert_enqueued_jobs 2, only: Bot::WebhookJob do
+          Bot::Event.new(users(:kevin), :deleted, base_url: @base_url).dispatch
+        end
+      end
+    end
+    payload = JSON.parse(broadcasts(BotEventsChannel.stream_name_for(betty)).last)
+    assert_equal "user_deleted", payload["event"]
+    assert_equal users(:kevin).id, payload.dig("user", "id")
+    assert_not payload.key?("room")
+  end
+
+  test "destroyed reactions retain their payload and current nil webhook reply room" do
+    boost = @message.boosts.create!(booster: users(:david), content: "Nice")
+    boost.destroy!
+
+    job = assert_enqueued_with(job: Bot::WebhookJob) do
+      Bot::Event.new(boost, :deleted, base_url: @base_url).dispatch
+    end
+    assert_equal "boost_deleted", job.arguments[1]
+    assert_equal({ "id" => boost.id, "body" => "Nice" }, JSON.parse(job.arguments[2])["boost"])
+    assert_nil job.arguments[3]
+    assert_equal false, job.arguments.last
+  end
+
+  test "broadcast errors propagate before any webhook is queued" do
+    ActionCable.server.expects(:broadcast).with(@stream, anything).raises(IOError, "broadcast unavailable")
+
+    assert_no_enqueued_jobs only: Bot::WebhookJob do
+      assert_raises(IOError) { Bot::Event.new(@message, :created, base_url: @base_url).dispatch }
+    end
+  end
+
+  test "enqueue errors propagate after the WebSocket broadcast" do
+    Bot::WebhookJob.expects(:perform_later).raises(IOError, "queue unavailable")
+
+    assert_broadcasts @stream, 1 do
+      assert_raises(IOError) { Bot::Event.new(@message, :created, base_url: @base_url).dispatch }
+    end
+  end
+end

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class WebhookTest < ActiveSupport::TestCase
+  include ActionCable::TestHelper
+
   test "payload contains absolute URLs" do
     message = messages(:first)
     base_url = "https://sabha.test"
@@ -32,6 +34,23 @@ class WebhookTest < ActiveSupport::TestCase
 
     reply_message = Message.last
     assert_equal "Hello back!", reply_message.body.to_plain_text
+  end
+
+  test "automatic replies do not announce events to mentioned bots" do
+    webhook = webhooks(:bender)
+    message = messages(:fourth)
+    WebMock.stub_request(:post, webhook.url).to_return(status: 200,
+      body: "<div>Hey #{mention_attachment_for(:nsa)}</div>", headers: { "Content-Type" => "text/html" })
+
+    assert_no_broadcasts "bot_events:#{users(:nsa).id}" do
+      assert_no_enqueued_jobs only: Bot::WebhookJob do
+        assert_difference -> { Message.count }, 1 do
+          webhook.deliver_now(message, :created, reply: true)
+        end
+      end
+    end
+    assert_equal users(:bender), Message.last.creator
+    assert_includes Message.last.mentionees, users(:nsa)
   end
 
   test "delivery with reply posts attachment response" do


### PR DESCRIPTION
Bot event delivery can now be exercised and reused outside a controller through `Bot::Event`, with explicit URL context. The existing `NotifyBots` adapter keeps request handling at the controller boundary.

This is a behavior-preserving extraction. Recipient selection, payload capture, WebSocket-before-webhook ordering, reply eligibility, and tenant context retain their existing behavior. Tests characterize the current ordinary-room and thread membership limitations, REST bot announcements, and automatic webhook reply bypass so later policy changes can be reviewed separately.

Validation on the committed code:

- `bin/rails test`: 1,874 tests, 6,250 assertions; no failures or errors, 4 skips.
- `SAAS=true bin/rails test saas/test/` with an isolated PostgreSQL test database: 313 tests, 958 assertions; no failures or errors.
- Commit-hook RuboCop: all six Ruby files pass.

Documentation is excluded from this PR.
