### PR TITLE
Render link previews only from off-host web URLs

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -142,6 +142,10 @@ module MessagesHelper
 
   def message_cache_key(message, room_id: nil, is_first_unread_message: false, is_unread: false, is_parent: false, show_room_name: false, composer_id: "composer", forum_replies_count: nil)
     [
+      # Bump this version when message presentation changes what it emits but the
+      # digestor can't see it — e.g. the opengraph embed partial, which ActionText
+      # renders by name rather than through a render call the digestor follows.
+      "presentation-v2",
       message,
       room_id,
       message.bookmarked_by?(Current.user),

--- a/app/views/action_text/attachables/_opengraph_embed.html.erb
+++ b/app/views/action_text/attachables/_opengraph_embed.html.erb
@@ -3,7 +3,7 @@
     <div class="og-embed gap <%= "og-embed--twitter-avatar" if opengraph_embed.twitter_avatar? %>">
       <div class="og-embed__content">
         <div class="og-embed__title">
-          <%= link_to truncate(opengraph_embed.filename, length: 280, omission: "…"), opengraph_embed.href, rel: "noreferrer", target: "_blank" %>
+          <%= link_to_if opengraph_embed.href.present?, truncate(opengraph_embed.filename, length: 280, omission: "…"), opengraph_embed.href, rel: "noreferrer", target: "_blank" %>
         </div>
         <div class="og-embed__description"><%= truncate(opengraph_embed.description.to_s, length: 560, omission: "…") %></div>
       </div>

--- a/lib/rails_ext/actiontext_opengraph_embeds.rb
+++ b/lib/rails_ext/actiontext_opengraph_embeds.rb
@@ -4,11 +4,12 @@ class ActionText::Attachment::OpengraphEmbed
   OPENGRAPH_EMBED_CONTENT_TYPE = "application/vnd.actiontext.opengraph-embed"
   TWITTER_AVATAR_URL_PREFIX = "https://pbs.twimg.com/profile_images"
 
-  # An embed with no link is a broken embed — bail rather than render a
-  # self-referential nil-href link. Guards the case where attributes_from_content
+  # A preview with neither a link nor a title is a broken embed — bail rather
+  # than render an empty figure. Guards the case where attributes_from_content
   # finds nothing (e.g. a renamed og-embed class), so `attachment if valid?`
-  # actually returns nil.
-  validates :href, presence: true
+  # actually returns nil. A dropped link (see web_url) still renders: the title
+  # shows as plain text rather than a link to the current page.
+  validate :link_or_title
 
   class << self
     def from_node(node)
@@ -28,8 +29,8 @@ class ActionText::Attachment::OpengraphEmbed
       def attributes_from_node(node)
         if node["href"].present?
           {
-            href: node["href"],
-            url: node["url"],
+            href: web_url(node["href"]),
+            url: web_url(node["url"]),
             filename: node["filename"],
             description: node["caption"]
           }
@@ -44,11 +45,54 @@ class ActionText::Attachment::OpengraphEmbed
         link = title&.at_css("a")
 
         {
-          href: link&.[]("href"),
-          url: fragment.at_css(".og-embed__image img")&.[]("src"),
+          href: web_url(link&.[]("href")),
+          url: web_url(fragment.at_css(".og-embed__image img")&.[]("src")),
           filename: (link || title)&.text&.strip,
           description: fragment.at_css(".og-embed__description")&.text&.strip
         }
+      end
+
+      # A link preview points at what we unfurled: an absolute http or https URL
+      # on some other host. Drop anything else a message body asks for, so it
+      # can't aim the preview's link or its image at this Sabha and have every
+      # reader's browser fetch it with their session attached. A dropped link
+      # renders the title as plain text; a dropped image renders no image.
+      def web_url(value)
+        return if value.blank?
+
+        parsed = URI.parse(value)
+        value if parsed.is_a?(URI::HTTP) && elsewhere?(parsed.host)
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      # "https:/rooms/1" parses as HTTPS with no host at all, and a browser
+      # resolves both that and our own hostname against the origin Sabha is
+      # served from. A percent-escape hides our hostname from this comparison
+      # while a browser still unescapes it back to us, so an escaped host is out
+      # too, and neither case is anything an unfurl could have produced.
+      def elsewhere?(host)
+        return false unless named_host?(host)
+
+        canonical_host(host) != canonical_host(Current.request_host.to_s)
+      end
+
+      # A preview names a page on the public internet, so its host is a domain
+      # name, written plainly. A bare address is not one, and a browser rewrites
+      # the many spellings of an address ("2130706433", "0x7f.0.0.1") into a
+      # single one before it fetches, which is a race a comparison here loses.
+      def named_host?(host)
+        host.present? && host.exclude?("%") && host.include?(".") && domain_ending?(host.split(".").last)
+      end
+
+      # What keeps a name from reading as an address is its last label, which is
+      # a word: never a number, and never the hexadecimal spelling of one.
+      def domain_ending?(label)
+        label.match?(/[a-z]/i) && !label.match?(/\A0x/i)
+      end
+
+      def canonical_host(host)
+        host.downcase.delete_suffix(".")
       end
   end
 
@@ -69,4 +113,9 @@ class ActionText::Attachment::OpengraphEmbed
   def to_partial_path
     "action_text/attachables/opengraph_embed"
   end
+
+  private
+    def link_or_title
+      errors.add(:base, "nothing to render") if href.blank? && filename.blank?
+    end
 end

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -81,6 +81,53 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_equal users(:david).rooms.last.id.to_s, response.cookies["last_room"]
   end
 
+  test "show drops a hand-written link preview's off-scheme link and image" do
+    room = rooms(:watercooler)
+    post room_messages_url(room, format: :turbo_stream), params: { message: {
+      body: link_preview_body(href: "javascript:alert(1)", url: "data:image/svg+xml;base64,PHN2Zy8+"),
+      client_message_id: "hand-written-preview" } }
+    assert_response :success
+
+    get room_url(room)
+
+    assert_response :success
+    # The dangerous values never reach a rendered sink: no link points at them
+    # and no image is fetched from them. (An inert url= attribute may linger on
+    # the <action-text-attachment> wrapper in stored markup, which a browser
+    # neither fetches nor executes.)
+    assert_no_match %r{href="javascript:}, response.body
+    assert_no_match %r{<img src="data:}, response.body
+  end
+
+  test "show drops a hand-written link preview aimed at this Sabha" do
+    room = rooms(:watercooler)
+    own_url = room_url(room, host: "www.example.com")
+    post room_messages_url(room, format: :turbo_stream), params: { message: {
+      body: link_preview_body(href: own_url, url: own_url),
+      client_message_id: "same-host-preview" } }
+    assert_response :success
+
+    get room_url(room)
+
+    assert_response :success
+    assert_no_match %r{<img src="#{Regexp.escape(own_url)}"}, response.body
+    assert_no_match %r{<a rel="noreferrer" target="_blank" href="#{Regexp.escape(own_url)}"}, response.body
+  end
+
+  test "show renders an unfurled link preview" do
+    room = rooms(:watercooler)
+    post room_messages_url(room, format: :turbo_stream), params: { message: {
+      body: link_preview_body(href: "https://example.com/page", url: "https://example.com/image.png"),
+      client_message_id: "unfurled-preview" } }
+    assert_response :success
+
+    get room_url(room)
+
+    assert_response :success
+    assert_match %r{<img src="https://example\.com/image\.png"}, response.body
+    assert_match %r{href="https://example\.com/page"}, response.body
+  end
+
   test "destroy" do
     # 2 broadcasts: one for :starred_rooms and one for :shared_rooms
     assert_turbo_stream_broadcasts [ accounts(:signal), :rooms ], count: 2 do
@@ -183,4 +230,10 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
       delete room_url(rooms(:designers))
     end
   end
+
+  private
+    def link_preview_body(href:, url:)
+      %(<div><action-text-attachment content-type="application/vnd.actiontext.opengraph-embed" ) +
+        %(href="#{href}" url="#{url}" filename="Free cookies" caption="Cookies here"></action-text-attachment></div>)
+    end
 end

--- a/test/lib/rails_ext/actiontext_opengraph_embeds_test.rb
+++ b/test/lib/rails_ext/actiontext_opengraph_embeds_test.rb
@@ -1,0 +1,130 @@
+require "test_helper"
+
+class ActionText::Attachment::OpengraphEmbedTest < ActiveSupport::TestCase
+  test "keeps absolute http and https links and images" do
+    embed = embed_from href: "http://example.com/page", url: "https://example.com/image.png"
+
+    assert_kind_of ActionText::Attachment::OpengraphEmbed, embed
+    assert_equal "http://example.com/page", embed.href
+    assert_equal "https://example.com/image.png", embed.url
+  end
+
+  test "keeps the link but drops an image that isn't a web URL" do
+    embed = embed_from href: "https://example.com/page", url: "javascript:alert(1)"
+
+    assert_kind_of ActionText::Attachment::OpengraphEmbed, embed
+    assert_equal "https://example.com/page", embed.href
+    assert_nil embed.url
+  end
+
+  test "keeps a Lexxy embed serialized in its content markup" do
+    embed = embed_from content: opengraph_content(href: "https://example.com/page", src: "https://example.com/image.png")
+
+    assert_kind_of ActionText::Attachment::OpengraphEmbed, embed
+    assert_equal "https://example.com/page", embed.href
+    assert_equal "https://example.com/image.png", embed.url
+  end
+
+  test "drops a link and an image that aren't web URLs" do
+    [ "javascript:alert(1)", "data:text/html,pwned", "vbscript:msgbox(1)", "//example.com/page",
+      "/rooms/1", "rooms/1", "http://exa mple.com/ ",
+      "https:/rooms/1", "https:rooms/1", "http:/rooms/1", "https://" ].each do |value|
+      embed = embed_from href: value, url: value
+
+      assert_nil embed.href, "expected #{value.inspect} to be dropped as a link"
+      assert_nil embed.url, "expected #{value.inspect} to be dropped as an image"
+    end
+  end
+
+  test "drops a link and an image on this Sabha's own host, however it is spelled" do
+    Current.set request: ActionDispatch::TestRequest.create("HTTP_HOST" => "once.sabha.test") do
+      [ "https://once.sabha.test/rooms/1", "http://once.sabha.test/rooms/1",
+        "https://ONCE.Sabha.Test/rooms/1", "https://once.sabha.test./rooms/1",
+        "https://%6fnce.sabha.test/rooms/1", "https://%77ww.example.com/x.png" ].each do |value|
+        embed = embed_from href: value, url: value
+
+        assert_nil embed.href, "expected #{value.inspect} to be dropped as a link"
+        assert_nil embed.url, "expected #{value.inspect} to be dropped as an image"
+      end
+
+      embed = embed_from href: "https://example.com/page", url: "https://example.com/image.png"
+      assert_equal "https://example.com/page", embed.href
+      assert_equal "https://example.com/image.png", embed.url
+    end
+  end
+
+  test "drops a link and an image on a bare address rather than a domain name" do
+    [ "http://127.0.0.1/rooms/1", "http://2130706433/rooms/1", "http://0177.0.0.1/rooms/1",
+      "http://0x7f.0.0.1/rooms/1", "http://1.2.3.0xff/rooms/1", "http://[::1]/rooms/1",
+      "http://localhost/rooms/1", "https://203.0.113.10/image.png" ].each do |value|
+      embed = embed_from href: value, url: value
+
+      assert_nil embed.href, "expected #{value.inspect} to be dropped as a link"
+      assert_nil embed.url, "expected #{value.inspect} to be dropped as an image"
+    end
+  end
+
+  test "renders the title as plain text when the link is dropped" do
+    html = render_embed href: "javascript:alert(1)", url: "data:image/svg+xml;base64,PHN2Zy8+"
+
+    assert_no_match /javascript:/, html
+    assert_no_match /data:/, html
+    assert_no_match /<img/, html
+    assert_no_match /<a /, html
+    assert_match "Title", html
+  end
+
+  test "keeps an internationalized domain written in punycode" do
+    embed = embed_from href: "https://xn--80aswg.xn--p1ai/page", url: "https://xn--80aswg.xn--p1ai/image.png"
+
+    assert_equal "https://xn--80aswg.xn--p1ai/page", embed.href
+    assert_equal "https://xn--80aswg.xn--p1ai/image.png", embed.url
+  end
+
+  test "renders the image and the link when both are web URLs" do
+    html = render_embed href: "https://example.com/page", url: "https://example.com/image.png"
+
+    assert_match %r{href="https://example\.com/page"}, html
+    assert_match %r{<img src="https://example\.com/image\.png"}, html
+  end
+
+  test "renders the title and the description as text" do
+    html = render_embed href: "https://example.com/page", url: "https://example.com/image.png",
+      filename: "<b>Title</b>", caption: "<img src=x onerror=alert(1)>"
+
+    assert_no_match /<b>Title/, html
+    assert_no_match /<img src=x/, html
+    assert_match "&lt;b&gt;Title&lt;/b&gt;", html
+    assert_match "&lt;img src=x onerror=alert(1)&gt;", html
+  end
+
+  private
+    def attachment_for(href: nil, url: nil, filename: "Title", caption: "Description", content: nil)
+      attributes = if content
+        %(content-type="#{ActionText::Attachment::OpengraphEmbed::OPENGRAPH_EMBED_CONTENT_TYPE}" content="#{CGI.escapeHTML(content)}")
+      else
+        %(content-type="#{ActionText::Attachment::OpengraphEmbed::OPENGRAPH_EMBED_CONTENT_TYPE}" ) +
+          %(href="#{href}" url="#{url}" filename="#{filename}" caption="#{caption}")
+      end
+      html = %(<action-text-attachment #{attributes}></action-text-attachment>)
+      node = ActionText::Fragment.wrap(html).find_all(ActionText::Attachment.tag_name).first
+
+      ActionText::Attachment.from_node(node)
+    end
+
+    def embed_from(**attributes)
+      attachment_for(**attributes).attachable
+    end
+
+    def opengraph_content(href:, src:)
+      %(<div class="og-embed"><div class="og-embed__content"><div class="og-embed__title">) +
+        %(<a href="#{href}">Title</a></div><div class="og-embed__description">Description</div></div>) +
+        %(<div class="og-embed__image"><img src="#{src}"></div></div>)
+    end
+
+    def render_embed(**attributes)
+      embed = embed_from(**attributes)
+
+      ApplicationController.render partial: embed.to_partial_path, locals: { opengraph_embed: embed }
+    end
+end


### PR DESCRIPTION
## Problem

A link preview is an `action-text-attachment` on a message body, and the composer fills its `href`/`url` from the unfurl the server performed. `_opengraph_embed.html.erb` renders those values directly — the preview's link from `href`, its image from `url` — and nothing between the message body and that partial validates them. `POST /rooms/:id/messages` stores whatever body it's handed, so a body composed by hand rather than by the editor can put any value in those attributes: a link or image in any scheme, or either one aimed at a path on this Sabha itself, which every reader's browser would then fetch with their session attached.

## Fix

`ActionText::Attachment::OpengraphEmbed` now keeps `href`/`url` only when they parse as absolute http/https URLs naming a domain other than the one serving the request — the shape an unfurl produces — and drops anything else (other schemes, same-origin paths, hostless `https:/rooms/1`, percent-escaped hostnames, and bare IP addresses in any spelling, which a browser rewrites before it fetches). Putting the check on the attachable rather than in a view filter means it holds wherever a message body is rendered.

A dropped link no longer falls back to a link to the current page — the title renders as plain text via `link_to_if`, and a dropped image renders no image. The presentation cache key is bumped so messages already cached pick this up (ActionText renders the embed partial by name, so the digestor can't see it).

## Notes for review

- Sabha resolves embed attributes down **two** paths — the legacy Trix node attributes and the Lexxy `attributes_from_content` markup — and the filter guards both.
- The former `validates :href, presence: true` is replaced with a check that bails only an embed with neither a link nor a title, so a preview whose link is dropped still shows its title as text instead of vanishing.
- One consequence of Lexxy storing the node verbatim: an inert `url=` attribute can linger on the `<action-text-attachment>` wrapper in stored markup. A browser never fetches or executes it; the tests assert on the actual `<a>`/`<img>` sinks.

Covered by unit tests for the URL filter (schemes, same-host spellings, IP spellings, punycode, the Lexxy path) and controller tests exercising the real post→render cycle.
